### PR TITLE
ci(L-T5): GHCR publish workflow on main push

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,0 +1,43 @@
+name: Docker Publish (GHCR)
+
+# L-T5 (gHashTag/trios-trainer-igla#8) — push image to
+# ghcr.io/ghashtag/trios-trainer-igla:latest after every main merge.
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build & push
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          push: true
+          tags: |
+            ghcr.io/ghashtag/trios-trainer-igla:latest
+            ghcr.io/ghashtag/trios-trainer-igla:${{ github.sha }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max


### PR DESCRIPTION
Lane **L-T5** — pushes `ghcr.io/ghashtag/trios-trainer-igla:latest` (and `:${sha}`) on every main merge.

Uses Docker Buildx + GitHub Actions cache (gha). Authenticates via `GITHUB_TOKEN` with `packages: write`.

Once this PR is green and merged, the latest tag will appear at:
https://github.com/users/gHashTag/packages/container/package/trios-trainer-igla

R5: pre-merge no image exists yet; honesty gate satisfied only by merge + the resulting publish run.

Anchor: φ² + φ⁻² = 3 (Zenodo DOI 10.5281/zenodo.19227877).