### PR TITLE
feat(L-T1/L-T2): port real transformer.rs + Coq-proven invariants.rs

### DIFF
--- a/src/invariants.rs
+++ b/src/invariants.rs
@@ -1,11 +1,346 @@
-//! Invariants stub for L-T1
+#![allow(clippy::needless_range_loop, clippy::useless_vec, clippy::excessive_precision, clippy::assertions_on_constants, dead_code)]
+//! # IGLA RACE — Coq-Proven Invariants (L-R14)
 //!
-//! Placeholder for `trios-igla-race::invariants` module.
-//! Will be imported via `--features trios-integration` feature.
+//! Every constant here is derived from formal Coq proofs in:
+//! `trinity-clara/proofs/igla/` (commit e0be8f8)
+//!
+//! INV-1: lr_phi_optimality.v   — champion LR is φ-optimal
+//! INV-2: igla_asha_bound.v     — ASHA champion always survives pruning
+//! INV-3: gf16_precision.v      — GF16 precision error ≤ φ⁻⁶
+//! INV-4: nca_entropy_band.v    — NCA entropy ∈ [φ, φ²] = width 1 exactly
+//! INV-5: lucas_closure_gf16.v  — Lucas sequence closes over integers
+//!
+//! NASA Rule 5: minimum 2 assert!() per pub fn.
+//! L-R5: cargo clippy -D warnings must pass.
 
+// ═══════════════════════════════════════════════════════════════════
+// Trinity φ-constants (Coq proven: φ² + φ⁻² = 3 exactly)
+// ═══════════════════════════════════════════════════════════════════
+
+/// φ = (1 + √5) / 2 — golden ratio
+/// Coq: Axiom phi_pos : phi > 0 (trinity-clara base axioms)
+pub const PHI: f64 = 1.618033988749895;
+
+/// φ² = φ + 1 (Coq proven algebraically)
+/// Source: nca_entropy_band.v::entropy_band_width
+pub const PHI_SQ: f64 = 2.618033988749895;
+
+/// φ³ = 2φ + 1 (Coq: lr_convergence.v::phi_cube)
+pub const PHI_CUBE: f64 = 4.23606797749979;
+
+/// φ⁻⁶ = 0.05572809... — GF16 precision floor
+/// Coq: gf16_precision.v::gf16_precision_bound
+pub const PHI_INV6: f64 = 0.05572809000085359;
+
+/// Trinity identity: φ² + φ⁻² = 3 (exact)
+/// Coq: Theorem trinity_identity (igla_asha_bound.v)
+pub const TRINITY_IDENTITY: f64 = 3.0;
+
+// ═══════════════════════════════════════════════════════════════════
+// INV-1: LR φ-Optimality
+// Coq: lr_phi_optimality.v::champion_lr_is_phi_optimal
+// Theorem: lr=0.004 ∈ [φ⁻³/2 × 0.9, φ⁻³/2 × 1.1]
+// ═══════════════════════════════════════════════════════════════════
+
+/// αφ = φ⁻³/2 = 0.11803399... ≈ αs(mZ) = 0.1180 (6 decimal places!)
+/// Coq: lr_phi_optimality.v::alpha_phi_pos
+pub const ALPHA_PHI: f64 = 0.11803398874989485;
+
+/// Champion LR — Coq proven safe: 0.004 ∈ [LR_SAFE_MIN, LR_SAFE_MAX]
+/// Coq: lr_phi_optimality.v::lr_champion_in_safe_range
+pub const LR_CHAMPION: f64 = 0.004;
+
+/// LR safe lower bound — Coq proven
 pub const LR_SAFE_MIN: f64 = 0.002;
+
+/// LR safe upper bound — Coq proven
 pub const LR_SAFE_MAX: f64 = 0.007;
 
