### PR TITLE
docs: tri railway ONE SHOT for Gate-2 deploy

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,81 @@ cargo run --release --bin trios-train -- \
     --config configs/champion.toml --seed 43
 ```
 
-## Run on Railway
+## Run on Railway via `tri` (ONE SHOT)
+
+The canonical way to launch the 3-seed Gate-2 chase on Railway is the `tri railway` ONE SHOT shipped with [gHashTag/t27](https://github.com/gHashTag/t27) (PR #544 / issue #543). It is **R5-honest**: `tri` has no HTTP client yet, so `up --confirm` prints the exact GraphQL bodies that *would* be POSTed and exits 2 (planned-but-not-executed). The operator runs the actual mutation. Without `--confirm`, `up` is a pure dry-run (exit 0).
+
+### Quickstart (copy-paste)
+
+```bash
+export RAILWAY_TOKEN=<your-railway-account-token>
+export GITHUB_SHA=$(git rev-parse HEAD)            # used by R7 triplets
+
+# 1. Verify the token (POSTs `me { id email }` against backboard)
+tri railway login
+
+# 2. Bind the Railway project (default: e4fe33bb-3b09-4842-9782-7d2dea1abc9b)
+tri railway link
+
+# 3. Plan the 3-seed Gate-2 chase. Dry-run by default (exit 0).
+tri railway up
+
+# 4. Print the GraphQL bodies that would be POSTed (exit 2 = planned).
+tri railway up --confirm
+
+# 5. Status / logs (read-only) and Gate-2 verdict
+tri railway status
+tri railway logs --seed 43
+tri railway gate2
+```
+
+### Environment variables
+
+| Var | Default | Effect |
+|---|---|---|
+| `RAILWAY_TOKEN` | (required) | Railway account token; consumed by `tri railway login` |
+| `GITHUB_SHA` | (auto) | Embedded in R7 triplets and binding metadata |
+| `TRIOS_SEED` | per-service | Forced seed (43, 44, or 45) for each Gate-2 service |
+| `TRIOS_LEDGER_PUSH` | `1` | Push embargo-checked rows to the ledger |
+| `TRIOS_TARGET_BPB` | `1.85` | Gate-2 acceptance threshold |
+| `TRIOS_STEPS` | `30000` | Cap per seed (rows must satisfy step >= 4000) |
+| `RUST_LOG` | `info` | Log filter |
+
+### Exit codes
+
+| Code | Meaning |
+|---|---|
+| 0 | Dry-run plan printed, no Railway calls |
+| 2 | `--confirm` plan printed -- bodies are ready, operator must POST them |
+| non-zero (other) | Embargo blocked, invalid seed set, missing token, IO error |
+
+### Stop rule (Gate-2)
+
+The ONE SHOT terminates as soon as either condition holds:
+
+- **Quorum**: 3 distinct seeds in `{43, 44, 45}` each emit a row with `BPB < 1.85` AND `step >= 4000`, **OR**
+- **Deadline**: `2026-04-30 23:59 UTC`.
+
+### R5 / R7 / R9 reminders
+
+- **R5 (Honesty)**: NO DONE without merged PR + green CI + ledger row written.
+- **R7 (Triplet)**: every emit carries `BPB=<v> @ step=<N> seed=<S> sha=<7c> jsonl_row=<L> gate_status=<g>`.
+- **R8 (Step floor)**: a ledger row is only valid for `step >= 4000`.
+- **R9 (Embargo)**: `tri railway up` reads `assertions/embargo.txt` and refuses to plan if the head SHA matches any embargoed prefix.
+
+### Troubleshooting
+
+- **`tri railway login` -> 401**: regenerate `RAILWAY_TOKEN` at https://railway.com/account/tokens and re-export.
+- **`Embargo blocked HEAD <sha>`**: rebase past the embargoed commit before re-running -- this is by design.
+- **`Gate-2 seed set must contain 43, 44, 45`**: pass `--seeds 43,44,45` or omit the flag to use the canonical set.
+- **`tri` not on PATH**: build from t27 -- `cargo build -p tri --release` -> `t27/target/release/tri`.
+- **Status / logs print "(tri has no HTTP client yet)"**: by design. Inspect the Railway dashboard at https://railway.com/project/e4fe33bb-3b09-4842-9782-7d2dea1abc9b directly.
+
+### Anchor
+
+Mathematical foundation: `phi^2 + phi^-2 = 3` -- see [Zenodo DOI 10.5281/zenodo.19227877](https://doi.org/10.5281/zenodo.19227877).
+
+### Manual fallback (no `tri`)
 
 ```bash
 railway login


### PR DESCRIPTION
Closes #22

## Summary
Replaces the bare `## Run on Railway` section with `## Run on Railway via \`tri\` (ONE SHOT)` and documents the **R5-honest** flow shipped by [gHashTag/t27 PR #544](https://github.com/gHashTag/t27/pull/544) (closes gHashTag/t27#543).

## What lands
- Quickstart: `tri railway login` -> `link` -> `up --confirm` -> `gate2`
- Env-var table (`RAILWAY_TOKEN`, `GITHUB_SHA`, `TRIOS_SEED`, `TRIOS_LEDGER_PUSH`, `TRIOS_TARGET_BPB`, `TRIOS_STEPS`, `RUST_LOG`)
- Exit-code table (0 = dry-run, 2 = planned-but-not-executed)
- Gate-2 stop rule (3 seeds with BPB<1.85 AND step>=4000 OR deadline 2026-04-30 23:59 UTC)
- R5 / R7 / R8 / R9 reminders + R7 triplet format
- Troubleshooting (auth, embargo, missing PATH, status notice)
- Anchor `phi^2 + phi^-2 = 3` ([Zenodo DOI 10.5281/zenodo.19227877](https://doi.org/10.5281/zenodo.19227877))
- Manual railway-CLI fallback retained at the bottom

## R5 honesty note
`tri` ships **no HTTP client** yet, so `up --confirm` prints the exact GraphQL bodies that would be POSTed and exits 2. The operator runs the actual mutation. This is documented explicitly so the docs do not overclaim.

## Pre-existing CI
trios-trainer-igla `main` currently has clippy/fmt errors unrelated to docs. This PR only touches `README.md`, so any red CI carries over from main.