### PR TITLE
ci: add ghcr-public.yml to set image visibility to public

### DIFF
--- a/.github/workflows/ghcr-public.yml
+++ b/.github/workflows/ghcr-public.yml
@@ -1,0 +1,29 @@
+name: Make GHCR package public
+
+on:
+  workflow_dispatch:
+
+permissions:
+  packages: write
+
+jobs:
+  set-public:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set package visibility to public
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          # Try user namespace
+          curl -sS -X PATCH \
+            -H "Accept: application/vnd.github+json" \
+            -H "Authorization: Bearer $GH_TOKEN" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            https://api.github.com/user/packages/container/trios-trainer-igla \
+            -d '{"visibility":"public"}' || true
+          echo "---"
+          # Verify
+          curl -sS \
+            -H "Accept: application/vnd.github+json" \
+            -H "Authorization: Bearer $GH_TOKEN" \
+            https://api.github.com/users/gHashTag/packages/container/trios-trainer-igla


### PR DESCRIPTION
Adds a manual workflow that sets ghcr.io/ghashtag/trios-trainer-igla to public visibility, so Railway services can pull without registry credentials.

Required to unblock L-T5 Railway 3-seed deployment for Gate-2.