-pub const PHI: f64 = 1.618033988749895;
-pub const PHI_SQ: f64 = PHI * PHI;
-pub const PHI_CUBE: f64 = PHI * PHI * PHI;
+// ═══════════════════════════════════════════════════════════════════
+// INV-2: ASHA Bound
+// Coq: igla_asha_bound.v::asha_champion_survives
+// Theorem: BPB_champion < PRUNE_THRESHOLD (2.5193 < 3.5)
+// ═══════════════════════════════════════════════════════════════════
+
+/// ASHA prune threshold — Coq proven: champion 2.5193 survives
+/// Coq: igla_asha_bound.v::no_prune_below_champion
+pub const ASHA_PRUNE_THRESHOLD: f64 = 3.5;
+
+/// Current champion BPB — ASHA trial #9006 (27K steps, seed=43)
+pub const BPB_CHAMPION: f64 = 2.5193;
+
+/// ASHA rungs — fixed array (NASA Rule 2: loop bounds)
+pub const ASHA_RUNGS: [u64; 4] = [1_000, 3_000, 9_000, 27_000];
+
+/// Max ASHA trials guard (NASA Rule 2: no unbounded loops)
+pub const MAX_ASHA_TRIALS: usize = 1_000;
+
+// ═══════════════════════════════════════════════════════════════════
+// INV-3: GF16 Precision
+// Coq: gf16_precision.v::gf16_safe_domain
+// Theorem: d_model ≥ 256 → GF16 precision error ≤ φ⁻⁶
+// ═══════════════════════════════════════════════════════════════════
+
+/// GF16 safe d_model lower bound (Law L-R9, Coq INV-3)
+/// Coq: gf16_precision.v::gf16_d_model_guard
+pub const GF16_SAFE_D_MODEL: usize = 256;
+
+/// Lucas sequence L(0)..L(6) — Coq proven integers
+/// Coq: lucas_closure_gf16.v::lucas_2_eq_3, lucas_4_eq_7
+pub const LUCAS: [u64; 7] = [2, 1, 3, 4, 7, 11, 18];
+
+// ═══════════════════════════════════════════════════════════════════
+// INV-4: NCA Entropy Band
+// Coq: nca_entropy_band.v::nca_entropy_stability
+// Theorem: entropy_band_width = φ² - φ = 1 EXACTLY (from φ²=φ+1)
+// ═══════════════════════════════════════════════════════════════════
+
+/// NCA entropy lower bound = φ (Coq proven)
+/// Replaces magic number 1.5 from empirical tuning
+/// Coq: nca_entropy_band.v::entropy_lower_bound_phi
+pub const NCA_ENTROPY_LO: f64 = PHI; // 1.618...
+
+/// NCA entropy upper bound = φ² = φ+1 (Coq proven)
+/// Replaces magic number 2.8 from empirical tuning
+/// Coq: nca_entropy_band.v::entropy_upper_bound_phi_sq
+pub const NCA_ENTROPY_HI: f64 = PHI_SQ; // 2.618...
+
+/// Band width = φ² - φ = 1 EXACTLY (Coq: entropy_band_width)
+/// Key: tighter than [1.5, 2.8]=1.3 width → better anti-collapse
+pub const NCA_ENTROPY_WIDTH: f64 = 1.0;
+
+/// NCA grid size = 9×9 = 81 = 3⁴ (Trinity structure)
+pub const NCA_GRID_SIZE: usize = 81;
+
+// ═══════════════════════════════════════════════════════════════════
+// L-R14: validate_config() — call BEFORE every ASHA trial
+// NASA Rule 5: ≥2 assert!() per pub fn
+// ═══════════════════════════════════════════════════════════════════
+
+/// Trial configuration validated by Coq invariants.
+#[derive(Debug, Clone)]
+pub struct TrialConfig {
+    pub lr: f64,
+    pub d_model: usize,
+    pub seed: u64,
+    pub steps: u64,
+    pub nca_weight: f32,
+    pub jepa_weight: f32,
+    pub ntp_weight: f32,
+    pub use_gf16: bool,
+}
+
+/// Validate trial config against all Coq-proven invariants.
+/// Call this BEFORE spawning any ASHA trial worker.
+///
+/// # Panics
+/// Panics with invariant name + Coq source on violation.
+///
+/// NASA Rule 5: 4 assert!() — pre/postconditions + 2 domain checks.
+pub fn validate_config(cfg: &TrialConfig) {
+    // INV-1: LR must be in Coq-proven safe range
+    assert!(
+        cfg.lr >= LR_SAFE_MIN && cfg.lr <= LR_SAFE_MAX,
+        "INV-1 VIOLATION: lr={} not in [{}, {}] (lr_phi_optimality.v::lr_champion_in_safe_range)",
+        cfg.lr, LR_SAFE_MIN, LR_SAFE_MAX
+    );
+    assert!(cfg.lr > 0.0, "INV-1: lr must be positive, got {}", cfg.lr);
+
+    // INV-3: GF16 requires d_model ≥ 256 (Law L-R9)
+    if cfg.use_gf16 {
+        assert!(
+            cfg.d_model >= GF16_SAFE_D_MODEL,
+            "INV-3 VIOLATION: GF16 requires d_model≥{}, got {} (gf16_precision.v::gf16_safe_domain)",
+            GF16_SAFE_D_MODEL, cfg.d_model
+        );
+    }
+    assert!(cfg.d_model > 0, "INV-3: d_model must be positive");
+
+    // INV-4: NCA weight must be positive (entropy band active)
+    assert!(
+        cfg.nca_weight >= 0.0 && cfg.nca_weight <= 1.0,
+        "INV-4 VIOLATION: nca_weight={} not in [0,1] (nca_entropy_band.v::nca_entropy_stability)",
+        cfg.nca_weight
+    );
+    assert!(
+        cfg.ntp_weight > 0.0,
+        "INV-1: ntp_weight must be positive (L-METRIC: BPB = NTP CE / ln(2))"
+    );
+
+    // INV-2: steps must be a valid ASHA rung or multiple thereof
+    assert!(
+        cfg.steps > 0 && cfg.steps <= ASHA_RUNGS[3] * 2,
+        "INV-2 VIOLATION: steps={} out of ASHA bounds [1, {}] (igla_asha_bound.v)",
+        cfg.steps, ASHA_RUNGS[3] * 2
+    );
+}
+
+/// Validate that a BPB value is physically meaningful.
+/// Called after every training rung result.
+///
+/// NASA Rule 5: 2 assert!() — range + champion bound.
+pub fn validate_bpb(bpb: f64, trial_id: &str) {
+    // L-METRIC: BPB = NTP CE / ln(2) — must be in physical range
+    assert!(
+        bpb > 0.0 && bpb < 20.0,
+        "L-METRIC VIOLATION: BPB={:.4} out of range (0, 20) for trial {}",
+        bpb, trial_id
+    );
+    // INV-2: if BPB suspiciously low — likely proxy metric (JEPA MSE), not real NTP
+    assert!(
+        bpb > 0.1,
+        "L-METRIC VIOLATION: BPB={:.4} suspiciously low — is this JEPA MSE not NTP BPB? (trial {})",
+        bpb, trial_id
+    );
+}
+
+/// Validate NCA entropy is within Coq-proven band [φ, φ²].
+///
+/// NASA Rule 5: 3 assert!() — bounds + width consistency.
+pub fn validate_nca_entropy(entropy: f64) {
+    assert!(
+        entropy >= NCA_ENTROPY_LO,
+        "INV-4 VIOLATION: entropy={:.4} < φ={:.4} (nca_entropy_band.v::entropy_lo_phi)",
+        entropy, NCA_ENTROPY_LO
+    );
+    assert!(
+        entropy <= NCA_ENTROPY_HI,
+        "INV-4 VIOLATION: entropy={:.4} > φ²={:.4} (nca_entropy_band.v::entropy_hi_phi_sq)",
+        entropy, NCA_ENTROPY_HI
+    );
+    // Band width sanity (Coq proven: φ² - φ = 1)
+    assert!(
+        (NCA_ENTROPY_HI - NCA_ENTROPY_LO - NCA_ENTROPY_WIDTH).abs() < 1e-10,
+        "INV-4 INTERNAL: band width != 1 — Trinity constants corrupted!"
+    );
+}
+
+// ═══════════════════════════════════════════════════════════════════
+// Tests — cargo test -p trios-train-cpu -- invariants
+// ═══════════════════════════════════════════════════════════════════
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_trinity_identity() {
+        // φ² + φ⁻² = 3 (Coq: igla_asha_bound.v::trinity_identity)
+        let phi_inv = 1.0 / PHI;
+        let result = PHI * PHI + phi_inv * phi_inv;
+        assert!(
+            (result - TRINITY_IDENTITY).abs() < 1e-10,
+            "Trinity identity violated: φ²+φ⁻²={result:.10} ≠ 3"
+        );
+    }
+
+    #[test]
+    fn test_phi_sq_eq_phi_plus_one() {
+        // φ² = φ + 1 (foundation of entropy_band_width=1)
+        assert!(
+            (PHI_SQ - (PHI + 1.0)).abs() < 1e-10,
+            "φ²=φ+1 violated: PHI_SQ={PHI_SQ}, PHI+1={}",
+            PHI + 1.0
+        );
+    }
+
+    #[test]
+    fn test_entropy_band_width_exact() {
+        // Coq: entropy_band_width = φ² - φ = 1 exactly
+        assert!(
+            (NCA_ENTROPY_HI - NCA_ENTROPY_LO - 1.0).abs() < 1e-10,
+            "Band width ≠ 1: got {}",
+            NCA_ENTROPY_HI - NCA_ENTROPY_LO
+        );
+    }
+
+    #[test]
+    fn test_champion_bpb_survives_asha() {
+        // Coq: asha_champion_survives (INV-2)
+        assert!(
+            BPB_CHAMPION < ASHA_PRUNE_THRESHOLD,
+            "Champion BPB={BPB_CHAMPION} would be pruned at {ASHA_PRUNE_THRESHOLD}!"
+        );
+    }
+
+    #[test]
+    fn test_lr_champion_in_safe_range() {
+        // Coq: lr_champion_in_safe_range (INV-1)
+        assert!(LR_CHAMPION >= LR_SAFE_MIN);
+        assert!(LR_CHAMPION <= LR_SAFE_MAX);
+    }
+
+    #[test]
+    fn test_gf16_precision_floor() {
+        // Coq: gf16_precision_bound — φ⁻⁶ sanity check
+        let phi_inv6 = (1.0_f64 / PHI).powi(6);
+        assert!(
+            (phi_inv6 - PHI_INV6).abs() < 1e-8,
+            "φ⁻⁶ mismatch: computed={phi_inv6:.8}, const={PHI_INV6:.8}"
+        );
+    }
+
+    #[test]
+    fn test_alpha_phi_matches_strong_coupling() {
+        // αφ = φ⁻³/2 ≈ αs(mZ) = 0.1180 to 4 decimal places
+        let alpha_s_mz = 0.1180_f64;
+        assert!(
+            (ALPHA_PHI - alpha_s_mz).abs() < 0.001,
+            "αφ={ALPHA_PHI:.6} diverges from αs(mZ)={alpha_s_mz} by >{:.4}",
+            (ALPHA_PHI - alpha_s_mz).abs()
+        );
+    }
+
+    #[test]
+    fn test_validate_config_champion() {
+        let cfg = TrialConfig {
+            lr: LR_CHAMPION,
+            d_model: 384,
+            seed: 43,
+            steps: 27_000,
+            nca_weight: 0.25,
+            jepa_weight: 1.0,
+            ntp_weight: 1.0,
+            use_gf16: false,
+        };
+        validate_config(&cfg); // must not panic
+    }
+
+    #[test]
+    fn test_validate_config_gf16_guard() {
+        let cfg = TrialConfig {
+            lr: 0.004,
+            d_model: 128, // ← violation: < 256
+            seed: 42,
+            steps: 3_000,
+            nca_weight: 0.25,
+            jepa_weight: 1.0,
+            ntp_weight: 1.0,
+            use_gf16: true, // ← GF16 requires d≥256
+        };
+        let result = std::panic::catch_unwind(|| validate_config(&cfg));
+        assert!(result.is_err(), "INV-3 should have caught d_model=128 with GF16");
+    }
+
+    #[test]
+    fn test_validate_bpb_catches_jepa_proxy() {
+        // BPB=0.014 was the JEPA MSE fake metric (L-METRIC violation)
+        let result = std::panic::catch_unwind(|| validate_bpb(0.014, "J-002"));
+        assert!(result.is_err(), "validate_bpb should reject suspicious 0.014 as fake metric");
+    }
+
+    #[test]
+    fn test_lucas_sequence() {
+        // Coq: lucas_2_eq_3, lucas_4_eq_7 (INV-5)
+        assert_eq!(LUCAS[2], 3, "L(2) must be 3");
+        assert_eq!(LUCAS[4], 7, "L(4) must be 7");
+        assert_eq!(LUCAS[6], 18, "L(6) must be 18");
+        // Lucas recurrence: L(n) = L(n-1) + L(n-2)
+        for i in 2..LUCAS.len() {
+            assert_eq!(
+                LUCAS[i], LUCAS[i-1] + LUCAS[i-2],
+                "Lucas recurrence violated at index {i}"
+            );
+        }
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -34,6 +34,7 @@ pub mod model_hybrid_attn;
 pub mod objective;
 pub mod optimizer;
 pub mod train_loop;
+pub mod transformer;
 
 pub use backward::{
     clip_gradients, gelu_backward, layer_norm_backward, linear_backward,

--- a/src/transformer.rs
+++ b/src/transformer.rs
@@ -1,0 +1,504 @@
+#![allow(clippy::needless_range_loop, clippy::useless_vec, clippy::excessive_precision, dead_code)]
+//! Minimal Transformer — Phase 2 (HIGH)
+//!
+//! Expected BPB: 1.80 (30% improvement over N-gram baseline 2.53)
+//! Architecture:
+//! - MHA (Multi-Head Attention): 8 heads, d_k=48
+//! - Positional Encoding: learned embeddings
+//! - LayerNorm (Pre-Norm)
+//! - FFN (Feed-Forward): 2 layers
+//!
+//! Based on IGLA Phase A/B study:
+//! - Phase B (n_layers=6, d_ff=233): 1.80 BPB ✓ PROVEN
+//! - Target: 1.50 BPB
+
+use crate::forward::gelu;
+
+/// Simple LCG for deterministic random numbers
+fn lcg_next(seed: &mut u64) -> f32 {
+    *seed = seed.wrapping_mul(6364136223846793005).wrapping_add(1442695040888963407);
+    (*seed as f32) / (u64::MAX as f32)
+}
+
+/// Xavier/Glorot initialization
+fn xavier_init(size: usize, fan_in: usize, fan_out: usize, seed: &mut u64) -> Vec<f32> {
+    let scale = (6.0f32 / (fan_in + fan_out) as f32).sqrt();
+
+    (0..size)
+        .map(|_| {
+            let t = lcg_next(seed);
+            t * 2.0 * scale - scale
+        })
+        .collect()
+}
+
+/// LayerNorm
+pub fn layer_norm(x: &[f32], eps: f32) -> Vec<f32> {
+    let n = x.len() as f32;
+    if n == 0.0 {
+        return vec![];
+    }
+    let mean = x.iter().sum::<f32>() / n;
+    let var = x.iter().map(|v| (v - mean).powi(2)).sum::<f32>() / n;
+    let std = (var + eps).sqrt();
+
+    x.iter().map(|v| (v - mean) / std).collect()
+}
+
+/// Positional encoding (sinusoidal)
+pub fn positional_encoding(seq_len: usize, d_model: usize) -> Vec<Vec<f32>> {
+    let mut pos_emb = vec![vec![0.0f32; d_model]; seq_len];
+
+    pos_emb.iter_mut().enumerate().for_each(|(pos, emb)| {
+        emb.iter_mut().enumerate().for_each(|(d, val)| {
+            let freq = if d % 2 == 0 {
+                (pos as f32 / 10000.0_f32.powf((d / 2) as f32 / d_model as f32)).sin()
+            } else {
+                (pos as f32 / 10000.0_f32.powf(((d - 1) / 2) as f32 / d_model as f32)).cos()
+            };
+            *val = freq;
+        });
+    });
+
+    pos_emb
+}
+
+/// Softmax
+pub fn softmax(x: &[f32]) -> Vec<f32> {
+    if x.is_empty() {
+        return vec![];
+    }
+
+    let max_val = x.iter().cloned().fold(f32::NEG_INFINITY, f32::max);
+    let exp_sum: f32 = x.iter().map(|&v| (v - max_val).exp()).sum();
+
+    if exp_sum == 0.0 {
+        return vec![1.0 / x.len() as f32; x.len()];
+    }
+
+    x.iter().map(|&v| (v - max_val).exp() / exp_sum).collect()
+}
+
+/// Simple self-attention (for a single position)
+pub fn self_attention(
+    x: &[f32],      // Full sequence embeddings: seq_len * d_model
+    pos: usize,     // Current position
+    d_model: usize,
+    seq_len: usize,
+    causal: bool,
+) -> Vec<f32> {
+    let mut output = vec![0.0f32; d_model];
+
+    // Compute attention weights for current position
+    let mut scores: Vec<f32> = Vec::with_capacity(seq_len);
+    for i in 0..seq_len {
+        if causal && i > pos {
+            // Mask future positions
+            scores.push(f32::NEG_INFINITY);
+            continue;
+        }
+
+        // Dot product attention score
+        let start_i = i * d_model;
+        let start_pos = pos * d_model;
+        let mut score = 0.0f32;
+        for d in 0..d_model {
+            score += x[start_i + d] * x[start_pos + d];
+        }
+        scores.push(score / (d_model as f32).sqrt());
+    }
+
+    // Softmax
+    let max_score = scores.iter().cloned().fold(f32::NEG_INFINITY, f32::max);
+    let exp_sum: f32 = scores.iter().map(|&s| (s - max_score).exp()).sum();
+    let weights: Vec<f32> = scores.iter().map(|&s| (s - max_score).exp() / exp_sum.max(1e-10)).collect();
+
+    // Weighted sum of all positions
+    for (i, &weight) in weights.iter().enumerate() {
+        let start_i = i * d_model;
+        for (d, out_val) in output.iter_mut().enumerate().take(d_model) {
+            *out_val += weight * x[start_i + d];
+        }
+    }
+
+    output
+}
+
+/// MHA (Multi-Head Attention)
+#[derive(Debug, Clone)]
+pub struct MultiHeadAttention {
+    #[allow(dead_code)]
+    n_heads: usize,
+    #[allow(dead_code)]
+    d_k: usize,
+    d_model: usize,
+    // Q, K, V projections for each head
+    w_q: Vec<f32>,
+    w_k: Vec<f32>,
+    w_v: Vec<f32>,
+    w_o: Vec<f32>,
+}
+
+impl MultiHeadAttention {
+    pub fn new(n_heads: usize, d_model: usize) -> Self {
+        let d_k = d_model / n_heads;
+        let mut rng = 0x1337_c0de_u64;
+
+        Self {
+            n_heads,
+            d_k,
+            d_model,
+            w_q: xavier_init(d_model * d_model, d_model, d_model, &mut rng),
+            w_k: xavier_init(d_model * d_model, d_model, d_model, &mut rng),
+            w_v: xavier_init(d_model * d_model, d_model, d_model, &mut rng),
+            w_o: xavier_init(d_model * d_model, d_model, d_model, &mut rng),
+        }
+    }
+
+    pub fn forward(&self, x: &[f32], seq_len: usize, causal: bool) -> Vec<f32> {
+        let mut output = vec![0.0f32; seq_len * self.d_model];
+
+        for pos in 0..seq_len {
+            // Apply self-attention for each position
+            let attn_out = self_attention(x, pos, self.d_model, seq_len, causal);
+
+            // Add residual connection
+            let start = pos * self.d_model;
+            for d in 0..self.d_model {
+                output[start + d] = x[start + d] + 0.1 * attn_out[d];
+            }
+        }
+
+        output
+    }
+}
+
+/// FFN (Feed-Forward Network)
+#[derive(Debug, Clone)]
+pub struct FFNLayer {
+    d_model: usize,
+    d_ffn: usize,
+    w1: Vec<f32>,
+    w2: Vec<f32>,
+    b1: Vec<f32>,
+    b2: Vec<f32>,
+}
+
+impl FFNLayer {
+    pub fn new(d_model: usize, d_ffn: usize) -> Self {
+        let mut rng = 0x1337_c0de_u64;
+
+        Self {
+            d_model,
+            d_ffn,
+            w1: xavier_init(d_model * d_ffn, d_model, d_ffn, &mut rng),
+            w2: xavier_init(d_ffn * d_model, d_ffn, d_model, &mut rng),
+            b1: vec![0.0f32; d_ffn],
+            b2: vec![0.0f32; d_model],
+        }
+    }
+
+    pub fn forward(&self, x: &[f32], seq_len: usize) -> Vec<f32> {
+        let mut output = vec![0.0f32; seq_len * self.d_model];
+
+        for pos in 0..seq_len {
+            let x_pos = &x[pos * self.d_model..(pos + 1) * self.d_model];
+
+            // First linear: d_model -> d_ffn
+            let mut hidden = vec![0.0f32; self.d_ffn];
+            for (i, hidden_val) in hidden.iter_mut().enumerate() {
+                for (j, &x_val) in x_pos.iter().enumerate() {
+                    *hidden_val += x_val * self.w1[j * self.d_ffn + i];
+                }
+                *hidden_val += self.b1[i];
+            }
+
+            // GELU activation (in-place)
+            gelu(&mut hidden);
+
+            // Second linear: d_ffn -> d_model
+            for (i, output_idx) in (pos * self.d_model..(pos + 1) * self.d_model).enumerate() {
+                for (j, &hidden_val) in hidden.iter().enumerate() {
+                    output[output_idx] += hidden_val * self.w2[j * self.d_model + i];
+                }
+                output[output_idx] += self.b2[i];
+            }
+        }
+
+        output
+    }
+}
+
+/// Transformer Layer
+#[derive(Debug, Clone)]
+pub struct TransformerLayer {
+    attention: MultiHeadAttention,
+    ffn: FFNLayer,
+    norm1_eps: f32,
+    norm2_eps: f32,
+}
+
+impl TransformerLayer {
+    pub fn new(d_model: usize, d_ffn: usize, n_heads: usize) -> Self {
+        Self {
+            attention: MultiHeadAttention::new(n_heads, d_model),
+            ffn: FFNLayer::new(d_model, d_ffn),
+            norm1_eps: 1e-5,
+            norm2_eps: 1e-5,
+        }
+    }
+
+    pub fn forward(&self, x: &[f32], seq_len: usize, causal: bool) -> Vec<f32> {
+        // Self-attention with residual connection
+        let attn_out = self.attention.forward(x, seq_len, causal);
+        let residual1: Vec<f32> = x.iter().zip(attn_out.iter()).map(|(&a, &b)| a + b).collect();
+        let norm1 = layer_norm(&residual1, self.norm1_eps);
+
+        // FFN with residual connection
+        let ffn_out = self.ffn.forward(&norm1, seq_len);
+        let residual2: Vec<f32> = norm1.iter().zip(ffn_out.iter()).map(|(&a, &b)| a + b).collect();
+        layer_norm(&residual2, self.norm2_eps)
+    }
+}
+
+/// Minimal Transformer Model
+pub struct MinimalTransformer {
+    vocab_size: usize,
+    d_model: usize,
+    #[allow(dead_code)]
+    d_ffn: usize,
+    #[allow(dead_code)]
+    n_heads: usize,
+    #[allow(dead_code)]
+    n_layers: usize,
+    #[allow(dead_code)]
+    max_seq_len: usize,
+
+    // Parameters
+    token_embedding: Vec<f32>,
+    pos_embedding: Vec<f32>,
+    layers: Vec<TransformerLayer>,
+    lm_head: Vec<f32>,
+}
+
+impl MinimalTransformer {
+    pub fn new(vocab_size: usize, d_model: usize, d_ffn: usize, n_heads: usize, n_layers: usize) -> Self {
+        let mut rng = 0x1337_c0de_u64;
+
+        // Token embeddings
+        let token_emb = xavier_init(vocab_size * d_model, vocab_size, d_model, &mut rng);
+
+        // Positional embeddings
+        let pos_emb = positional_encoding(256, d_model).into_iter().flatten().collect();
+
+        // Transformer layers
+        let layers: Vec<TransformerLayer> = (0..n_layers)
+            .map(|_| TransformerLayer::new(d_model, d_ffn, n_heads))
+            .collect();
+
+        // Language model head
+        let lm_head = xavier_init(vocab_size * d_model, d_model, vocab_size, &mut rng);
+
+        Self {
+            vocab_size,
+            d_model,
+            d_ffn,
+            n_heads,
+            n_layers,
+            max_seq_len: 256,
+            token_embedding: token_emb,
+            pos_embedding: pos_emb,
+            layers,
+            lm_head,
+        }
+    }
+
+    /// Get embedding for a token
+    fn get_token_embedding(&self, token_id: usize) -> Vec<f32> {
+        let start = token_id * self.d_model;
+        let end = start + self.d_model;
+        if end <= self.token_embedding.len() {
+            self.token_embedding[start..end].to_vec()
+        } else {
+            vec![0.0f32; self.d_model]
+        }
+    }
+
+    /// Get positional encoding for position
+    fn get_pos_embedding(&self, pos: usize) -> Vec<f32> {
+        let start = pos * self.d_model;
+        let end = start + self.d_model;
+        if end <= self.pos_embedding.len() {
+            self.pos_embedding[start..end].to_vec()
+        } else {
+            vec![0.0f32; self.d_model]
+        }
+    }
+
+    /// Forward pass
+    pub fn forward(&self, tokens: &[usize]) -> Vec<Vec<f32>> {
+        if tokens.is_empty() {
+            return vec![];
+        }
+
+        let seq_len = tokens.len();
+
+        // Build input embeddings with positional encoding
+        let mut input_embeddings = vec![0.0f32; seq_len * self.d_model];
+        for (pos, &token_id) in tokens.iter().enumerate() {
+            let token_emb = self.get_token_embedding(token_id);
+            let pos_emb = self.get_pos_embedding(pos);
+
+            for d in 0..self.d_model {
+                input_embeddings[pos * self.d_model + d] = token_emb[d] + pos_emb[d];
+            }
+        }
+
+        // Apply layer norm to input
+        let mut x = input_embeddings;
+        for pos in 0..seq_len {
+            let start = pos * self.d_model;
+            let end = start + self.d_model;
+            let normed = layer_norm(&x[start..end], 1e-5);
+            for (i, &val) in normed.iter().enumerate() {
+                x[start + i] = val;
+            }
+        }
+
+        // Apply transformer layers
+        for layer in &self.layers {
+            x = layer.forward(&x, seq_len, true);
+        }
+
+        // Project to vocabulary (for each position)
+        let mut logits = vec![vec![0.0f32; self.vocab_size]; seq_len];
+        for (pos, logits_row) in logits.iter_mut().enumerate() {
+            let x_pos = &x[pos * self.d_model..(pos + 1) * self.d_model];
+            for (v, logit) in logits_row.iter_mut().enumerate() {
+                for (d, &x_val) in x_pos.iter().enumerate() {
+                    *logit += x_val * self.lm_head[d * self.vocab_size + v];
+                }
+            }
+        }
+
+        logits
+    }
+
+    /// Get model parameter count
+    pub fn param_count(&self) -> usize {
+        let token_emb = self.token_embedding.len();
+        let pos_emb = self.pos_embedding.len();
+        let mut layers = 0;
+        for layer in &self.layers {
+            layers += layer.attention.w_q.len();
+            layers += layer.attention.w_k.len();
+            layers += layer.attention.w_v.len();
+            layers += layer.attention.w_o.len();
+            layers += layer.ffn.w1.len();
+            layers += layer.ffn.w2.len();
+            layers += layer.ffn.b1.len();
+            layers += layer.ffn.b2.len();
+        }
+        let lm_head = self.lm_head.len();
+
+        token_emb + pos_emb + layers + lm_head
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_layer_norm() {
+        let x = vec![1.0f32, 2.0, 3.0, 4.0, 5.0];
+        let normalized = layer_norm(&x, 1e-5);
+
+        assert_eq!(normalized.len(), 5);
+        let mean = normalized.iter().sum::<f32>() / 5.0;
+        assert!((mean).abs() < 1e-4, "Mean should be close to 0");
+    }
+
+    #[test]
+    fn test_positional_encoding() {
+        let d_model = 384;
+        let seq_len = 64;
+
+        let pos_emb = positional_encoding(seq_len, d_model);
+
+        assert_eq!(pos_emb.len(), seq_len);
+        assert_eq!(pos_emb[0].len(), d_model);
+    }
+
+    #[test]
+    fn test_softmax() {
+        let x = vec![1.0f32, 2.0, 3.0];
+        let soft = softmax(&x);
+
+        assert_eq!(soft.len(), 3);
+        let sum: f32 = soft.iter().sum();
+        assert!((sum - 1.0).abs() < 1e-6);
+    }
+
+    #[test]
+    fn test_multi_head_attention_new() {
+        let mha = MultiHeadAttention::new(8, 384);
+        assert_eq!(mha.n_heads, 8);
+        assert_eq!(mha.d_model, 384);
+        assert_eq!(mha.d_k, 48);
+    }
+
+    #[test]
+    fn test_ffn_layer_new() {
+        let ffn = FFNLayer::new(384, 1536);
+        assert_eq!(ffn.d_model, 384);
+        assert_eq!(ffn.d_ffn, 1536);
+        assert_eq!(ffn.w1.len(), 384 * 1536);
+        assert_eq!(ffn.w2.len(), 1536 * 384);
+    }
+
+    #[test]
+    fn test_transformer_layer_new() {
+        let layer = TransformerLayer::new(384, 1536, 8);
+        assert_eq!(layer.attention.n_heads, 8);
+        assert_eq!(layer.ffn.d_model, 384);
+    }
+
+    #[test]
+    fn test_minimal_transformer_new() {
+        let transformer = MinimalTransformer::new(128, 384, 1536, 8, 2);
+        assert_eq!(transformer.vocab_size, 128);
+        assert_eq!(transformer.d_model, 384);
+        assert_eq!(transformer.n_heads, 8);
+        assert_eq!(transformer.n_layers, 2);
+        assert!(transformer.param_count() > 0);
+    }
+
+    #[test]
+    fn test_minimal_transformer_forward() {
+        let transformer = MinimalTransformer::new(16, 64, 256, 4, 1);
+        let tokens = vec![1usize, 2, 3, 4];
+
+        let logits = transformer.forward(&tokens);
+
+        assert_eq!(logits.len(), 4);
+        for pos_logits in &logits {
+            assert_eq!(pos_logits.len(), 16);
+        }
+    }
+
+    #[test]
+    fn test_xavier_init() {
+        let mut rng = 0x1337_c0de_u64;
+        let weights = xavier_init(1000, 100, 100, &mut rng);
+
+        assert_eq!(weights.len(), 1000);
+
+        // Check bounds - Xavier should keep weights in reasonable range
+        let max_val = weights.iter().cloned().fold(f32::NEG_INFINITY, f32::max);
+        let min_val = weights.iter().cloned().fold(f32::INFINITY, f32::min);
+
+        assert!(max_val.abs() < 1.0, "Max value should be < 1.0");
+        assert!(min_val.abs() < 1.0, "Min value should be < 1.0");
+    }
+}


### PR DESCRIPTION
Lands the canonical Coq-proven artefacts that were previously only present in
`gHashTag/trios crates/trios-train-cpu/src/`.

## Changed

| File | Before | After | Notes |
|---|---|---|---|
| `src/invariants.rs` | 11-line stub | 345 lines | Full L-R14 module |
| `src/transformer.rs` | absent | 503 lines | MHA + FFN + LayerNorm + posenc |
| `src/lib.rs` | — | +1 line | `pub mod transformer;` |

## Why

R5 honesty: L-T3 cannot delete `crates/trios-train-cpu` from `gHashTag/trios`
until the canonical Coq-proven `invariants.rs` and the Minimal Transformer
have a permanent home in the SOT repo. Risk Register row 1 mandates this.

## Verification

```
cargo clippy --lib --all-targets -- -D warnings   # OK
cargo test --lib                                  # 111 passed
cargo test                                        # all suites green
```

## Anchor

phi^2 + phi^-2 = 3 — Zenodo DOI [10.5281/zenodo.19227877](https://doi.org/10.5281/zenodo.19227877)

Refs gHashTag/trios-trainer-igla#4 gHashTag/trios-trainer-igla#5.