### PR TITLE
fix: rustfmt src/bin/arch_explorer.rs

### DIFF
--- a/src/bin/arch_explorer.rs
+++ b/src/bin/arch_explorer.rs
@@ -14,10 +14,10 @@
 #![allow(clippy::needless_range_loop)]
 #![allow(clippy::too_many_arguments)]
 
+use std::env;
 use std::fs;
 use std::io::Write;
 use std::time::Instant;
-use std::env;
 
 const VOCAB: usize = 128;
 const DIM: usize = 64;
@@ -53,7 +53,13 @@ fn activate(x: f32, name: &str) -> f32 {
 fn activate_grad(x: f32, name: &str) -> f32 {
     match name {
         "gelu" => gelu(x),
-        _ => if x > 0.0 { 1.0 } else { 0.0 },
+        _ => {
+            if x > 0.0 {
+                1.0
+            } else {
+                0.0
+            }
+        }
     }
 }
 
@@ -68,8 +74,13 @@ fn load_data(path: &str) -> Vec<usize> {
 fn softmax(v: &mut [f32]) {
     let max = v.iter().cloned().fold(f32::NEG_INFINITY, f32::max);
     let mut sum = 0.0f32;
-    for x in v.iter_mut() { *x = (*x - max).exp(); sum += *x; }
-    for x in v.iter_mut() { *x /= sum; }
+    for x in v.iter_mut() {
+        *x = (*x - max).exp();
+        sum += *x;
+    }
+    for x in v.iter_mut() {
+        *x /= sum;
+    }
 }
 
 fn layer_norm(x: &[f32], eps: f32) -> Vec<f32> {
@@ -81,15 +92,27 @@ fn layer_norm(x: &[f32], eps: f32) -> Vec<f32> {
 }
 
 struct AdamW {
-    m: Vec<f32>, v: Vec<f32>, step: usize,
-    beta1: f32, beta2: f32, eps: f32, wd: f32,
+    m: Vec<f32>,
+    v: Vec<f32>,
+    step: usize,
+    beta1: f32,
+    beta2: f32,
+    eps: f32,
+    wd: f32,
 }
 
 impl AdamW {
     fn new(size: usize, wd: f32) -> Self {
         let phi = (1.0 + 5.0f64.sqrt()) / 2.0;
-        Self { m: vec![0.0; size], v: vec![0.0; size], step: 0,
-            beta1: 1.0 / phi as f32, beta2: 0.999, eps: 1e-8, wd }
+        Self {
+            m: vec![0.0; size],
+            v: vec![0.0; size],
+            step: 0,
+            beta1: 1.0 / phi as f32,
+            beta2: 0.999,
+            eps: 1e-8,
+            wd,
+        }
     }
     fn update(&mut self, params: &mut [f32], grads: &[f32], lr: f32, clip: Option<f32>) {
         self.step += 1;
@@ -122,18 +145,28 @@ struct NgramModel {
 }
 
 impl NgramModel {
-    fn new(vocab: usize, dim: usize, hidden: usize, activation: String, seed: u64, num_ctx: usize, weight_tying: bool) -> Self {
+    fn new(
+        vocab: usize,
+        dim: usize,
+        hidden: usize,
+        activation: String,
+        seed: u64,
+        num_ctx: usize,
+        weight_tying: bool,
+    ) -> Self {
         let mut s = seed;
         let mut rng = || {
-            s = s.wrapping_mul(6364136223846793005).wrapping_add(1442695040888963407);
+            s = s
+                .wrapping_mul(6364136223846793005)
+                .wrapping_add(1442695040888963407);
             ((s >> 33) as f32) / (u32::MAX as f32) * 2.0 - 1.0
         };
         let lim = (6.0f32 / (3 * dim) as f32).sqrt();
         let lim_h = (6.0f32 / (dim + hidden) as f32).sqrt();
 
-        let ctx = (0..num_ctx).map(|_| {
-            (0..vocab * dim).map(|_| rng() * lim).collect()
-        }).collect();
+        let ctx = (0..num_ctx)
+            .map(|_| (0..vocab * dim).map(|_| rng() * lim).collect())
+            .collect();
 
         let base_weights: Vec<f32> = vec![0.7, 0.3, 0.2, 0.15, 0.12, 0.1, 0.08, 0.06];
         let ctx_weights: Vec<f32> = base_weights.iter().take(num_ctx).cloned().collect();
@@ -150,7 +183,11 @@ impl NgramModel {
             ctx_weights,
             proj: (0..hidden * dim).map(|_| rng() * lim_h).collect(),
             lm_head,
-            vocab, dim, hidden, activation, weight_tying,
+            vocab,
+            dim,
+            hidden,
+            activation,
+            weight_tying,
         }
     }
 
@@ -165,10 +202,14 @@ impl NgramModel {
 
         for (ci, cw) in self.ctx_weights.iter().enumerate() {
             let ctx_idx = tokens_context.len() - 2 - ci;
-            if ctx_idx == 0 && ci > 0 { break; }
+            if ctx_idx == 0 && ci > 0 {
+                break;
+            }
             let t = tokens_context[ctx_idx].min(v - 1);
             let cv = &self.ctx[ci][t * d..(t + 1) * d];
-            for j in 0..d { combined[j] += cv[j] * cw; }
+            for j in 0..d {
+                combined[j] += cv[j] * cw;
+            }
         }
 
         let ln = layer_norm(&combined, 1e-5);
@@ -176,7 +217,9 @@ impl NgramModel {
         let mut hidden = vec![0.0f32; h];
         for hi in 0..h {
             let w = &self.proj[hi * d..(hi + 1) * d];
-            for (j, l) in ln.iter().enumerate() { hidden[hi] += w[j] * l; }
+            for (j, l) in ln.iter().enumerate() {
+                hidden[hi] += w[j] * l;
+            }
             hidden[hi] = activate(hidden[hi], &self.activation);
         }
         hidden
@@ -189,7 +232,9 @@ impl NgramModel {
 
         for (vi, logit) in logits.iter_mut().enumerate() {
             let w = &self.lm_head[vi * h..(vi + 1) * h];
-            for (hi, hn) in hidden.iter().enumerate() { *logit += w[hi] * hn; }
+            for (hi, hn) in hidden.iter().enumerate() {
+                *logit += w[hi] * hn;
+            }
         }
         logits
     }
@@ -197,7 +242,9 @@ impl NgramModel {
     fn loss_on_seq(&self, tokens: &[usize]) -> f32 {
         let num_ctx = self.ctx.len();
         let ngram = num_ctx + 2;
-        if tokens.len() < ngram + 1 { return 0.0; }
+        if tokens.len() < ngram + 1 {
+            return 0.0;
+        }
         let count = tokens.len() - ngram;
         let mut total = 0.0f32;
 
@@ -213,12 +260,21 @@ impl NgramModel {
     }
 
     #[allow(clippy::needless_range_loop)]
-    fn train_step(&mut self, tokens: &[usize], lr: f32,
-        opt_embed: &mut AdamW, opt_ctx: &mut [AdamW], opt_proj: &mut AdamW, opt_head: &mut AdamW,
-        clip: Option<f32>) {
+    fn train_step(
+        &mut self,
+        tokens: &[usize],
+        lr: f32,
+        opt_embed: &mut AdamW,
+        opt_ctx: &mut [AdamW],
+        opt_proj: &mut AdamW,
+        opt_head: &mut AdamW,
+        clip: Option<f32>,
+    ) {
         let num_ctx = self.ctx.len();
         let ngram = num_ctx + 2;
-        if tokens.len() < ngram + 1 { return; }
+        if tokens.len() < ngram + 1 {
+            return;
+        }
         let v = self.vocab;
         let d = self.dim;
         let h = self.hidden;
@@ -243,14 +299,18 @@ impl NgramModel {
                 let ctx_idx = ngram - 2 - ci;
                 let t = context[ctx_idx].min(v - 1);
                 let cv = &self.ctx[ci][t * d..(t + 1) * d];
-                for j in 0..d { combined[j] += cv[j] * cw; }
+                for j in 0..d {
+                    combined[j] += cv[j] * cw;
+                }
             }
             let ln = layer_norm(&combined, 1e-5);
             let mut pre_act = vec![0.0f32; h];
             let mut hidden = vec![0.0f32; h];
             for hi in 0..h {
                 let w = &self.proj[hi * d..(hi + 1) * d];
-                for (j, l) in ln.iter().enumerate() { pre_act[hi] += w[j] * l; }
+                for (j, l) in ln.iter().enumerate() {
+                    pre_act[hi] += w[j] * l;
+                }
                 hidden[hi] = activate(pre_act[hi], &self.activation);
             }
             all_hidden.push(hidden);
@@ -262,13 +322,15 @@ impl NgramModel {
         for i in 0..count {
             let target = tokens[i + ngram].min(v - 1);
             let hidden = &all_hidden[i];
-            let mut d_hidden = vec![0.0f32; h];  // Always h since it comes from activation
+            let mut d_hidden = vec![0.0f32; h]; // Always h since it comes from activation
 
             // Compute logits and gradients (no weight tying for now)
             let mut logits = vec![0.0f32; v];
             for (vi, logit) in logits.iter_mut().enumerate() {
                 let w = &self.lm_head[vi * h..(vi + 1) * h];
-                for (hi, hn) in hidden.iter().enumerate() { *logit += w[hi] * hn; }
+                for (hi, hn) in hidden.iter().enumerate() {
+                    *logit += w[hi] * hn;
+                }
             }
             softmax(&mut logits);
 
@@ -280,7 +342,10 @@ impl NgramModel {
                 }
             }
 
-            let act_grads: Vec<f32> = all_pre_act[i].iter().map(|&pv| activate_grad(pv, &self.activation)).collect();
+            let act_grads: Vec<f32> = all_pre_act[i]
+                .iter()
+                .map(|&pv| activate_grad(pv, &self.activation))
+                .collect();
 
             // Backprop through proj and layer norm
             for hi in 0..h {
@@ -306,10 +371,20 @@ impl NgramModel {
         }
 
         let n = count as f32;
-        for x in g_embed.iter_mut() { *x /= n; }
-        for gc in g_ctx.iter_mut() { for x in gc.iter_mut() { *x /= n; } }
-        for x in g_proj.iter_mut() { *x /= n; }
-        for x in g_head.iter_mut() { *x /= n; }
+        for x in g_embed.iter_mut() {
+            *x /= n;
+        }
+        for gc in g_ctx.iter_mut() {
+            for x in gc.iter_mut() {
+                *x /= n;
+            }
+        }
+        for x in g_proj.iter_mut() {
+            *x /= n;
+        }
+        for x in g_head.iter_mut() {
+            *x /= n;
+        }
 
         opt_embed.update(&mut self.embed, &g_embed, lr, clip);
         for (ci, oc) in opt_ctx.iter_mut().enumerate() {
@@ -327,11 +402,18 @@ fn evaluate(model: &NgramModel, tokens: &[usize], seq_len: usize) -> (f32, f32) 
     let mut n = 0usize;
     for c in (0..tokens.len()).step_by(seq_len + 1) {
         let end = (c + seq_len + 1).min(tokens.len());
-        if end - c < model.ctx.len() + 3 { continue; }
+        if end - c < model.ctx.len() + 3 {
+            continue;
+        }
         let loss = model.loss_on_seq(&tokens[c..end]);
-        if loss.is_finite() { total += loss / LN_2; n += 1; }
+        if loss.is_finite() {
+            total += loss / LN_2;
+            n += 1;
+        }
     }
-    if n == 0 { return (f32::MAX, f32::MAX); }
+    if n == 0 {
+        return (f32::MAX, f32::MAX);
+    }
     let bpb = total / n as f32;
     (bpb * LN_2, bpb)
 }
@@ -349,9 +431,19 @@ fn get_lr(step: usize, max_steps: usize, base_lr: f32, warmup: usize, cosine: bo
     }
 }
 
-fn write_experience(trial_name: &str, config: &TrialConfig, best_bpb: f32, steps: usize, duration_sec: f64, outcome: &str) {
+fn write_experience(
+    trial_name: &str,
+    config: &TrialConfig,
+    best_bpb: f32,
+    steps: usize,
+    duration_sec: f64,
+    outcome: &str,
+) {
     let ts = chrono::Utc::now().format("%Y-%m-%dT%H:%M:%SZ");
-    let ep = format!(".trinity/experience/trios_{}.trinity", chrono::Utc::now().format("%Y%m%d"));
+    let ep = format!(
+        ".trinity/experience/trios_{}.trinity",
+        chrono::Utc::now().format("%Y%m%d")
+    );
     let _ = fs::create_dir_all(".trinity/experience");
 
     let mut entry = format!(
@@ -359,30 +451,62 @@ fn write_experience(trial_name: &str, config: &TrialConfig, best_bpb: f32, steps
         ts, trial_name, outcome, config.hidden, config.base_lr
     );
 
-    if config.weight_tying { entry.push_str(" | weight_tying=true"); }
-    if config.cosine_lr { entry.push_str(" | cosine_lr=true"); }
-    if let Some(c) = config.gradient_clip { entry.push_str(&format!(" | grad_clip={:.2}", c)); }
-    if config.warmup_steps > 0 { entry.push_str(&format!(" | warmup={}", config.warmup_steps)); }
+    if config.weight_tying {
+        entry.push_str(" | weight_tying=true");
+    }
+    if config.cosine_lr {
+        entry.push_str(" | cosine_lr=true");
+    }
+    if let Some(c) = config.gradient_clip {
+        entry.push_str(&format!(" | grad_clip={:.2}", c));
+    }
+    if config.warmup_steps > 0 {
+        entry.push_str(&format!(" | warmup={}", config.warmup_steps));
+    }
 
-    entry.push_str(&format!(" | bpb={:.4} | steps={} | {:.1}s\n", best_bpb, steps, duration_sec));
+    entry.push_str(&format!(
+        " | bpb={:.4} | steps={} | {:.1}s\n",
+        best_bpb, steps, duration_sec
+    ));
 
-    let _ = fs::OpenOptions::new().create(true).append(true)
-        .open(&ep).unwrap().write_all(entry.as_bytes());
+    let _ = fs::OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(&ep)
+        .unwrap()
+        .write_all(entry.as_bytes());
 }
 
-fn run_trial(config: TrialConfig, seed: u64, max_steps: usize, prune_step: usize, prune_threshold: f32) -> (f32, usize, String, f64) {
-    let ngram_order = 6;  // Fixed at 6-gram for all trials
+fn run_trial(
+    config: TrialConfig,
+    seed: u64,
+    max_steps: usize,
+    prune_step: usize,
+    prune_threshold: f32,
+) -> (f32, usize, String, f64) {
+    let ngram_order = 6; // Fixed at 6-gram for all trials
     let num_ctx = 4;
 
     println!("\n╔════════════════════════════════════════════════════════════╗");
     println!("║  ARCH-EXPLORER TRIAL: {:<45} ║", config.name);
     println!("╠════════════════════════════════════════════════════════════╣");
-    println!("║  {}-gram | h={} | lr={:.6} | seed={} {:<18}║", ngram_order, config.hidden, config.base_lr, seed,
-        if config.weight_tying { "| tying" } else { "" });
-    println!("║  cosine={} | clip={:<5} | warmup={:<4}",
+    println!(
+        "║  {}-gram | h={} | lr={:.6} | seed={} {:<18}║",
+        ngram_order,
+        config.hidden,
+        config.base_lr,
+        seed,
+        if config.weight_tying { "| tying" } else { "" }
+    );
+    println!(
+        "║  cosine={} | clip={:<5} | warmup={:<4}",
         config.cosine_lr,
-        config.gradient_clip.map(|c| format!("{:.2}", c)).unwrap_or_else(|| "none".to_string()),
-        config.warmup_steps);
+        config
+            .gradient_clip
+            .map(|c| format!("{:.2}", c))
+            .unwrap_or_else(|| "none".to_string()),
+        config.warmup_steps
+    );
     println!("║                                                      ║");
 
     let tokens = load_data("data/tinyshakespeare.txt");
@@ -390,20 +514,39 @@ fn run_trial(config: TrialConfig, seed: u64, max_steps: usize, prune_step: usize
     let train = &tokens[..train_end];
     let val = &tokens[train_end..];
 
-    let mut model = NgramModel::new(VOCAB, DIM, config.hidden, "relu".to_string(), seed, num_ctx, config.weight_tying);
+    let mut model = NgramModel::new(
+        VOCAB,
+        DIM,
+        config.hidden,
+        "relu".to_string(),
+        seed,
+        num_ctx,
+        config.weight_tying,
+    );
     let ps = VOCAB * DIM;
     let mut opt_embed = AdamW::new(ps, 0.01);
     let mut opt_ctx: Vec<AdamW> = (0..num_ctx).map(|_| AdamW::new(ps, 0.01)).collect();
 
-    let proj_size = if config.weight_tying { config.hidden * DIM } else { DIM * config.hidden };
+    let proj_size = if config.weight_tying {
+        config.hidden * DIM
+    } else {
+        DIM * config.hidden
+    };
     let mut opt_proj = AdamW::new(proj_size, 0.01);
 
-    let head_size = if config.weight_tying { VOCAB * DIM } else { VOCAB * config.hidden };
+    let head_size = if config.weight_tying {
+        VOCAB * DIM
+    } else {
+        VOCAB * config.hidden
+    };
     let mut opt_head = AdamW::new(head_size, 0.01);
 
     let (init_loss, init_bpb) = evaluate(&model, val, SEQ);
     println!("\nInitial val: loss={:.4} bpb={:.4}", init_loss, init_bpb);
-    println!("\n{:>6} | {:>10} | {:>10} | {:>10} | {:>8}", "step", "val_loss", "val_bpb", "best_bpb", "lr");
+    println!(
+        "\n{:>6} | {:>10} | {:>10} | {:>10} | {:>8}",
+        "step", "val_loss", "val_bpb", "best_bpb", "lr"
+    );
     println!("{}", "-".repeat(60));
 
     let t0 = Instant::now();
@@ -414,11 +557,23 @@ fn run_trial(config: TrialConfig, seed: u64, max_steps: usize, prune_step: usize
     let dl = train.len();
 
     for step in 1..=max_steps {
-        let lr = get_lr(step, max_steps, config.base_lr, config.warmup_steps, config.cosine_lr);
+        let lr = get_lr(
+            step,
+            max_steps,
+            config.base_lr,
+            config.warmup_steps,
+            config.cosine_lr,
+        );
         let off = (step * 97 + seed as usize) % (dl.saturating_sub(SEQ + 1));
-        model.train_step(&train[off..off + SEQ + 1], lr,
-            &mut opt_embed, &mut opt_ctx, &mut opt_proj, &mut opt_head,
-            config.gradient_clip);
+        model.train_step(
+            &train[off..off + SEQ + 1],
+            lr,
+            &mut opt_embed,
+            &mut opt_ctx,
+            &mut opt_proj,
+            &mut opt_head,
+            config.gradient_clip,
+        );
 
         if step % 500 == 0 || step == max_steps || step == prune_step {
             let _ms = t0.elapsed().as_millis();
@@ -427,12 +582,18 @@ fn run_trial(config: TrialConfig, seed: u64, max_steps: usize, prune_step: usize
                 best_bpb = vb;
                 best_step = step;
             }
-            println!("{:>6} | {:>10.4} | {:>10.4} | {:>10.4} | {:.6}", step, vl, vb, best_bpb, lr);
+            println!(
+                "{:>6} | {:>10.4} | {:>10.4} | {:>10.4} | {:.6}",
+                step, vl, vb, best_bpb, lr
+            );
             results.push((step, vl, vb));
 
             // Pruning check
             if step == prune_step && vb > prune_threshold {
-                println!("\n✂️  PRUNED at step {}: BPB={:.4} > {:.4}", step, vb, prune_threshold);
+                println!(
+                    "\n✂️  PRUNED at step {}: BPB={:.4} > {:.4}",
+                    step, vb, prune_threshold
+                );
                 pruned = true;
                 break;
             }
@@ -448,10 +609,22 @@ fn run_trial(config: TrialConfig, seed: u64, max_steps: usize, prune_step: usize
 
     println!("\n=== TRIAL {} DONE ===", config.name);
     println!("Outcome: {}", outcome);
-    println!("BPB: {:.4} → {:.4} | Delta: {:.4}", init_bpb, best_bpb, best_bpb - init_bpb);
+    println!(
+        "BPB: {:.4} → {:.4} | Delta: {:.4}",
+        init_bpb,
+        best_bpb,
+        best_bpb - init_bpb
+    );
     println!("Time: {:.1}s", total.as_secs_f64());
 
-    write_experience(&config.name, &config, best_bpb, best_step, total.as_secs_f64(), &outcome);
+    write_experience(
+        &config.name,
+        &config,
+        best_bpb,
+        best_step,
+        total.as_secs_f64(),
+        &outcome,
+    );
 
     (best_bpb, best_step, outcome, total.as_secs_f64())
 }
@@ -464,7 +637,7 @@ fn main() {
         TrialConfig {
             name: "X1".to_string(),
             hidden: 384,
-            weight_tying: false,     // DISABLED: needs h == dim for proper tying
+            weight_tying: false, // DISABLED: needs h == dim for proper tying
             cosine_lr: false,
             gradient_clip: None,
             warmup_steps: 0,
@@ -474,14 +647,14 @@ fn main() {
             name: "X2".to_string(),
             hidden: 384,
             weight_tying: false,
-            cosine_lr: true,         // Cosine LR schedule
+            cosine_lr: true, // Cosine LR schedule
             gradient_clip: None,
             warmup_steps: 0,
             base_lr: 0.004,
         },
         TrialConfig {
             name: "X3".to_string(),
-            hidden: 320,             // Smaller hidden
+            hidden: 320, // Smaller hidden
             weight_tying: false,
             cosine_lr: false,
             gradient_clip: None,
@@ -493,7 +666,7 @@ fn main() {
             hidden: 384,
             weight_tying: false,
             cosine_lr: false,
-            gradient_clip: Some(0.5),  // Gradient clipping
+            gradient_clip: Some(0.5), // Gradient clipping
             warmup_steps: 0,
             base_lr: 0.004,
         },
@@ -503,7 +676,7 @@ fn main() {
             weight_tying: false,
             cosine_lr: false,
             gradient_clip: None,
-            warmup_steps: 500,       // Warmup 500 steps
+            warmup_steps: 500, // Warmup 500 steps
             base_lr: 0.004,
         },
     ];
@@ -515,10 +688,12 @@ fn main() {
 
     // Determine which trial(s) to run
     let trial_idx = if args.len() > 1 && args[1] == "--all" {
-        None  // Run all
-    } else if let Some(idx) = args.iter().find(|a| a.starts_with("--trial=")).map(|a| {
-        a[8..].parse::<usize>().unwrap_or(0)
-    }) {
+        None // Run all
+    } else if let Some(idx) = args
+        .iter()
+        .find(|a| a.starts_with("--trial="))
+        .map(|a| a[8..].parse::<usize>().unwrap_or(0))
+    {
         if idx > 0 && idx <= trials.len() {
             Some(idx - 1)
         } else {
@@ -526,7 +701,7 @@ fn main() {
             None
         }
     } else {
-        None  // Default: run all
+        None // Default: run all
     };
 
     let trials_to_run: Vec<_> = if let Some(idx) = trial_idx {
@@ -537,17 +712,30 @@ fn main() {
 
     println!("\n╔════════════════════════════════════════════════════════════╗");
     println!("║  🏎️  ARCH-EXPLORER (АГЕНТ 3)                        ║");
-    println!("║  Machine: {}                                          ║", MACHINE_ID);
-    println!("║  Trials: {}                                           ║", trials_to_run.len());
-    println!("║  Max steps: {} | Prune at: {} if BPB > {:.2}        ║", max_steps, prune_step, prune_threshold);
-    println!("║  Target: BPB < {:.2}                                    ║", target_bpb);
+    println!(
+        "║  Machine: {}                                          ║",
+        MACHINE_ID
+    );
+    println!(
+        "║  Trials: {}                                           ║",
+        trials_to_run.len()
+    );
+    println!(
+        "║  Max steps: {} | Prune at: {} if BPB > {:.2}        ║",
+        max_steps, prune_step, prune_threshold
+    );
+    println!(
+        "║  Target: BPB < {:.2}                                    ║",
+        target_bpb
+    );
     println!("╚════════════════════════════════════════════════════════════╝");
 
     let mut all_results = vec![];
 
     for config in trials_to_run {
         let seed = 42;
-        let (bpb, step, outcome, duration) = run_trial(config.clone(), seed, max_steps, prune_step, prune_threshold);
+        let (bpb, step, outcome, duration) =
+            run_trial(config.clone(), seed, max_steps, prune_step, prune_threshold);
         all_results.push((config.name.clone(), bpb, step, outcome, duration));
     }
 
@@ -566,24 +754,42 @@ fn main() {
     }
 
     // Check for winner
-    let best_result = all_results.iter().min_by(|a, b| a.1.partial_cmp(&b.1).unwrap());
+    let best_result = all_results
+        .iter()
+        .min_by(|a, b| a.1.partial_cmp(&b.1).unwrap());
     if let Some((name, bpb, step, _, _)) = best_result {
         if *bpb < target_bpb {
             println!("\n🎯🎯🎯 WINNER FOUND! 🎯🎯🎯");
-            println!("Trial {} achieved BPB={:.4} < {:.4} at step {}", name, bpb, target_bpb, step);
+            println!(
+                "Trial {} achieved BPB={:.4} < {:.4} at step {}",
+                name, bpb, target_bpb, step
+            );
         } else {
-            println!("\n📊 Best trial: {} with BPB={:.4} (target: <{:.4})", name, bpb, target_bpb);
+            println!(
+                "\n📊 Best trial: {} with BPB={:.4} (target: <{:.4})",
+                name, bpb, target_bpb
+            );
             println!("Delta to target: +{:.4}", bpb - target_bpb);
         }
     }
 
     // Write summary to experience
     let ts = chrono::Utc::now().format("%Y-%m-%dT%H:%M:%SZ");
-    let ep = format!(".trinity/experience/trios_{}.trinity", chrono::Utc::now().format("%Y%m%d"));
-    let _ = fs::OpenOptions::new().create(true).append(true)
-        .open(&ep).unwrap().write_all(format!(
+    let ep = format!(
+        ".trinity/experience/trios_{}.trinity",
+        chrono::Utc::now().format("%Y%m%d")
+    );
+    let _ = fs::OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(&ep)
+        .unwrap()
+        .write_all(
+            format!(
             "[{}] ARCH-EXPLORER SUMMARY | machine={} | trials={} | best_bpb={:.4} | target={:.4}\n",
             ts, MACHINE_ID, all_results.len(),
             best_result.map(|(_, b, _, _, _)| *b).unwrap_or(999.9), target_bpb
-        ).as_bytes());
+        )
+            .as_bytes(),
+        );
 }

--- a/src/bin/cpu_train.rs
+++ b/src/bin/cpu_train.rs
@@ -25,7 +25,9 @@ fn softmax(v: &mut [f32]) {
 }
 
 fn rng_next(s: &mut u64) -> f32 {
-    *s = s.wrapping_mul(6364136223846793005).wrapping_add(1442695040888963407);
+    *s = s
+        .wrapping_mul(6364136223846793005)
+        .wrapping_add(1442695040888963407);
     let t = ((*s >> 33) as f32) / (u32::MAX as f32);
     t * 2.0 - 1.0
 }
@@ -43,7 +45,8 @@ impl BigramHash {
     }
 
     fn hash(&self, curr: usize, prev: usize) -> usize {
-        ((36313u32.wrapping_mul(curr as u32)) ^ (27191u32.wrapping_mul(prev as u32))) as usize % (self.vocab - 1)
+        ((36313u32.wrapping_mul(curr as u32)) ^ (27191u32.wrapping_mul(prev as u32))) as usize
+            % (self.vocab - 1)
     }
 
     fn forward(&self, tokens: &[usize]) -> Vec<Vec<f32>> {
@@ -75,18 +78,34 @@ struct SmearGate {
 
 impl SmearGate {
     fn new(dim: usize) -> Self {
-        Self { gate: vec![0.0f32; dim] }
+        Self {
+            gate: vec![0.0f32; dim],
+        }
     }
 
     fn forward(&self, xs: &[Vec<f32>]) -> Vec<Vec<f32>> {
         let mut out = Vec::with_capacity(xs.len());
         for (i, x) in xs.iter().enumerate() {
-            let g: Vec<f32> = self.gate.iter().map(|&g| 1.0 / (1.0 + (-g).exp())).collect();
+            let g: Vec<f32> = self
+                .gate
+                .iter()
+                .map(|&g| 1.0 / (1.0 + (-g).exp()))
+                .collect();
             if i == 0 {
-                out.push(x.iter().zip(g.iter()).map(|(xi, gi)| xi * (1.0 - gi)).collect());
+                out.push(
+                    x.iter()
+                        .zip(g.iter())
+                        .map(|(xi, gi)| xi * (1.0 - gi))
+                        .collect(),
+                );
             } else {
-                out.push(x.iter().zip(g.iter()).zip(xs[i - 1].iter())
-                    .map(|((xi, gi), pi)| xi * (1.0 - gi) + pi * gi).collect());
+                out.push(
+                    x.iter()
+                        .zip(g.iter())
+                        .zip(xs[i - 1].iter())
+                        .map(|((xi, gi), pi)| xi * (1.0 - gi) + pi * gi)
+                        .collect(),
+                );
             }
         }
         out
@@ -127,16 +146,20 @@ impl FFNLayer {
 
     #[allow(clippy::needless_range_loop)]
     fn forward(&self, x: &[f32]) -> Vec<f32> {
-        let hidden: Vec<f32> = (0..self.d_ff).map(|r| {
-            let row = &self.w1[r * self.d_model..(r + 1) * self.d_model];
-            let sum: f32 = row.iter().zip(x.iter()).map(|(&w, &xi)| w * xi).sum();
-            (sum + self.b1[r]).max(0.0)
-        }).collect();
-        (0..self.d_model).map(|r| {
-            let row = &self.w2[r * self.d_ff..(r + 1) * self.d_ff];
-            let sum: f32 = row.iter().zip(hidden.iter()).map(|(&w, &h)| w * h).sum();
-            sum + self.b2[r]
-        }).collect()
+        let hidden: Vec<f32> = (0..self.d_ff)
+            .map(|r| {
+                let row = &self.w1[r * self.d_model..(r + 1) * self.d_model];
+                let sum: f32 = row.iter().zip(x.iter()).map(|(&w, &xi)| w * xi).sum();
+                (sum + self.b1[r]).max(0.0)
+            })
+            .collect();
+        (0..self.d_model)
+            .map(|r| {
+                let row = &self.w2[r * self.d_ff..(r + 1) * self.d_ff];
+                let sum: f32 = row.iter().zip(hidden.iter()).map(|(&w, &h)| w * h).sum();
+                sum + self.b2[r]
+            })
+            .collect()
     }
 
     #[allow(clippy::needless_range_loop)]
@@ -149,7 +172,10 @@ impl FFNLayer {
             hidden[r] = row.iter().zip(x.iter()).map(|(&w, &xi)| w * xi).sum();
         }
         let activated: Vec<f32> = hidden.iter().map(|&h| h.max(0.0)).collect();
-        let relu_mask: Vec<f32> = hidden.iter().map(|&h| if h > 0.0 { 1.0 } else { 0.0 }).collect();
+        let relu_mask: Vec<f32> = hidden
+            .iter()
+            .map(|&h| if h > 0.0 { 1.0 } else { 0.0 })
+            .collect();
 
         let mut d_w2 = vec![0.0f32; d * ff];
         let mut d_b2 = vec![0.0f32; d];
@@ -195,7 +221,15 @@ struct AdamW {
 
 impl AdamW {
     fn new(size: usize, lr: f32) -> Self {
-        Self { m: vec![0.0; size], v: vec![0.0; size], lr, beta1: 0.9, beta2: 0.999, wd: 0.01, step: 0 }
+        Self {
+            m: vec![0.0; size],
+            v: vec![0.0; size],
+            lr,
+            beta1: 0.9,
+            beta2: 0.999,
+            wd: 0.01,
+            step: 0,
+        }
     }
 
     fn step(&mut self, params: &mut [f32], grads: &[f32]) {
@@ -231,7 +265,7 @@ impl CpuModel {
         let lm_head: Vec<f32> = (0..vocab * dim).map(|_| rng_next(&mut s) * 0.02).collect();
         let bigram = BigramHash::new(vocab, dim, &mut s);
         let smear = SmearGate::new(dim);
-        
+
         let ffn_layers = if std::env::args().any(|a| a == "--ffn") {
             let mut layers = Vec::new();
             // Read --ffn-layers argument, default to 2 if not present
@@ -244,8 +278,17 @@ impl CpuModel {
         } else {
             Vec::new()
         };
-        
-        Self { embed, lm_head, bigram, smear, ffn_layers, bigram_scale: 0.1, vocab, dim }
+
+        Self {
+            embed,
+            lm_head,
+            bigram,
+            smear,
+            ffn_layers,
+            bigram_scale: 0.1,
+            vocab,
+            dim,
+        }
     }
 
     #[allow(dead_code)]
@@ -253,13 +296,21 @@ impl CpuModel {
         let d = self.dim;
         let v = self.vocab;
 
-        let tok_emb: Vec<Vec<f32>> = tokens.iter()
+        let tok_emb: Vec<Vec<f32>> = tokens
+            .iter()
             .map(|&id| self.embed[(id % v) * d..((id % v) + 1) * d].to_vec())
             .collect();
 
         let bigram_emb = self.bigram.forward(tokens);
-        let mut xs: Vec<Vec<f32>> = tok_emb.iter().zip(bigram_emb.iter())
-            .map(|(t, b)| t.iter().zip(b.iter()).map(|(ti, bi)| ti + bi * self.bigram_scale).collect())
+        let mut xs: Vec<Vec<f32>> = tok_emb
+            .iter()
+            .zip(bigram_emb.iter())
+            .map(|(t, b)| {
+                t.iter()
+                    .zip(b.iter())
+                    .map(|(ti, bi)| ti + bi * self.bigram_scale)
+                    .collect()
+            })
             .collect();
 
         xs = self.smear.forward(&xs);
@@ -282,28 +333,45 @@ impl CpuModel {
         let v = self.vocab;
         let n = tokens.len();
 
-        let tok_emb: Vec<Vec<f32>> = tokens.iter()
+        let tok_emb: Vec<Vec<f32>> = tokens
+            .iter()
             .map(|&id| self.embed[(id % v) * d..((id % v) + 1) * d].to_vec())
             .collect();
         let bigram_emb = self.bigram.forward(tokens);
-        let xs: Vec<Vec<f32>> = tok_emb.iter().zip(bigram_emb.iter())
-            .map(|(t, b)| t.iter().zip(b.iter()).map(|(ti, bi)| ti + bi * self.bigram_scale).collect())
+        let xs: Vec<Vec<f32>> = tok_emb
+            .iter()
+            .zip(bigram_emb.iter())
+            .map(|(t, b)| {
+                t.iter()
+                    .zip(b.iter())
+                    .map(|(ti, bi)| ti + bi * self.bigram_scale)
+                    .collect()
+            })
             .collect();
         let xs_smeared = self.smear.forward(&xs);
 
         let xs_final: Vec<Vec<f32>> = if !self.ffn_layers.is_empty() {
             let mut current = xs_smeared;
             for ffn_layer in &self.ffn_layers {
-                let normed: Vec<Vec<f32>> = current.iter().map(|x| {
-                    let mean = x.iter().sum::<f32>() / d as f32;
-                    let var = x.iter().map(|v| (v - mean).powi(2)).sum::<f32>() / d as f32;
-                    let std = (var + 1e-5).sqrt();
-                    x.iter().map(|v| (v - mean) / std).collect()
-                }).collect();
+                let normed: Vec<Vec<f32>> = current
+                    .iter()
+                    .map(|x| {
+                        let mean = x.iter().sum::<f32>() / d as f32;
+                        let var = x.iter().map(|v| (v - mean).powi(2)).sum::<f32>() / d as f32;
+                        let std = (var + 1e-5).sqrt();
+                        x.iter().map(|v| (v - mean) / std).collect()
+                    })
+                    .collect();
                 let ffn_out: Vec<Vec<f32>> = normed.iter().map(|x| ffn_layer.forward(x)).collect();
-                current = (0..n).map(|i| {
-                    current[i].iter().zip(ffn_out[i].iter()).map(|(&a, &b)| a + b).collect()
-                }).collect();
+                current = (0..n)
+                    .map(|i| {
+                        current[i]
+                            .iter()
+                            .zip(ffn_out[i].iter())
+                            .map(|(&a, &b)| a + b)
+                            .collect()
+                    })
+                    .collect();
             }
             current
         } else {
@@ -344,7 +412,13 @@ impl CpuModel {
         (loss, d_logits, d_hidden)
     }
 
-    fn train_step(&mut self, tokens: &[usize], opt_embed: &mut AdamW, opt_head: &mut AdamW, lr: f32) -> f32 {
+    fn train_step(
+        &mut self,
+        tokens: &[usize],
+        opt_embed: &mut AdamW,
+        opt_head: &mut AdamW,
+        lr: f32,
+    ) -> f32 {
         let d = self.dim;
         let v = self.vocab;
         let n = tokens.len();
@@ -352,12 +426,20 @@ impl CpuModel {
         let (loss, d_logits, _d_hidden) = self.loss_and_grad(tokens);
 
         // Recompute forward activations
-        let tok_emb: Vec<Vec<f32>> = tokens.iter()
+        let tok_emb: Vec<Vec<f32>> = tokens
+            .iter()
             .map(|&id| self.embed[(id % v) * d..((id % v) + 1) * d].to_vec())
             .collect();
         let bigram_emb = self.bigram.forward(tokens);
-        let xs: Vec<Vec<f32>> = tok_emb.iter().zip(bigram_emb.iter())
-            .map(|(t, b)| t.iter().zip(b.iter()).map(|(ti, bi)| ti + bi * self.bigram_scale).collect())
+        let xs: Vec<Vec<f32>> = tok_emb
+            .iter()
+            .zip(bigram_emb.iter())
+            .map(|(t, b)| {
+                t.iter()
+                    .zip(b.iter())
+                    .map(|(ti, bi)| ti + bi * self.bigram_scale)
+                    .collect()
+            })
             .collect();
         let xs_smeared = self.smear.forward(&xs);
 
@@ -377,20 +459,29 @@ impl CpuModel {
             // Forward: xs_final = smeared + ffn1(layernorm(smeared)) + ffn2(...) + ...
             let mut xs_final = xs_smeared.clone();
             let mut normed_activations = Vec::new();
-            
+
             for ffn_layer in &self.ffn_layers {
-                let normed: Vec<Vec<f32>> = xs_final.iter().map(|x| {
-                    let mean = x.iter().sum::<f32>() / d as f32;
-                    let var = x.iter().map(|v| (v - mean).powi(2)).sum::<f32>() / d as f32;
-                    let std = (var + 1e-5).sqrt();
-                    x.iter().map(|v| (v - mean) / std).collect()
-                }).collect();
+                let normed: Vec<Vec<f32>> = xs_final
+                    .iter()
+                    .map(|x| {
+                        let mean = x.iter().sum::<f32>() / d as f32;
+                        let var = x.iter().map(|v| (v - mean).powi(2)).sum::<f32>() / d as f32;
+                        let std = (var + 1e-5).sqrt();
+                        x.iter().map(|v| (v - mean) / std).collect()
+                    })
+                    .collect();
                 normed_activations.push(normed.clone());
-                
+
                 let ffn_out: Vec<Vec<f32>> = normed.iter().map(|x| ffn_layer.forward(x)).collect();
-                xs_final = (0..n).map(|i| {
-                    xs_final[i].iter().zip(ffn_out[i].iter()).map(|(&a, &b)| a + b).collect()
-                }).collect();
+                xs_final = (0..n)
+                    .map(|i| {
+                        xs_final[i]
+                            .iter()
+                            .zip(ffn_out[i].iter())
+                            .map(|(&a, &b)| a + b)
+                            .collect()
+                    })
+                    .collect();
             }
 
             // d_lm_head
@@ -408,10 +499,10 @@ impl CpuModel {
             let mut d_to_emb = vec![vec![0.0f32; d]; n];
             let mut current_grad = d_from_logits.clone();
             let mut all_layer_grads = Vec::with_capacity(self.ffn_layers.len());
-            
+
             for (layer_idx, ffn_layer) in self.ffn_layers.iter().rev().enumerate() {
                 let normed = &normed_activations[self.ffn_layers.len() - 1 - layer_idx];
-                
+
                 let mut layer_grads = Vec::with_capacity(n);
                 for (i, normed_row) in normed.iter().enumerate() {
                     let gi = i.min(n - 2);
@@ -419,7 +510,7 @@ impl CpuModel {
                     layer_grads.push((dw1, db1, dw2, db2));
                 }
                 all_layer_grads.push(layer_grads);
-                
+
                 // Compute gradient flowing to previous layer (through layer norm)
                 for (i, d_to_emb_row) in d_to_emb.iter_mut().enumerate().take(n) {
                     let x = &xs_smeared[i];
@@ -427,20 +518,27 @@ impl CpuModel {
                     let var = x.iter().map(|vv| (vv - mean).powi(2)).sum::<f32>() / d as f32;
                     let std = (var + 1e-5).sqrt();
                     let nn = d as f32;
-                    let dx_sum: f32 = current_grad[i.min(n-2)].iter().sum();
-                    let dx_xm_sum: f32 = current_grad[i.min(n-2)].iter().zip(x.iter()).map(|(&g, &xi)| g * (xi - mean)).sum();
+                    let dx_sum: f32 = current_grad[i.min(n - 2)].iter().sum();
+                    let dx_xm_sum: f32 = current_grad[i.min(n - 2)]
+                        .iter()
+                        .zip(x.iter())
+                        .map(|(&g, &xi)| g * (xi - mean))
+                        .sum();
                     let inv_n_std = 1.0 / (nn * std);
                     let inv_var_eps = 1.0 / (var + 1e-5);
-                    
+
                     for (j, de) in d_to_emb_row.iter_mut().enumerate() {
                         let xm = x[j] - mean;
-                        *de = inv_n_std * (nn * current_grad[i.min(n-2)][j] - dx_sum - xm * inv_var_eps * dx_xm_sum);
+                        *de = inv_n_std
+                            * (nn * current_grad[i.min(n - 2)][j]
+                                - dx_sum
+                                - xm * inv_var_eps * dx_xm_sum);
                     }
                 }
-                
+
                 current_grad = d_to_emb.clone();
             }
-            
+
             // Final gradient: residual + FFN path
             for (i, d_to_emb_row) in d_to_emb.iter_mut().enumerate() {
                 let gi = i.min(n - 2);
@@ -448,16 +546,24 @@ impl CpuModel {
                     *de += d_from_logits[gi][j];
                 }
             }
-            
+
             // Phase 2: Apply all parameter updates
             let n_layers = self.ffn_layers.len();
             for (layer_idx, layer_grads) in all_layer_grads.into_iter().enumerate() {
                 let layer_mut = &mut self.ffn_layers[n_layers - 1 - layer_idx];
                 for (dw1, db1, dw2, db2) in layer_grads.into_iter() {
-                    for (k, &g) in dw1.iter().enumerate() { layer_mut.w1[k] -= lr * g; }
-                    for (k, &g) in db1.iter().enumerate() { layer_mut.b1[k] -= lr * g; }
-                    for (k, &g) in dw2.iter().enumerate() { layer_mut.w2[k] -= lr * g; }
-                    for (k, &g) in db2.iter().enumerate() { layer_mut.b2[k] -= lr * g; }
+                    for (k, &g) in dw1.iter().enumerate() {
+                        layer_mut.w1[k] -= lr * g;
+                    }
+                    for (k, &g) in db1.iter().enumerate() {
+                        layer_mut.b1[k] -= lr * g;
+                    }
+                    for (k, &g) in dw2.iter().enumerate() {
+                        layer_mut.w2[k] -= lr * g;
+                    }
+                    for (k, &g) in db2.iter().enumerate() {
+                        layer_mut.b2[k] -= lr * g;
+                    }
                 }
             }
 
@@ -500,7 +606,9 @@ impl CpuModel {
         let mut n = 0usize;
         for c in (0..eval_tokens.len()).step_by(seq_len + 1) {
             let end = (c + seq_len + 1).min(eval_tokens.len());
-            if end - c < 3 { continue; }
+            if end - c < 3 {
+                continue;
+            }
             let seq = &eval_tokens[c..end];
             let (loss, _, _) = self.loss_and_grad(seq);
             if loss.is_finite() {
@@ -508,7 +616,9 @@ impl CpuModel {
                 n += 1;
             }
         }
-        if n == 0 { return f32::MAX; }
+        if n == 0 {
+            return f32::MAX;
+        }
         total_bpb / n as f32
     }
 }
@@ -525,12 +635,19 @@ fn main() {
     let tokens: Vec<usize> = raw_tokens.iter().map(|&t| t % vocab).collect();
 
     println!("=== trios CPU Training (Analytical Backprop) ===");
-    println!("vocab={} dim={} seq={} steps={} seed={} lr={}", vocab, dim, seq, steps, seed, lr);
+    println!(
+        "vocab={} dim={} seq={} steps={} seed={} lr={}",
+        vocab, dim, seq, steps, seed, lr
+    );
 
     let train_end = (tokens.len() as f64 * 0.9) as usize;
     let train_tokens = &tokens[..train_end];
     let val_tokens = &tokens[train_end..];
-    println!("Dataset: {} train / {} val tokens", train_tokens.len(), val_tokens.len());
+    println!(
+        "Dataset: {} train / {} val tokens",
+        train_tokens.len(),
+        val_tokens.len()
+    );
 
     let mut model = CpuModel::new(vocab, dim, seed);
     let mut opt_embed = AdamW::new(vocab * dim, lr);
@@ -539,7 +656,10 @@ fn main() {
     let init_bpb = model.eval_bpb(val_tokens, seq);
     println!("Initial val BPB: {:.4}", init_bpb);
     println!();
-    println!("{:>6} | {:>10} | {:>10} | {:>10} | {:>8}", "step", "train_loss", "val_bpb", "best_bpb", "ms");
+    println!(
+        "{:>6} | {:>10} | {:>10} | {:>10} | {:>8}",
+        "step", "train_loss", "val_bpb", "best_bpb", "ms"
+    );
     println!("{}", "-".repeat(60));
 
     let t0 = Instant::now();
@@ -558,7 +678,9 @@ fn main() {
         };
 
         let offset = {
-            rng_state = rng_state.wrapping_mul(6364136223846793005).wrapping_add(1442695040888963407);
+            rng_state = rng_state
+                .wrapping_mul(6364136223846793005)
+                .wrapping_add(1442695040888963407);
             (rng_state as usize) % (data_len.saturating_sub(seq + 1))
         };
         let batch = &train_tokens[offset..offset + seq + 1];
@@ -570,16 +692,23 @@ fn main() {
             if val_bpb < best_bpb && val_bpb.is_finite() {
                 best_bpb = val_bpb;
             }
-            println!("{:>6} | {:>10.4} | {:>10.4} | {:>10.4} | {:>6}ms",
-                step, train_loss, val_bpb, best_bpb, ms);
+            println!(
+                "{:>6} | {:>10.4} | {:>10.4} | {:>10.4} | {:>6}ms",
+                step, train_loss, val_bpb, best_bpb, ms
+            );
         }
     }
 
     let total = t0.elapsed();
     println!();
     println!("=== Training Complete ===");
-    println!("Time: {:.1}s | Init BPB: {:.4} | Best BPB: {:.4} | Delta: {:.4}",
-        total.as_secs_f64(), init_bpb, best_bpb, init_bpb - best_bpb);
+    println!(
+        "Time: {:.1}s | Init BPB: {:.4} | Best BPB: {:.4} | Delta: {:.4}",
+        total.as_secs_f64(),
+        init_bpb,
+        best_bpb,
+        init_bpb - best_bpb
+    );
 
     let _ = fs::create_dir_all(".trinity/results");
     let result_json = serde_json::json!({
@@ -598,8 +727,14 @@ fn main() {
     });
 
     let rpath = format!(".trinity/results/cpu_train_seed{}.json", seed);
-    fs::File::create(&rpath).unwrap()
-        .write_all(serde_json::to_string_pretty(&result_json).unwrap().as_bytes()).unwrap();
+    fs::File::create(&rpath)
+        .unwrap()
+        .write_all(
+            serde_json::to_string_pretty(&result_json)
+                .unwrap()
+                .as_bytes(),
+        )
+        .unwrap();
     println!("Results: {}", rpath);
 }
 

--- a/src/bin/gf16_test.rs
+++ b/src/bin/gf16_test.rs
@@ -1,7 +1,7 @@
 //! GF16 Test Binary - Quantization and accuracy benchmarks
 
-use trios_trainer::gf16::{GF16, benchmark_quantization};
 use std::time::Instant;
+use trios_trainer::gf16::{benchmark_quantization, GF16};
 
 fn main() {
     println!("=== GF16 Test Suite ===\n");
@@ -43,15 +43,19 @@ fn test_basic_conversions() {
     for &v in &values {
         let gf = GF16::from_f32(v);
         let back = gf.to_f32();
-        println!("  f32: {:10.4} -> GF16: {:10.4} -> f32: {:10.4} (error: {:.6}%)",
-                 v, gf, back, ((back - v).abs() / v.abs().max(1e-10) * 100.0));
+        println!(
+            "  f32: {:10.4} -> GF16: {:10.4} -> f32: {:10.4} (error: {:.6}%)",
+            v,
+            gf,
+            back,
+            ((back - v).abs() / v.abs().max(1e-10) * 100.0)
+        );
     }
 }
 
 fn test_roundtrip_accuracy() {
     let test_values = vec![
-        0.001, 0.01, 0.1, 0.5, 1.0, 2.0, 5.0, 10.0, 100.0,
-        0.0001, 0.00001, -0.5, -2.5, -10.0,
+        0.001, 0.01, 0.1, 0.5, 1.0, 2.0, 5.0, 10.0, 100.0, 0.0001, 0.00001, -0.5, -2.5, -10.0,
     ];
 
     let mut max_rel_error = 0.0f64;
@@ -91,23 +95,49 @@ fn test_phi_distance() {
     let phi = 1.618_033_988_749_895_f64;
     let inv_phi = 1.0 / phi;
     let gf16_phi_dist = GF16::phi_distance();
-    let exp_mant_ratio = 6.0 / 9.0;  // GF16's 6:9 split
+    let exp_mant_ratio = 6.0 / 9.0; // GF16's 6:9 split
 
     println!("  Golden ratio (φ):      {:.15}", phi);
     println!("  Inverse φ (1/φ):      {:.15}", inv_phi);
     println!("  GF16 exp:mant ratio:  {:.6}", exp_mant_ratio);
     println!("  GF16 φ-distance:      {:.6}", gf16_phi_dist);
-    println!("  Expected φ-distance:  {:.6}", (exp_mant_ratio - inv_phi).abs());
-    println!("  Matches specification: {}", (gf16_phi_dist - 0.0486).abs() < 0.001);
+    println!(
+        "  Expected φ-distance:  {:.6}",
+        (exp_mant_ratio - inv_phi).abs()
+    );
+    println!(
+        "  Matches specification: {}",
+        (gf16_phi_dist - 0.0486).abs() < 0.001
+    );
 }
 
 fn test_special_values() {
-    println!("  Zero:        {} -> f32: {}", GF16::ZERO, GF16::ZERO.to_f32());
-    println!("  Neg Zero:    {} -> f32: {}", GF16::NEG_ZERO, GF16::NEG_ZERO.to_f32());
-    println!("  Infinity:    {} -> f32: {}", GF16::INF, GF16::INF.to_f32());
-    println!("  Neg Infinity:{} -> f32: {}", GF16::NEG_INF, GF16::NEG_INF.to_f32());
-    println!("  NaN:         {} -> f32: {} (is_nan: {})",
-             GF16::NAN, GF16::NAN.to_f32(), GF16::NAN.is_nan());
+    println!(
+        "  Zero:        {} -> f32: {}",
+        GF16::ZERO,
+        GF16::ZERO.to_f32()
+    );
+    println!(
+        "  Neg Zero:    {} -> f32: {}",
+        GF16::NEG_ZERO,
+        GF16::NEG_ZERO.to_f32()
+    );
+    println!(
+        "  Infinity:    {} -> f32: {}",
+        GF16::INF,
+        GF16::INF.to_f32()
+    );
+    println!(
+        "  Neg Infinity:{} -> f32: {}",
+        GF16::NEG_INF,
+        GF16::NEG_INF.to_f32()
+    );
+    println!(
+        "  NaN:         {} -> f32: {} (is_nan: {})",
+        GF16::NAN,
+        GF16::NAN.to_f32(),
+        GF16::NAN.is_nan()
+    );
 
     // Test special value properties
     assert!(GF16::NAN.is_nan());
@@ -123,19 +153,35 @@ fn test_range_boundaries() {
 
     // Test near minimum
     let tiny = GF16::from_f32(1e-20);
-    println!("  Very small (1e-20): {} -> {}", GF16::from_bits(tiny.0), tiny.to_f32());
+    println!(
+        "  Very small (1e-20): {} -> {}",
+        GF16::from_bits(tiny.0),
+        tiny.to_f32()
+    );
     println!("    Clamped to zero: {}", tiny.to_f32() == 0.0);
 
     let min_pos = GF16::from_f32(1e-9);
-    println!("  Small (1e-9):       {} -> {}", GF16::from_bits(min_pos.0), min_pos.to_f32());
+    println!(
+        "  Small (1e-9):       {} -> {}",
+        GF16::from_bits(min_pos.0),
+        min_pos.to_f32()
+    );
 
     // Test near maximum
     let huge = GF16::from_f32(1e20);
-    println!("  Very large (1e20):  {} -> {}", GF16::from_bits(huge.0), huge.to_f32());
+    println!(
+        "  Very large (1e20):  {} -> {}",
+        GF16::from_bits(huge.0),
+        huge.to_f32()
+    );
     println!("    Clamped to inf: {}", huge.is_infinite());
 
     let large = GF16::from_f32(1e9);
-    println!("  Large (1e9):        {} -> {}", GF16::from_bits(large.0), large.to_f32());
+    println!(
+        "  Large (1e9):        {} -> {}",
+        GF16::from_bits(large.0),
+        large.to_f32()
+    );
     println!("    Is finite: {}", large.is_finite());
 }
 

--- a/src/bin/honey_audit.rs
+++ b/src/bin/honey_audit.rs
@@ -151,10 +151,7 @@ const KEY_ALIASES: [(&str, &str); 1] = [("ts", "timestamp_utc")];
 const SHA_KEYS: [&str; 4] = ["sha", "commit_sha", "main_sha", "parent_sha"];
 
 /// Resolve a logical key against a JSON object honoring aliases.
-fn lookup_logical<'a>(
-    obj: &'a serde_json::Map<String, Value>,
-    logical: &str,
-) -> Option<&'a Value> {
+fn lookup_logical<'a>(obj: &'a serde_json::Map<String, Value>, logical: &str) -> Option<&'a Value> {
     if let Some(v) = obj.get(logical) {
         return Some(v);
     }

--- a/src/bin/hybrid_train.rs
+++ b/src/bin/hybrid_train.rs
@@ -163,10 +163,18 @@ impl HybridModel {
         let attn_cfg = m.attn.config();
         let d = attn_cfg.d_model;
         let attn_lim = (2.0f32 / d as f32).sqrt();
-        for w in m.attn.wq_mut() { *w = rng() * attn_lim; }
-        for w in m.attn.wk_mut() { *w = rng() * attn_lim; }
-        for w in m.attn.wv_mut() { *w = rng() * attn_lim; }
-        for w in m.attn.wo_mut() { *w = rng() * attn_lim; }
+        for w in m.attn.wq_mut() {
+            *w = rng() * attn_lim;
+        }
+        for w in m.attn.wk_mut() {
+            *w = rng() * attn_lim;
+        }
+        for w in m.attn.wv_mut() {
+            *w = rng() * attn_lim;
+        }
+        for w in m.attn.wo_mut() {
+            *w = rng() * attn_lim;
+        }
 
         m
     }
@@ -270,7 +278,8 @@ fn compute_grads_for_positions(
     let h = model.hidden;
     let d = model.attn.config().d_model;
     for &pos in positions {
-        let (combined, ln, hidden, mut logits, attn_out_saved) = model.forward_position(tokens, pos);
+        let (combined, ln, hidden, mut logits, attn_out_saved) =
+            model.forward_position(tokens, pos);
         softmax(&mut logits);
         let target = tokens[pos + NGRAM].min(VOCAB - 1);
 
@@ -399,30 +408,33 @@ fn main() {
     };
 
     for &seed in &seeds {
-    eprintln!(
-        "=== Hybrid Train (ngram+attn) seed={} ===",
-        seed
-    );
-    eprintln!(
-        "steps={} lr={} hidden={} eval_every={} accum={}",
-        steps, base_lr, hidden, eval_every, accum
-    );
-    eprintln!(
-        "DIM={} NUM_CTX={} NGRAM={} SEQ={} VOCAB={}",
-        DIM, NUM_CTX, NGRAM, SEQ, VOCAB
-    );
-    eprintln!("ctx_weights={:?}", CTX_WEIGHTS);
+        eprintln!("=== Hybrid Train (ngram+attn) seed={} ===", seed);
+        eprintln!(
+            "steps={} lr={} hidden={} eval_every={} accum={}",
+            steps, base_lr, hidden, eval_every, accum
+        );
+        eprintln!(
+            "DIM={} NUM_CTX={} NGRAM={} SEQ={} VOCAB={}",
+            DIM, NUM_CTX, NGRAM, SEQ, VOCAB
+        );
+        eprintln!("ctx_weights={:?}", CTX_WEIGHTS);
 
-    let train_data = load_data("data/tiny_shakespeare.txt");
-    let val_data = load_data("data/tiny_shakespeare_val.txt");
-    eprintln!("train={} val={}", train_data.len(), val_data.len());
+        let train_data = load_data("data/tiny_shakespeare.txt");
+        let val_data = load_data("data/tiny_shakespeare_val.txt");
+        eprintln!("train={} val={}", train_data.len(), val_data.len());
 
-    let mut model = HybridModel::new(hidden, seed);
+        let mut model = HybridModel::new(hidden, seed);
 
-    let d = model.attn.config().d_model;
-    let attn_params = d * model.hidden * 2;
-    let total_params = VOCAB * DIM + NUM_CTX * VOCAB * DIM + hidden * DIM + VOCAB * hidden + attn_params;
-    eprintln!("params={} ({:.1}K) attn_d={}", total_params, total_params as f64 / 1000.0, d);
+        let d = model.attn.config().d_model;
+        let attn_params = d * model.hidden * 2;
+        let total_params =
+            VOCAB * DIM + NUM_CTX * VOCAB * DIM + hidden * DIM + VOCAB * hidden + attn_params;
+        eprintln!(
+            "params={} ({:.1}K) attn_d={}",
+            total_params,
+            total_params as f64 / 1000.0,
+            d
+        );
 
         let train_data = load_data("data/tiny_shakespeare.txt");
         let val_data = load_data("data/tiny_shakespeare_val.txt");
@@ -432,13 +444,11 @@ fn main() {
 
         let wd = 0.04f32;
         let mut opt_embed = AdamW::new(VOCAB * DIM, wd);
-        let mut opt_ctx: Vec<AdamW> = (0..NUM_CTX)
-            .map(|_| AdamW::new(VOCAB * DIM, wd))
-            .collect();
-    let mut opt_proj = AdamW::new(hidden * DIM, wd);
-    let mut opt_attn_down = AdamW::new(d * hidden, wd);
-    let mut opt_attn_up = AdamW::new(hidden * d, wd);
-    let mut opt_head = AdamW::new(VOCAB * hidden, wd);
+        let mut opt_ctx: Vec<AdamW> = (0..NUM_CTX).map(|_| AdamW::new(VOCAB * DIM, wd)).collect();
+        let mut opt_proj = AdamW::new(hidden * DIM, wd);
+        let mut opt_attn_down = AdamW::new(d * hidden, wd);
+        let mut opt_attn_up = AdamW::new(hidden * d, wd);
+        let mut opt_head = AdamW::new(VOCAB * hidden, wd);
 
         let init_bpb = evaluate(&model, &val_data);
         eprintln!("Initial val_bpb={:.4}", init_bpb);
@@ -454,13 +464,12 @@ fn main() {
             let lr = cosine_lr(step, steps, base_lr, warmup);
 
             let mut g_embed = vec![0.0f32; VOCAB * DIM];
-            let mut g_ctx: Vec<Vec<f32>> = (0..NUM_CTX)
-                .map(|_| vec![0.0f32; VOCAB * DIM])
-                .collect();
-        let mut g_proj = vec![0.0f32; hidden * DIM];
-        let mut g_head = vec![0.0f32; VOCAB * hidden];
-        let mut g_attn_down = vec![0.0f32; d * hidden];
-        let mut g_attn_up = vec![0.0f32; hidden * d];
+            let mut g_ctx: Vec<Vec<f32>> =
+                (0..NUM_CTX).map(|_| vec![0.0f32; VOCAB * DIM]).collect();
+            let mut g_proj = vec![0.0f32; hidden * DIM];
+            let mut g_head = vec![0.0f32; VOCAB * hidden];
+            let mut g_attn_down = vec![0.0f32; d * hidden];
+            let mut g_attn_up = vec![0.0f32; hidden * d];
 
             for _micro in 0..accum {
                 rng_s = rng_s
@@ -488,17 +497,17 @@ fn main() {
                     positions.push(p);
                 }
 
-            compute_grads_for_positions(
-                &model,
-                chunk,
-                &positions,
-                &mut g_embed,
-                &mut g_ctx,
-                &mut g_proj,
-                &mut g_head,
-                &mut g_attn_down,
-                &mut g_attn_up,
-            );
+                compute_grads_for_positions(
+                    &model,
+                    chunk,
+                    &positions,
+                    &mut g_embed,
+                    &mut g_ctx,
+                    &mut g_proj,
+                    &mut g_head,
+                    &mut g_attn_down,
+                    &mut g_attn_up,
+                );
             }
 
             let total_positions = (accum * 8) as f32;
@@ -513,24 +522,24 @@ fn main() {
             for x in g_proj.iter_mut() {
                 *x /= total_positions;
             }
-        for x in g_head.iter_mut() {
-            *x /= total_positions;
-        }
-        for x in g_attn_down.iter_mut() {
-            *x /= total_positions;
-        }
-        for x in g_attn_up.iter_mut() {
-            *x /= total_positions;
-        }
+            for x in g_head.iter_mut() {
+                *x /= total_positions;
+            }
+            for x in g_attn_down.iter_mut() {
+                *x /= total_positions;
+            }
+            for x in g_attn_up.iter_mut() {
+                *x /= total_positions;
+            }
 
             opt_embed.update(&mut model.embed, &g_embed, lr);
             for (ci, oc) in opt_ctx.iter_mut().enumerate() {
                 oc.update(&mut model.ctx[ci], &g_ctx[ci], lr);
             }
-        opt_proj.update(&mut model.proj, &g_proj, lr);
-        opt_attn_down.update(&mut model.attn_down, &g_attn_down, lr);
-        opt_attn_up.update(&mut model.attn_up, &g_attn_up, lr);
-        opt_head.update(&mut model.lm_head, &g_head, lr);
+            opt_proj.update(&mut model.proj, &g_proj, lr);
+            opt_attn_down.update(&mut model.attn_down, &g_attn_down, lr);
+            opt_attn_up.update(&mut model.attn_up, &g_attn_up, lr);
+            opt_head.update(&mut model.lm_head, &g_head, lr);
 
             if step >= gf16_floor_step && step % eval_every == 0 {
                 gf16_floor(&mut model.embed);
@@ -577,7 +586,10 @@ mod tests {
     fn gf16_floor_step_at_70pct() {
         let steps = 81000;
         let floor_step = (GF16_FLOOR_FRAC * steps as f32).floor() as usize;
-        assert_eq!(floor_step, 56700, "GF16 floor activates at 56700 for 81K steps");
+        assert_eq!(
+            floor_step, 56700,
+            "GF16 floor activates at 56700 for 81K steps"
+        );
     }
 
     #[test]

--- a/src/bin/igla_train.rs
+++ b/src/bin/igla_train.rs
@@ -38,27 +38,38 @@ impl EmbeddingModel {
     fn new(vocab: usize, dim: usize, seed: u64) -> Self {
         let mut s = seed;
         let mut rng = || {
-            s = s.wrapping_mul(6364136223846793005).wrapping_add(1442695040888963407);
+            s = s
+                .wrapping_mul(6364136223846793005)
+                .wrapping_add(1442695040888963407);
             let t = ((s >> 33) as f32) / (u32::MAX as f32);
             t * 0.04 - 0.02
         };
         let embed: Vec<f32> = (0..vocab * dim).map(|_| rng()).collect();
         let lm_head: Vec<f32> = (0..vocab * dim).map(|_| rng()).collect();
-        Self { embed, lm_head, vocab, dim }
+        Self {
+            embed,
+            lm_head,
+            vocab,
+            dim,
+        }
     }
 
     fn forward(&self, input_id: usize) -> Vec<f32> {
         let id = input_id.min(self.vocab - 1);
         let d = self.dim;
         let x = &self.embed[id * d..(id + 1) * d];
-        (0..self.vocab).map(|v| {
-            let w = &self.lm_head[v * d..(v + 1) * d];
-            x.iter().zip(w.iter()).map(|(a, b)| a * b).sum::<f32>()
-        }).collect()
+        (0..self.vocab)
+            .map(|v| {
+                let w = &self.lm_head[v * d..(v + 1) * d];
+                x.iter().zip(w.iter()).map(|(a, b)| a * b).sum::<f32>()
+            })
+            .collect()
     }
 
     fn loss_on_seq(&self, tokens: &[usize]) -> f32 {
-        if tokens.len() < 2 { return 0.0; }
+        if tokens.len() < 2 {
+            return 0.0;
+        }
         let mut total = 0.0f32;
         for i in 0..tokens.len() - 1 {
             let logits = self.forward(tokens[i]);
@@ -72,7 +83,9 @@ impl EmbeddingModel {
     }
 
     fn train_step(&mut self, tokens: &[usize], lr: f32) {
-        if tokens.len() < 2 { return; }
+        if tokens.len() < 2 {
+            return;
+        }
         let d = self.dim;
         let v = self.vocab;
 
@@ -104,7 +117,9 @@ fn evaluate(model: &EmbeddingModel, tokens: &[usize], seq_len: usize) -> (f32, f
     let mut n = 0usize;
     for c in (0..tokens.len()).step_by(seq_len + 1) {
         let end = (c + seq_len + 1).min(tokens.len());
-        if end - c < 3 { continue; }
+        if end - c < 3 {
+            continue;
+        }
         let seq = &tokens[c..end];
         let loss = model.loss_on_seq(seq);
         if loss.is_finite() {
@@ -112,7 +127,9 @@ fn evaluate(model: &EmbeddingModel, tokens: &[usize], seq_len: usize) -> (f32, f
             n += 1;
         }
     }
-    if n == 0 { return (f32::MAX, f32::MAX); }
+    if n == 0 {
+        return (f32::MAX, f32::MAX);
+    }
     let bpb = total / n as f32;
     (bpb * LN_2, bpb)
 }
@@ -132,7 +149,10 @@ fn main() {
         .unwrap_or(0.1);
 
     println!("=== IGLA-STACK-502 Embedding Training ===");
-    println!("vocab={} dim={} seq={} steps={} seed={} lr={}", VOCAB, DIM, SEQ, steps, seed, lr);
+    println!(
+        "vocab={} dim={} seq={} steps={} seed={} lr={}",
+        VOCAB, DIM, SEQ, steps, seed, lr
+    );
     println!();
 
     let tokens = load_data("data/tinyshakespeare.txt");
@@ -143,7 +163,10 @@ fn main() {
     let (init_loss, init_bpb) = evaluate(&model, &tokens, SEQ);
     println!("Initial: loss={:.4} bpb={:.4}", init_loss, init_bpb);
     println!();
-    println!("{:>6} | {:>10} | {:>10} | {:>10} | {:>8}", "step", "loss", "bpb", "best_bpb", "ms");
+    println!(
+        "{:>6} | {:>10} | {:>10} | {:>10} | {:>8}",
+        "step", "loss", "bpb", "best_bpb", "ms"
+    );
     println!("{}", "-".repeat(60));
 
     let t0 = Instant::now();
@@ -162,8 +185,10 @@ fn main() {
             if eval_bpb < best_bpb && eval_bpb.is_finite() {
                 best_bpb = eval_bpb;
             }
-            println!("{:>6} | {:>10.4} | {:>10.4} | {:>10.4} | {:>6}ms",
-                step, eval_loss, eval_bpb, best_bpb, ms);
+            println!(
+                "{:>6} | {:>10.4} | {:>10.4} | {:>10.4} | {:>6}ms",
+                step, eval_loss, eval_bpb, best_bpb, ms
+            );
             results.push((step, eval_loss, eval_bpb));
         }
     }
@@ -171,8 +196,13 @@ fn main() {
     let total = t0.elapsed();
     println!();
     println!("=== Training Complete ===");
-    println!("Time: {:.1}s | Initial BPB: {:.4} | Final BPB: {:.4} | Delta: {:.4}",
-        total.as_secs_f64(), init_bpb, best_bpb, best_bpb - init_bpb);
+    println!(
+        "Time: {:.1}s | Initial BPB: {:.4} | Final BPB: {:.4} | Delta: {:.4}",
+        total.as_secs_f64(),
+        init_bpb,
+        best_bpb,
+        best_bpb - init_bpb
+    );
 
     let _ = fs::create_dir_all(".trinity/results");
     let result_json = serde_json::json!({
@@ -194,20 +224,35 @@ fn main() {
     });
 
     let rpath = format!(".trinity/results/igla_train_seed{}.json", seed);
-    fs::File::create(&rpath).unwrap()
-        .write_all(serde_json::to_string_pretty(&result_json).unwrap().as_bytes()).unwrap();
+    fs::File::create(&rpath)
+        .unwrap()
+        .write_all(
+            serde_json::to_string_pretty(&result_json)
+                .unwrap()
+                .as_bytes(),
+        )
+        .unwrap();
     println!("Results: {}", rpath);
 
     let ts = chrono::Utc::now().format("%Y-%m-%dT%H:%M:%SZ");
     let edir = ".trinity/experience";
     let _ = fs::create_dir_all(edir);
-    let epath = format!("{}/trios_{}.trinity", edir, chrono::Utc::now().format("%Y%m%d"));
-    let entry = format!(
+    let epath = format!(
+        "{}/trios_{}.trinity",
+        edir,
+        chrono::Utc::now().format("%Y%m%d")
+    );
+    let entry =
+        format!(
         "[{}] TASK: IGLA training | seed={} | steps={} | bpb={:.4}->{:.4} | delta={:.4} | {:.1}s\n",
         ts, seed, steps, init_bpb, best_bpb, best_bpb - init_bpb, total.as_secs_f64()
     );
-    let _ = fs::OpenOptions::new().create(true).append(true)
-        .open(&epath).unwrap().write_all(entry.as_bytes());
+    let _ = fs::OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(&epath)
+        .unwrap()
+        .write_all(entry.as_bytes());
     println!("Experience: {}", epath);
 
     // L-R8: stdout must end with BPB=X.XXXX for ASHA worker parsing

--- a/src/bin/igla_trigram.rs
+++ b/src/bin/igla_trigram.rs
@@ -77,14 +77,22 @@ impl TrigramModel {
     fn new(vocab: usize, dim: usize, seed: u64) -> Self {
         let mut s = seed;
         let mut rng = || {
-            s = s.wrapping_mul(6364136223846793005).wrapping_add(1442695040888963407);
+            s = s
+                .wrapping_mul(6364136223846793005)
+                .wrapping_add(1442695040888963407);
             let t = ((s >> 33) as f32) / (u32::MAX as f32);
             (t * 2.0 - 1.0) * (6.0 / (vocab + dim) as f32).sqrt()
         };
         let embed: Vec<f32> = (0..vocab * dim).map(|_| rng()).collect();
         let context: Vec<f32> = (0..vocab * dim).map(|_| rng()).collect();
         let lm_head: Vec<f32> = (0..vocab * dim).map(|_| rng()).collect();
-        Self { embed, context, lm_head, vocab, dim }
+        Self {
+            embed,
+            context,
+            lm_head,
+            vocab,
+            dim,
+        }
     }
 
     fn forward_pair(&self, id_prev: usize, id_cur: usize) -> Vec<f32> {
@@ -94,15 +102,27 @@ impl TrigramModel {
         let cur = id_cur.min(v - 1);
         let e_prev = &self.context[prev * d..(prev + 1) * d];
         let e_cur = &self.embed[cur * d..(cur + 1) * d];
-        let combined: Vec<f32> = e_prev.iter().zip(e_cur.iter()).map(|(a, b)| a + b).collect();
-        (0..v).map(|vi| {
-            let w = &self.lm_head[vi * d..(vi + 1) * d];
-            combined.iter().zip(w.iter()).map(|(a, b)| a * b).sum::<f32>()
-        }).collect()
+        let combined: Vec<f32> = e_prev
+            .iter()
+            .zip(e_cur.iter())
+            .map(|(a, b)| a + b)
+            .collect();
+        (0..v)
+            .map(|vi| {
+                let w = &self.lm_head[vi * d..(vi + 1) * d];
+                combined
+                    .iter()
+                    .zip(w.iter())
+                    .map(|(a, b)| a * b)
+                    .sum::<f32>()
+            })
+            .collect()
     }
 
     fn loss_on_seq(&self, tokens: &[usize]) -> f32 {
-        if tokens.len() < 3 { return 0.0; }
+        if tokens.len() < 3 {
+            return 0.0;
+        }
         let mut total = 0.0f32;
         for i in 1..tokens.len() - 1 {
             let logits = self.forward_pair(tokens[i - 1], tokens[i]);
@@ -115,8 +135,17 @@ impl TrigramModel {
         total / (tokens.len() - 2) as f32
     }
 
-    fn train_step(&mut self, tokens: &[usize], lr: f32, opt_e: &mut AdamWState, opt_c: &mut AdamWState, opt_h: &mut AdamWState) {
-        if tokens.len() < 3 { return; }
+    fn train_step(
+        &mut self,
+        tokens: &[usize],
+        lr: f32,
+        opt_e: &mut AdamWState,
+        opt_c: &mut AdamWState,
+        opt_h: &mut AdamWState,
+    ) {
+        if tokens.len() < 3 {
+            return;
+        }
         let d = self.dim;
         let v = self.vocab;
 
@@ -148,9 +177,15 @@ impl TrigramModel {
         }
 
         let n = (tokens.len() - 2) as f32;
-        for g in grad_embed.iter_mut() { *g /= n; }
-        for g in grad_context.iter_mut() { *g /= n; }
-        for g in grad_head.iter_mut() { *g /= n; }
+        for g in grad_embed.iter_mut() {
+            *g /= n;
+        }
+        for g in grad_context.iter_mut() {
+            *g /= n;
+        }
+        for g in grad_head.iter_mut() {
+            *g /= n;
+        }
 
         opt_e.update(&mut self.embed, &grad_embed, lr);
         opt_c.update(&mut self.context, &grad_context, lr);
@@ -163,7 +198,9 @@ fn evaluate(model: &TrigramModel, tokens: &[usize], seq_len: usize) -> (f32, f32
     let mut n = 0usize;
     for c in (0..tokens.len()).step_by(seq_len + 1) {
         let end = (c + seq_len + 1).min(tokens.len());
-        if end - c < 4 { continue; }
+        if end - c < 4 {
+            continue;
+        }
         let seq = &tokens[c..end];
         let loss = model.loss_on_seq(seq);
         if loss.is_finite() {
@@ -171,7 +208,9 @@ fn evaluate(model: &TrigramModel, tokens: &[usize], seq_len: usize) -> (f32, f32
             n += 1;
         }
     }
-    if n == 0 { return (f32::MAX, f32::MAX); }
+    if n == 0 {
+        return (f32::MAX, f32::MAX);
+    }
     let bpb = total / n as f32;
     (bpb * LN_2, bpb)
 }
@@ -201,7 +240,10 @@ fn main() {
         .unwrap_or(0.003);
 
     println!("=== IGLA-STACK-502 Trigram Training ===");
-    println!("vocab={} dim={} seq={} steps={} seed={} lr={}", VOCAB, DIM, SEQ, steps, seed, base_lr);
+    println!(
+        "vocab={} dim={} seq={} steps={} seed={} lr={}",
+        VOCAB, DIM, SEQ, steps, seed, base_lr
+    );
     println!();
 
     let tokens = load_data("data/tinyshakespeare.txt");
@@ -216,7 +258,10 @@ fn main() {
     let (init_loss, init_bpb) = evaluate(&model, &tokens, SEQ);
     println!("Initial: loss={:.4} bpb={:.4}", init_loss, init_bpb);
     println!();
-    println!("{:>6} | {:>10} | {:>10} | {:>10} | {:>8} | {:>6}", "step", "loss", "bpb", "best_bpb", "ms", "lr");
+    println!(
+        "{:>6} | {:>10} | {:>10} | {:>10} | {:>8} | {:>6}",
+        "step", "loss", "bpb", "best_bpb", "ms", "lr"
+    );
     println!("{}", "-".repeat(70));
 
     let t0 = Instant::now();
@@ -236,8 +281,10 @@ fn main() {
             if eval_bpb < best_bpb && eval_bpb.is_finite() {
                 best_bpb = eval_bpb;
             }
-            println!("{:>6} | {:>10.4} | {:>10.4} | {:>10.4} | {:>6}ms | {:.6}",
-                step, eval_loss, eval_bpb, best_bpb, ms, lr);
+            println!(
+                "{:>6} | {:>10.4} | {:>10.4} | {:>10.4} | {:>6}ms | {:.6}",
+                step, eval_loss, eval_bpb, best_bpb, ms, lr
+            );
             results.push((step, eval_loss, eval_bpb));
         }
     }
@@ -245,8 +292,13 @@ fn main() {
     let total = t0.elapsed();
     println!();
     println!("=== Training Complete ===");
-    println!("Time: {:.1}s | Initial BPB: {:.4} | Final BPB: {:.4} | Delta: {:.4}",
-        total.as_secs_f64(), init_bpb, best_bpb, best_bpb - init_bpb);
+    println!(
+        "Time: {:.1}s | Initial BPB: {:.4} | Final BPB: {:.4} | Delta: {:.4}",
+        total.as_secs_f64(),
+        init_bpb,
+        best_bpb,
+        best_bpb - init_bpb
+    );
 
     let _ = fs::create_dir_all(".trinity/results");
     let result_json = serde_json::json!({
@@ -269,19 +321,33 @@ fn main() {
     });
 
     let rpath = format!(".trinity/results/igla_trigram_seed{}.json", seed);
-    fs::File::create(&rpath).unwrap()
-        .write_all(serde_json::to_string_pretty(&result_json).unwrap().as_bytes()).unwrap();
+    fs::File::create(&rpath)
+        .unwrap()
+        .write_all(
+            serde_json::to_string_pretty(&result_json)
+                .unwrap()
+                .as_bytes(),
+        )
+        .unwrap();
     println!("Results: {}", rpath);
 
     let ts = chrono::Utc::now().format("%Y-%m-%dT%H:%M:%SZ");
     let edir = ".trinity/experience";
     let _ = fs::create_dir_all(edir);
-    let epath = format!("{}/trios_{}.trinity", edir, chrono::Utc::now().format("%Y%m%d"));
+    let epath = format!(
+        "{}/trios_{}.trinity",
+        edir,
+        chrono::Utc::now().format("%Y%m%d")
+    );
     let entry = format!(
         "[{}] TASK: IGLA trigram training | seed={} | steps={} | bpb={:.4}->{:.4} | delta={:.4} | {:.1}s\n",
         ts, seed, steps, init_bpb, best_bpb, best_bpb - init_bpb, total.as_secs_f64()
     );
-    let _ = fs::OpenOptions::new().create(true).append(true)
-        .open(&epath).unwrap().write_all(entry.as_bytes());
+    let _ = fs::OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(&epath)
+        .unwrap()
+        .write_all(entry.as_bytes());
     println!("Experience: {}", epath);
 }

--- a/src/bin/ledger_check.rs
+++ b/src/bin/ledger_check.rs
@@ -66,12 +66,12 @@ use std::process::ExitCode;
 use clap::Parser;
 use serde_json::Value;
 
+use trios_trainer::invariants::{IGLA_TARGET_BPB, VICTORY_SEED_TARGET};
 use trios_trainer::race::victory::{
-    check_victory, stat_strength, SeedResult, TtestReport, VictoryError,
-    VictoryReport, JEPA_PROXY_BPB_FLOOR,
+    check_victory, stat_strength, SeedResult, TtestReport, VictoryError, VictoryReport,
+    JEPA_PROXY_BPB_FLOOR,
 };
 use trios_trainer::race::victory::{TTEST_ALPHA, TTEST_BASELINE_MU0, TTEST_EFFECT_SIZE_MIN};
-use trios_trainer::invariants::{IGLA_TARGET_BPB, VICTORY_SEED_TARGET};
 
 /// CLI for adjudicating the IGLA RACE victory predicate against a
 /// JSONL seed-results ledger.
@@ -194,13 +194,13 @@ fn row_to_seed_result(v: &Value, line_no: usize) -> Result<SeedResult, LedgerErr
         reason: "row is not a JSON object".into(),
     })?;
 
-    let seed = obj
-        .get("seed")
-        .and_then(Value::as_u64)
-        .ok_or_else(|| LedgerError::MalformedRow {
-            line_no,
-            reason: "missing or non-u64 `seed`".into(),
-        })?;
+    let seed =
+        obj.get("seed")
+            .and_then(Value::as_u64)
+            .ok_or_else(|| LedgerError::MalformedRow {
+                line_no,
+                reason: "missing or non-u64 `seed`".into(),
+            })?;
     let bpb = obj
         .get("bpb")
         .and_then(Value::as_f64)
@@ -208,13 +208,13 @@ fn row_to_seed_result(v: &Value, line_no: usize) -> Result<SeedResult, LedgerErr
             line_no,
             reason: "missing or non-f64 `bpb`".into(),
         })?;
-    let step = obj
-        .get("step")
-        .and_then(Value::as_u64)
-        .ok_or_else(|| LedgerError::MalformedRow {
-            line_no,
-            reason: "missing or non-u64 `step`".into(),
-        })?;
+    let step =
+        obj.get("step")
+            .and_then(Value::as_u64)
+            .ok_or_else(|| LedgerError::MalformedRow {
+                line_no,
+                reason: "missing or non-u64 `step`".into(),
+            })?;
     let sha = obj
         .get("sha")
         .and_then(Value::as_str)
@@ -242,11 +242,10 @@ pub fn parse_ledger(text: &str) -> Result<Vec<SeedResult>, LedgerError> {
         if line.is_empty() {
             continue;
         }
-        let value: Value =
-            serde_json::from_str(line).map_err(|e| LedgerError::MalformedRow {
-                line_no,
-                reason: format!("invalid JSON: {}", e),
-            })?;
+        let value: Value = serde_json::from_str(line).map_err(|e| LedgerError::MalformedRow {
+            line_no,
+            reason: format!("invalid JSON: {}", e),
+        })?;
         if is_header_row(&value) {
             continue;
         }
@@ -311,7 +310,11 @@ fn render_human(verdict: &LedgerVerdict, rows: &[SeedResult], verbose: bool) -> 
             let _ = writeln!(s, "   winning_seeds     : {:?}", report.winning_seeds);
             let _ = writeln!(s, "   min_bpb           : {:.6}", report.min_bpb);
             let _ = writeln!(s, "   mean_bpb          : {:.6}", report.mean_bpb);
-            let _ = writeln!(s, "   t_stat / -t_crit  : {:.4} < -{:.4}", ttest.t_statistic, ttest.df);
+            let _ = writeln!(
+                s,
+                "   t_stat / -t_crit  : {:.4} < -{:.4}",
+                ttest.t_statistic, ttest.df
+            );
         }
         LedgerVerdict::GateOkStatWeak { report, ttest } => {
             let _ = writeln!(s, " VERDICT             : NECESSARY-OK / STAT-WEAK");
@@ -465,7 +468,8 @@ mod tests {
     /// `assertions/seed_results.jsonl` on main.
     #[test]
     fn empty_ledger_yields_empty_verdict() {
-        let header = r#"{"_schema":"trios.assertions.seed_results.v1","_target":1.5,"_warmup":4000}"#;
+        let header =
+            r#"{"_schema":"trios.assertions.seed_results.v1","_target":1.5,"_warmup":4000}"#;
         let v = evaluate_ledger(header).unwrap();
         assert_eq!(v, LedgerVerdict::Empty);
         assert_eq!(v.exit_code(), 5);
@@ -490,11 +494,7 @@ mod tests {
         ]
         .join("\n");
         let v = evaluate_ledger(&rows).unwrap();
-        assert!(
-            v.is_victory(),
-            "expected Victory, got {:?}",
-            v
-        );
+        assert!(v.is_victory(), "expected Victory, got {:?}", v);
         assert_eq!(v.exit_code(), 0);
     }
 
@@ -516,7 +516,10 @@ mod tests {
                 assert!(ttest.t_statistic < 0.0);
                 assert!(report.mean_bpb < TTEST_BASELINE_MU0);
             }
-            other => panic!("expected Victory (zero variance with mean < target passes), got {:?}", other),
+            other => panic!(
+                "expected Victory (zero variance with mean < target passes), got {:?}",
+                other
+            ),
         }
     }
 
@@ -685,10 +688,9 @@ mod tests {
     /// rejects an ordinary row.
     #[test]
     fn header_detection_round_trip() {
-        let header: Value = serde_json::from_str(
-            r#"{"_schema":"trios.assertions.seed_results.v1","_target":1.5}"#,
-        )
-        .unwrap();
+        let header: Value =
+            serde_json::from_str(r#"{"_schema":"trios.assertions.seed_results.v1","_target":1.5}"#)
+                .unwrap();
         let row: Value =
             serde_json::from_str(r#"{"seed":1,"bpb":1.4,"step":5000,"sha":"a"}"#).unwrap();
         assert!(is_header_row(&header));

--- a/src/bin/lstm_train.rs
+++ b/src/bin/lstm_train.rs
@@ -11,14 +11,24 @@ const EVAL_INTERVAL: usize = 500;
 const EVAL_SEQS: usize = 20;
 
 fn sigmoid(x: f32) -> f32 {
-    if x >= 0.0 { 1.0 / (1.0 + (-x).exp()) } else { let e = x.exp(); e / (1.0 + e) }
+    if x >= 0.0 {
+        1.0 / (1.0 + (-x).exp())
+    } else {
+        let e = x.exp();
+        e / (1.0 + e)
+    }
 }
 
 fn softmax(v: &mut [f32]) {
     let max = v.iter().cloned().fold(f32::NEG_INFINITY, f32::max);
     let mut sum = 0.0f32;
-    for x in v.iter_mut() { *x = (*x - max).exp(); sum += *x; }
-    for x in v.iter_mut() { *x /= sum; }
+    for x in v.iter_mut() {
+        *x = (*x - max).exp();
+        sum += *x;
+    }
+    for x in v.iter_mut() {
+        *x /= sum;
+    }
 }
 
 struct LstmTrain {
@@ -54,7 +64,13 @@ struct AdamW {
 }
 
 impl AdamW {
-    fn new(size: usize) -> Self { Self { m: vec![0.0; size], v: vec![0.0; size], step: 0 } }
+    fn new(size: usize) -> Self {
+        Self {
+            m: vec![0.0; size],
+            v: vec![0.0; size],
+            step: 0,
+        }
+    }
     fn update(&mut self, p: &mut [f32], g: &[f32], lr: f32, wd: f32) {
         self.step += 1;
         let bc1 = 1.0 - 0.9f32.powi(self.step as i32);
@@ -72,7 +88,9 @@ impl LstmTrain {
     fn new(hidden: usize, seed: u64) -> Self {
         let mut s = seed;
         let mut rng = || {
-            s = s.wrapping_mul(6364136223846793005).wrapping_add(1442695040888963407);
+            s = s
+                .wrapping_mul(6364136223846793005)
+                .wrapping_add(1442695040888963407);
             ((s >> 33) as f32) / (u32::MAX as f32) * 2.0 - 1.0
         };
         let d = DIM + hidden;
@@ -81,10 +99,14 @@ impl LstmTrain {
         let lim_w = (6.0 / (d + g4) as f32).sqrt();
         let lim_o = (6.0 / (hidden + VOCAB) as f32).sqrt();
         let mut b = vec![0.0f32; g4];
-        for i in 0..hidden { b[hidden + i] = 2.0; }
+        for i in 0..hidden {
+            b[hidden + i] = 2.0;
+        }
         let cap = SEQ + 1;
         Self {
-            h: hidden, d, g4,
+            h: hidden,
+            d,
+            g4,
             embed: (0..VOCAB * DIM).map(|_| rng() * lim_e).collect(),
             w: (0..g4 * d).map(|_| rng() * lim_w).collect(),
             b,
@@ -105,25 +127,39 @@ impl LstmTrain {
         let h = self.h;
         let d = self.d;
         let g4 = self.g4;
-        for v in 0..h { self.h_state[v] = 0.0; self.c_state[v] = 0.0; }
+        for v in 0..h {
+            self.h_state[v] = 0.0;
+            self.c_state[v] = 0.0;
+        }
 
         let mut total_loss = 0.0f32;
         for t in 0..tokens.len() {
             let tok = tokens[t].min(VOCAB - 1);
             let ex = &self.embed[tok * DIM..(tok + 1) * DIM];
             let mut xh = vec![0.0f32; d];
-            for j in 0..DIM { xh[j] = ex[j]; }
-            for j in 0..h { xh[DIM + j] = self.h_state[j]; }
+            for j in 0..DIM {
+                xh[j] = ex[j];
+            }
+            for j in 0..h {
+                xh[DIM + j] = self.h_state[j];
+            }
 
             let mut gates = vec![0.0f32; g4];
             for i in 0..g4 {
                 let mut val = self.b[i];
-                for j in 0..d { val += self.w[i * d + j] * xh[j]; }
+                for j in 0..d {
+                    val += self.w[i * d + j] * xh[j];
+                }
                 let pre = val;
-                if i < h { gates[i] = sigmoid(pre); }
-                else if i < 2 * h { gates[i] = sigmoid(pre); }
-                else if i < 3 * h { gates[i] = sigmoid(pre); }
-                else { gates[i] = pre.tanh(); }
+                if i < h {
+                    gates[i] = sigmoid(pre);
+                } else if i < 2 * h {
+                    gates[i] = sigmoid(pre);
+                } else if i < 3 * h {
+                    gates[i] = sigmoid(pre);
+                } else {
+                    gates[i] = pre.tanh();
+                }
             }
 
             let c_prev = self.c_state.clone();
@@ -136,7 +172,9 @@ impl LstmTrain {
 
             let mut logits = vec![0.0f32; VOCAB];
             for v in 0..VOCAB {
-                for j in 0..h { logits[v] += self.head[v * h + j] * self.h_state[j]; }
+                for j in 0..h {
+                    logits[v] += self.head[v * h + j] * self.h_state[j];
+                }
             }
 
             self.s_h[t] = self.h_state.clone();
@@ -209,7 +247,9 @@ impl LstmTrain {
             let mut dxh = vec![0.0f32; d];
             for i in 0..g4 {
                 let dgi = dg[i];
-                if dgi.abs() < 1e-12 { continue; }
+                if dgi.abs() < 1e-12 {
+                    continue;
+                }
                 for j in 0..d {
                     g_w[i * d + j] += dgi * self.s_xh[t][j];
                     dxh[j] += dgi * self.w[i * d + j];
@@ -217,41 +257,76 @@ impl LstmTrain {
                 g_b[i] += dgi;
             }
 
-            for j in 0..h { dh[j] = dxh[DIM + j]; }
+            for j in 0..h {
+                dh[j] = dxh[DIM + j];
+            }
             let tok = self.s_tok[t];
-            for j in 0..DIM { g_embed[tok * DIM + j] += dxh[j]; }
+            for j in 0..DIM {
+                g_embed[tok * DIM + j] += dxh[j];
+            }
         }
 
         let inv = 1.0 / n;
-        for x in g_embed.iter_mut() { *x *= inv; }
-        for x in g_w.iter_mut() { *x *= inv; }
-        for x in g_b.iter_mut() { *x *= inv; }
-        for x in g_head.iter_mut() { *x *= inv; }
+        for x in g_embed.iter_mut() {
+            *x *= inv;
+        }
+        for x in g_w.iter_mut() {
+            *x *= inv;
+        }
+        for x in g_b.iter_mut() {
+            *x *= inv;
+        }
+        for x in g_head.iter_mut() {
+            *x *= inv;
+        }
 
         let max_norm = 1.0f32;
         let mut gn2 = 0.0f32;
-        for x in g_w.iter() { gn2 += x * x; }
-        for x in g_embed.iter() { gn2 += x * x; }
+        for x in g_w.iter() {
+            gn2 += x * x;
+        }
+        for x in g_embed.iter() {
+            gn2 += x * x;
+        }
         let gn = gn2.sqrt();
         if gn > max_norm {
             let scale = max_norm / gn;
-            for x in g_w.iter_mut() { *x *= scale; }
-            for x in g_embed.iter_mut() { *x *= scale; }
-            for x in g_b.iter_mut() { *x *= scale; }
-            for x in g_head.iter_mut() { *x *= scale; }
+            for x in g_w.iter_mut() {
+                *x *= scale;
+            }
+            for x in g_embed.iter_mut() {
+                *x *= scale;
+            }
+            for x in g_b.iter_mut() {
+                *x *= scale;
+            }
+            for x in g_head.iter_mut() {
+                *x *= scale;
+            }
         }
 
-        Grads { g_embed, g_w, g_b, g_head }
+        Grads {
+            g_embed,
+            g_w,
+            g_b,
+            g_head,
+        }
     }
 
     fn eval_bpb(&mut self, tokens: &[usize]) -> f32 {
         let dl = tokens.len();
-        if dl < 2 { return f32::MAX; }
+        if dl < 2 {
+            return f32::MAX;
+        }
         let num_possible = dl.saturating_sub(SEQ + 1);
-        if num_possible == 0 { return f32::MAX; }
+        if num_possible == 0 {
+            return f32::MAX;
+        }
         let nc = EVAL_SEQS.min(num_possible);
         let stride = num_possible / nc;
-        if stride == 0 { return f32::MAX; }
+        if stride == 0 {
+            return f32::MAX;
+        }
         let h = self.h;
         let d = self.d;
         let g4 = self.g4;
@@ -261,7 +336,9 @@ impl LstmTrain {
         for c in 0..nc {
             let start = c * stride;
             let end = (start + SEQ + 1).min(dl);
-            if end <= start + 2 { continue; }
+            if end <= start + 2 {
+                continue;
+            }
             let chunk = &tokens[start..end];
             let mut h_st = vec![0.0f32; h];
             let mut c_st = vec![0.0f32; h];
@@ -270,13 +347,23 @@ impl LstmTrain {
                 let tok = chunk[t].min(VOCAB - 1);
                 let ex = &self.embed[tok * DIM..(tok + 1) * DIM];
                 let mut xh = vec![0.0f32; d];
-                for j in 0..DIM { xh[j] = ex[j]; }
-                for j in 0..h { xh[DIM + j] = h_st[j]; }
+                for j in 0..DIM {
+                    xh[j] = ex[j];
+                }
+                for j in 0..h {
+                    xh[DIM + j] = h_st[j];
+                }
                 let mut gates = vec![0.0f32; g4];
                 for i in 0..g4 {
                     let mut val = self.b[i];
-                    for j in 0..d { val += self.w[i * d + j] * xh[j]; }
-                    if i < 3 * h { gates[i] = sigmoid(val); } else { gates[i] = val.tanh(); }
+                    for j in 0..d {
+                        val += self.w[i * d + j] * xh[j];
+                    }
+                    if i < 3 * h {
+                        gates[i] = sigmoid(val);
+                    } else {
+                        gates[i] = val.tanh();
+                    }
                 }
                 let c_old = c_st.clone();
                 for i in 0..h {
@@ -285,7 +372,9 @@ impl LstmTrain {
                 }
                 let mut logits = vec![0.0f32; VOCAB];
                 for v in 0..VOCAB {
-                    for j in 0..h { logits[v] += self.head[v * h + j] * h_st[j]; }
+                    for j in 0..h {
+                        logits[v] += self.head[v * h + j] * h_st[j];
+                    }
                 }
                 softmax(&mut logits);
                 let target = chunk[t + 1].min(VOCAB - 1);
@@ -294,12 +383,18 @@ impl LstmTrain {
             total += loss / (chunk.len() - 1) as f32 / LN_2;
             n += 1;
         }
-        if n == 0 { f32::MAX } else { total / n as f32 }
+        if n == 0 {
+            f32::MAX
+        } else {
+            total / n as f32
+        }
     }
 }
 
 fn cosine_lr(step: usize, max_steps: usize, base_lr: f32, warmup: usize) -> f32 {
-    if step < warmup { return base_lr * step as f32 / warmup.max(1) as f32; }
+    if step < warmup {
+        return base_lr * step as f32 / warmup.max(1) as f32;
+    }
     let p = (step - warmup) as f32 / (max_steps - warmup).max(1) as f32;
     1e-5 + (base_lr - 1e-5) * 0.5 * (1.0 + (std::f32::consts::PI * p).cos())
 }
@@ -307,7 +402,9 @@ fn cosine_lr(step: usize, max_steps: usize, base_lr: f32, warmup: usize) -> f32 
 fn load_data(path: &str) -> Vec<usize> {
     let raw = fs::read(path).unwrap_or_else(|e| {
         eprintln!("Failed to load {}: {}. Using fallback.", path, e);
-        b"The quick brown fox jumps over the lazy dog. ".repeat(100).to_vec()
+        b"The quick brown fox jumps over the lazy dog. "
+            .repeat(100)
+            .to_vec()
     });
     assert!(!raw.is_empty(), "loaded data is empty");
     raw.into_iter().map(|b| (b as usize) % VOCAB).collect()
@@ -315,20 +412,36 @@ fn load_data(path: &str) -> Vec<usize> {
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     let args: Vec<String> = std::env::args().collect();
-    let seed: u64 = args.iter().find(|a| a.starts_with("--seed="))
-        .and_then(|a| a[7..].parse().ok()).unwrap_or(43);
-    let steps: usize = args.iter().find(|a| a.starts_with("--steps="))
-        .and_then(|a| a[8..].parse().ok()).unwrap_or(10000);
-    let lr: f32 = args.iter().find(|a| a.starts_with("--lr="))
-        .and_then(|a| a[5..].parse().ok()).unwrap_or(0.003);
-    let hidden: usize = args.iter().find(|a| a.starts_with("--hidden="))
-        .and_then(|a| a[9..].parse().ok()).unwrap_or(256);
+    let seed: u64 = args
+        .iter()
+        .find(|a| a.starts_with("--seed="))
+        .and_then(|a| a[7..].parse().ok())
+        .unwrap_or(43);
+    let steps: usize = args
+        .iter()
+        .find(|a| a.starts_with("--steps="))
+        .and_then(|a| a[8..].parse().ok())
+        .unwrap_or(10000);
+    let lr: f32 = args
+        .iter()
+        .find(|a| a.starts_with("--lr="))
+        .and_then(|a| a[5..].parse().ok())
+        .unwrap_or(0.003);
+    let hidden: usize = args
+        .iter()
+        .find(|a| a.starts_with("--hidden="))
+        .and_then(|a| a[9..].parse().ok())
+        .unwrap_or(256);
 
     let train_data = load_data("data/tiny_shakespeare.txt");
     let val_data = load_data("data/tiny_shakespeare_val.txt");
     let train_end = (train_data.len() as f64 * 0.9) as usize;
     let train = &train_data[..train_end];
-    let val = if val_data.len() > 100 { &val_data } else { &train_data[train_end..] };
+    let val = if val_data.len() > 100 {
+        &val_data
+    } else {
+        &train_data[train_end..]
+    };
 
     let mut m = LstmTrain::new(hidden, seed);
     let d = DIM + hidden;
@@ -348,7 +461,11 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     eprintln!(
         "lstm_v2: hidden={} seq={} lr={} seed={} steps={} params≈{}",
-        hidden, seq, lr, seed, steps,
+        hidden,
+        seq,
+        lr,
+        seed,
+        steps,
         VOCAB * DIM + g4 * d + g4 + VOCAB * hidden
     );
 
@@ -366,8 +483,13 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         if step % EVAL_INTERVAL == 0 || step == steps {
             let elapsed = start.elapsed().as_secs_f64();
             let val_bpb = m.eval_bpb(val);
-            if val_bpb < best_bpb && val_bpb.is_finite() { best_bpb = val_bpb; }
-            eprintln!("step={:5} val_bpb={:.4} best={:.4} t={}s", step, val_bpb, best_bpb, elapsed as u64);
+            if val_bpb < best_bpb && val_bpb.is_finite() {
+                best_bpb = val_bpb;
+            }
+            eprintln!(
+                "step={:5} val_bpb={:.4} best={:.4} t={}s",
+                step, val_bpb, best_bpb, elapsed as u64
+            );
         }
     }
 

--- a/src/bin/ngram_train.rs
+++ b/src/bin/ngram_train.rs
@@ -21,7 +21,10 @@ fn gelu(x: f32) -> f32 {
 fn activate(x: f32, name: &str) -> f32 {
     match name {
         "gelu" => gelu(x),
-        "relu2" => { let r = x.max(0.0); r * r },
+        "relu2" => {
+            let r = x.max(0.0);
+            r * r
+        }
         _ => x.max(0.0),
     }
 }
@@ -29,8 +32,17 @@ fn activate(x: f32, name: &str) -> f32 {
 fn activate_grad(x: f32, name: &str) -> f32 {
     match name {
         "gelu" => gelu(x),
-        "relu2" => { let r = x.max(0.0); 2.0 * r },
-        _ => if x > 0.0 { 1.0 } else { 0.0 },
+        "relu2" => {
+            let r = x.max(0.0);
+            2.0 * r
+        }
+        _ => {
+            if x > 0.0 {
+                1.0
+            } else {
+                0.0
+            }
+        }
     }
 }
 
@@ -45,8 +57,13 @@ fn load_data(path: &str) -> Vec<usize> {
 fn softmax(v: &mut [f32]) {
     let max = v.iter().cloned().fold(f32::NEG_INFINITY, f32::max);
     let mut sum = 0.0f32;
-    for x in v.iter_mut() { *x = (*x - max).exp(); sum += *x; }
-    for x in v.iter_mut() { *x /= sum; }
+    for x in v.iter_mut() {
+        *x = (*x - max).exp();
+        sum += *x;
+    }
+    for x in v.iter_mut() {
+        *x /= sum;
+    }
 }
 
 fn layer_norm(x: &[f32], eps: f32) -> Vec<f32> {
@@ -58,15 +75,27 @@ fn layer_norm(x: &[f32], eps: f32) -> Vec<f32> {
 }
 
 struct LocalAdamW {
-    m: Vec<f32>, v: Vec<f32>, step: usize,
-    beta1: f32, beta2: f32, eps: f32, wd: f32,
+    m: Vec<f32>,
+    v: Vec<f32>,
+    step: usize,
+    beta1: f32,
+    beta2: f32,
+    eps: f32,
+    wd: f32,
 }
 
 impl LocalAdamW {
     fn new(size: usize, wd: f32) -> Self {
         let phi = (1.0 + 5.0f64.sqrt()) / 2.0;
-        Self { m: vec![0.0; size], v: vec![0.0; size], step: 0,
-            beta1: 1.0 / phi as f32, beta2: 0.999, eps: 1e-8, wd }
+        Self {
+            m: vec![0.0; size],
+            v: vec![0.0; size],
+            step: 0,
+            beta1: 1.0 / phi as f32,
+            beta2: 0.999,
+            eps: 1e-8,
+            wd,
+        }
     }
     fn update(&mut self, params: &mut [f32], grads: &[f32], lr: f32) {
         self.step += 1;
@@ -82,15 +111,17 @@ impl LocalAdamW {
 }
 
 trait Optimizer {
-	fn update(&mut self, params: &mut [f32], grads: &[f32], lr: f32);
+    fn update(&mut self, params: &mut [f32], grads: &[f32], lr: f32);
 }
 impl Optimizer for LocalAdamW {
-	fn update(&mut self, params: &mut [f32], grads: &[f32], lr: f32) { LocalAdamW::update(self, params, grads, lr) }
+    fn update(&mut self, params: &mut [f32], grads: &[f32], lr: f32) {
+        LocalAdamW::update(self, params, grads, lr)
+    }
 }
 impl Optimizer for MuonOptimizer {
-	fn update(&mut self, params: &mut [f32], grads: &[f32], lr: f32) {
-		self.step(params, &grads.iter().map(|&g| g * lr).collect::<Vec<_>>());
-	}
+    fn update(&mut self, params: &mut [f32], grads: &[f32], lr: f32) {
+        self.step(params, &grads.iter().map(|&g| g * lr).collect::<Vec<_>>());
+    }
 }
 
 struct NgramModel {
@@ -111,19 +142,29 @@ struct NgramModel {
 }
 
 impl NgramModel {
-    fn new(vocab: usize, dim: usize, hidden: usize, activation: String, seed: u64, num_ctx: usize, use_attention: bool) -> Self {
+    fn new(
+        vocab: usize,
+        dim: usize,
+        hidden: usize,
+        activation: String,
+        seed: u64,
+        num_ctx: usize,
+        use_attention: bool,
+    ) -> Self {
         let mut s = seed;
         let mut rng = || {
-            s = s.wrapping_mul(6364136223846793005).wrapping_add(1442695040888963407);
+            s = s
+                .wrapping_mul(6364136223846793005)
+                .wrapping_add(1442695040888963407);
             ((s >> 33) as f32) / (u32::MAX as f32) * 2.0 - 1.0
         };
         let lim = (6.0f32 / (3 * dim) as f32).sqrt();
         let lim_h = (6.0f32 / (dim + hidden) as f32).sqrt();
         let lim_o = (6.0f32 / (hidden + dim) as f32).sqrt();
 
-        let ctx = (0..num_ctx).map(|_| {
-            (0..vocab * dim).map(|_| rng() * lim).collect()
-        }).collect();
+        let ctx = (0..num_ctx)
+            .map(|_| (0..vocab * dim).map(|_| rng() * lim).collect())
+            .collect();
 
         let base_weights: Vec<f32> = vec![0.7, 0.3, 0.2, 0.15, 0.12, 0.1, 0.08, 0.06];
         let ctx_weights: Vec<f32> = base_weights.iter().take(num_ctx).cloned().collect();
@@ -136,10 +177,27 @@ impl NgramModel {
             ctx_weights,
             proj: (0..hidden * dim).map(|_| rng() * lim_h).collect(),
             lm_head: (0..vocab * hidden).map(|_| rng() * lim_o).collect(),
-            attn_query: if use_attention { (0..attn_dim).map(|_| rng() * 0.1).collect() } else { vec![] },
-            attn_key: if use_attention { (0..hidden * attn_dim).map(|_| rng() * 0.1).collect() } else { vec![] },
-            attn_value: if use_attention { (0..hidden * attn_dim).map(|_| rng() * 0.1).collect() } else { vec![] },
-            vocab, dim, hidden, activation, use_attention, attn_dim,
+            attn_query: if use_attention {
+                (0..attn_dim).map(|_| rng() * 0.1).collect()
+            } else {
+                vec![]
+            },
+            attn_key: if use_attention {
+                (0..hidden * attn_dim).map(|_| rng() * 0.1).collect()
+            } else {
+                vec![]
+            },
+            attn_value: if use_attention {
+                (0..hidden * attn_dim).map(|_| rng() * 0.1).collect()
+            } else {
+                vec![]
+            },
+            vocab,
+            dim,
+            hidden,
+            activation,
+            use_attention,
+            attn_dim,
         }
     }
 
@@ -154,10 +212,14 @@ impl NgramModel {
 
         for (ci, cw) in self.ctx_weights.iter().enumerate() {
             let ctx_idx = tokens_context.len() - 2 - ci;
-            if ctx_idx == 0 && ci > 0 { break; }
+            if ctx_idx == 0 && ci > 0 {
+                break;
+            }
             let t = tokens_context[ctx_idx].min(v - 1);
             let cv = &self.ctx[ci][t * d..(t + 1) * d];
-            for j in 0..d { combined[j] += cv[j] * cw; }
+            for j in 0..d {
+                combined[j] += cv[j] * cw;
+            }
         }
 
         let ln = layer_norm(&combined, 1e-5);
@@ -165,7 +227,9 @@ impl NgramModel {
         let mut hidden = vec![0.0f32; h];
         for hi in 0..h {
             let w = &self.proj[hi * d..(hi + 1) * d];
-            for (j, l) in ln.iter().enumerate() { hidden[hi] += w[j] * l; }
+            for (j, l) in ln.iter().enumerate() {
+                hidden[hi] += w[j] * l;
+            }
             hidden[hi] = activate(hidden[hi], &self.activation);
         }
         hidden
@@ -224,14 +288,18 @@ impl NgramModel {
         let mut logits = vec![0.0f32; v];
         for (vi, logit) in logits.iter_mut().enumerate() {
             let w = &self.lm_head[vi * h..(vi + 1) * h];
-            for (hi, hn) in final_hidden.iter().enumerate() { *logit += w[hi] * hn; }
+            for (hi, hn) in final_hidden.iter().enumerate() {
+                *logit += w[hi] * hn;
+            }
         }
         logits
     }
 
     fn loss_on_seq(&self, tokens: &[usize]) -> f32 {
         let ngram = self.ctx.len() + 2;
-        if tokens.len() < ngram + 1 { return 0.0; }
+        if tokens.len() < ngram + 1 {
+            return 0.0;
+        }
         let v = self.vocab;
         let h = self.hidden;
         let count = tokens.len() - ngram;
@@ -261,7 +329,9 @@ impl NgramModel {
                 let mut logits = vec![0.0f32; v];
                 for (vi, logit) in logits.iter_mut().enumerate() {
                     let w = &self.lm_head[vi * h..(vi + 1) * h];
-                    for (hi, hn) in hidden.iter().enumerate() { *logit += w[hi] * hn; }
+                    for (hi, hn) in hidden.iter().enumerate() {
+                        *logit += w[hi] * hn;
+                    }
                 }
                 softmax(&mut logits);
                 total -= logits[target].max(1e-10).ln();
@@ -271,11 +341,22 @@ impl NgramModel {
     }
 
     #[allow(clippy::needless_range_loop)]
-    fn train_step(&mut self, tokens: &[usize], lr: f32,
-        opt_embed: &mut dyn Optimizer, opt_ctx: &mut [Box<dyn Optimizer>], opt_proj: &mut dyn Optimizer, opt_head: &mut dyn Optimizer,
-        opt_aq: &mut dyn Optimizer, opt_ak: &mut dyn Optimizer, opt_av: &mut dyn Optimizer) {
+    fn train_step(
+        &mut self,
+        tokens: &[usize],
+        lr: f32,
+        opt_embed: &mut dyn Optimizer,
+        opt_ctx: &mut [Box<dyn Optimizer>],
+        opt_proj: &mut dyn Optimizer,
+        opt_head: &mut dyn Optimizer,
+        opt_aq: &mut dyn Optimizer,
+        opt_ak: &mut dyn Optimizer,
+        opt_av: &mut dyn Optimizer,
+    ) {
         let ngram = self.ctx.len() + 2;
-        if tokens.len() < ngram + 1 { return; }
+        if tokens.len() < ngram + 1 {
+            return;
+        }
         let v = self.vocab;
         let d = self.dim;
         let h = self.hidden;
@@ -287,9 +368,21 @@ impl NgramModel {
         let mut g_ctx: Vec<Vec<f32>> = (0..num_ctx).map(|_| vec![0.0f32; v * d]).collect();
         let mut g_proj = vec![0.0f32; h * d];
         let mut g_head = vec![0.0f32; v * h];
-        let mut g_aq = if self.use_attention { vec![0.0f32; ad] } else { vec![] };
-        let mut g_ak = if self.use_attention { vec![0.0f32; ad * h] } else { vec![] };
-        let mut g_av = if self.use_attention { vec![0.0f32; ad * h] } else { vec![] };
+        let mut g_aq = if self.use_attention {
+            vec![0.0f32; ad]
+        } else {
+            vec![]
+        };
+        let mut g_ak = if self.use_attention {
+            vec![0.0f32; ad * h]
+        } else {
+            vec![]
+        };
+        let mut g_av = if self.use_attention {
+            vec![0.0f32; ad * h]
+        } else {
+            vec![]
+        };
 
         let mut all_hidden: Vec<Vec<f32>> = Vec::with_capacity(count);
         let mut all_ln: Vec<Vec<f32>> = Vec::with_capacity(count);
@@ -305,14 +398,18 @@ impl NgramModel {
                 let ctx_idx = ngram - 2 - ci;
                 let t = context[ctx_idx].min(v - 1);
                 let cv = &self.ctx[ci][t * d..(t + 1) * d];
-                for j in 0..d { combined[j] += cv[j] * cw; }
+                for j in 0..d {
+                    combined[j] += cv[j] * cw;
+                }
             }
             let ln = layer_norm(&combined, 1e-5);
             let mut pre_act = vec![0.0f32; h];
             let mut hidden = vec![0.0f32; h];
             for hi in 0..h {
                 let w = &self.proj[hi * d..(hi + 1) * d];
-                for (j, l) in ln.iter().enumerate() { pre_act[hi] += w[j] * l; }
+                for (j, l) in ln.iter().enumerate() {
+                    pre_act[hi] += w[j] * l;
+                }
                 hidden[hi] = activate(pre_act[hi], &self.activation);
             }
             all_hidden.push(hidden);
@@ -365,7 +462,9 @@ impl NgramModel {
                 let mut logits = vec![0.0f32; v];
                 for (vi, logit) in logits.iter_mut().enumerate() {
                     let w = &self.lm_head[vi * h..(vi + 1) * h];
-                    for (hi, hn) in combined.iter().enumerate() { *logit += w[hi] * hn; }
+                    for (hi, hn) in combined.iter().enumerate() {
+                        *logit += w[hi] * hn;
+                    }
                 }
                 softmax(&mut logits);
 
@@ -383,7 +482,8 @@ impl NgramModel {
 
                 for wi in 0..window_len {
                     for j in 0..ad {
-                        g_av[j * h..(j + 1) * h].iter_mut()
+                        g_av[j * h..(j + 1) * h]
+                            .iter_mut()
                             .zip(all_hidden[start + wi].iter())
                             .for_each(|(g, &h_val)| *g += scores[wi] * d_attn_vec[j] * h_val);
                     }
@@ -395,7 +495,11 @@ impl NgramModel {
                         d_scores[wi] += d_attn_vec[j] * values[wi][j] * scores[wi];
                         d_scores[wi] += d_attn_vec[j] * values[wi][j];
                     }
-                    d_scores[wi] -= d_attn_vec.iter().zip(values[wi].iter()).map(|(&da, &vl)| da * vl * scores[wi]).sum::<f32>();
+                    d_scores[wi] -= d_attn_vec
+                        .iter()
+                        .zip(values[wi].iter())
+                        .map(|(&da, &vl)| da * vl * scores[wi])
+                        .sum::<f32>();
                 }
 
                 let mut d_scores_clean = vec![0.0f32; window_len];
@@ -404,7 +508,11 @@ impl NgramModel {
                         d_scores_clean[wi] += d_attn_vec[j] * values[wi][j];
                     }
                     for wj in 0..window_len {
-                        let dot: f32 = d_attn_vec.iter().zip(values[wj].iter()).map(|(&da, &vl)| da * vl).sum();
+                        let dot: f32 = d_attn_vec
+                            .iter()
+                            .zip(values[wj].iter())
+                            .map(|(&da, &vl)| da * vl)
+                            .sum();
                         d_scores_clean[wi] -= scores[wi] * scores[wj] * dot;
                     }
                 }
@@ -418,7 +526,8 @@ impl NgramModel {
                 let mut d_keys = vec![vec![0.0f32; ad]; window_len];
                 for wi in 0..window_len {
                     for j in 0..ad {
-                        d_keys[wi][j] = d_scores_clean[wi] * self.attn_query[j] / (ad as f32).sqrt();
+                        d_keys[wi][j] =
+                            d_scores_clean[wi] * self.attn_query[j] / (ad as f32).sqrt();
                     }
                 }
 
@@ -444,7 +553,9 @@ impl NgramModel {
                 let mut logits = vec![0.0f32; v];
                 for (vi, logit) in logits.iter_mut().enumerate() {
                     let w = &self.lm_head[vi * h..(vi + 1) * h];
-                    for (hi, hn) in hidden.iter().enumerate() { *logit += w[hi] * hn; }
+                    for (hi, hn) in hidden.iter().enumerate() {
+                        *logit += w[hi] * hn;
+                    }
                 }
                 softmax(&mut logits);
 
@@ -457,7 +568,10 @@ impl NgramModel {
                 }
             }
 
-            let act_grads: Vec<f32> = all_pre_act[i].iter().map(|&pv| activate_grad(pv, &self.activation)).collect();
+            let act_grads: Vec<f32> = all_pre_act[i]
+                .iter()
+                .map(|&pv| activate_grad(pv, &self.activation))
+                .collect();
             for hi in 0..h {
                 for j in 0..d {
                     g_proj[hi * d + j] += d_hidden_final[hi] * act_grads[hi] * all_ln[i][j];
@@ -480,14 +594,30 @@ impl NgramModel {
         }
 
         let n = count as f32;
-        for x in g_embed.iter_mut() { *x /= n; }
-        for gc in g_ctx.iter_mut() { for x in gc.iter_mut() { *x /= n; } }
-        for x in g_proj.iter_mut() { *x /= n; }
-        for x in g_head.iter_mut() { *x /= n; }
+        for x in g_embed.iter_mut() {
+            *x /= n;
+        }
+        for gc in g_ctx.iter_mut() {
+            for x in gc.iter_mut() {
+                *x /= n;
+            }
+        }
+        for x in g_proj.iter_mut() {
+            *x /= n;
+        }
+        for x in g_head.iter_mut() {
+            *x /= n;
+        }
         if self.use_attention {
-            for x in g_aq.iter_mut() { *x /= n; }
-            for x in g_ak.iter_mut() { *x /= n; }
-            for x in g_av.iter_mut() { *x /= n; }
+            for x in g_aq.iter_mut() {
+                *x /= n;
+            }
+            for x in g_ak.iter_mut() {
+                *x /= n;
+            }
+            for x in g_av.iter_mut() {
+                *x /= n;
+            }
         }
 
         opt_embed.update(&mut self.embed, &g_embed, lr);
@@ -505,51 +635,101 @@ impl NgramModel {
 }
 
 fn evaluate(model: &NgramModel, tokens: &[usize], seq_len: usize) -> (f32, f32) {
-    let eval_step = if model.use_attention { (seq_len + 1) * 8 } else { seq_len + 1 };
+    let eval_step = if model.use_attention {
+        (seq_len + 1) * 8
+    } else {
+        seq_len + 1
+    };
     let mut total = 0.0f32;
     let mut n = 0usize;
     for c in (0..tokens.len()).step_by(eval_step) {
         let end = (c + seq_len + 1).min(tokens.len());
-        if end - c < model.ctx.len() + 3 { continue; }
+        if end - c < model.ctx.len() + 3 {
+            continue;
+        }
         let loss = model.loss_on_seq(&tokens[c..end]);
-        if loss.is_finite() { total += loss / LN_2; n += 1; }
+        if loss.is_finite() {
+            total += loss / LN_2;
+            n += 1;
+        }
     }
-    if n == 0 { return (f32::MAX, f32::MAX); }
+    if n == 0 {
+        return (f32::MAX, f32::MAX);
+    }
     let bpb = total / n as f32;
     (bpb * LN_2, bpb)
 }
 
 fn cosine_lr(step: usize, max_steps: usize, base_lr: f32, warmup: usize) -> f32 {
-    if step < warmup { return base_lr * step as f32 / warmup as f32; }
+    if step < warmup {
+        return base_lr * step as f32 / warmup as f32;
+    }
     let p = (step - warmup) as f32 / (max_steps - warmup).max(1) as f32;
     1e-5 + (base_lr - 1e-5) * 0.5 * (1.0 + (std::f32::consts::PI * p).cos())
 }
 
 fn main() {
     let args: Vec<String> = std::env::args().collect();
-    let seed: u64 = args.iter().find(|a| a.starts_with("--seed="))
-        .map(|a| a[7..].parse::<u64>().unwrap_or(42)).unwrap_or(42);
-    let steps: usize = args.iter().find(|a| a.starts_with("--steps="))
-        .map(|a| a[8..].parse::<usize>().unwrap_or(10000)).unwrap_or(10000);
-    let base_lr: f32 = args.iter().find(|a| a.starts_with("--lr="))
-        .map(|a| a[5..].parse::<f32>().unwrap_or(0.003)).unwrap_or(0.003);
-    let hidden: usize = args.iter().find(|a| a.starts_with("--hidden="))
-        .map(|a| a[9..].parse::<usize>().unwrap_or(128)).unwrap_or(128);
-    let wd: f32 = args.iter().find(|a| a.starts_with("--wd="))
-        .map(|a| a[5..].parse::<f32>().unwrap_or(0.04)).unwrap_or(0.04);
-    let activation = args.iter().find(|a| a.starts_with("--activation="))
-        .map(|a| a[13..].to_string()).unwrap_or_else(|| "relu".to_string());
+    let seed: u64 = args
+        .iter()
+        .find(|a| a.starts_with("--seed="))
+        .map(|a| a[7..].parse::<u64>().unwrap_or(42))
+        .unwrap_or(42);
+    let steps: usize = args
+        .iter()
+        .find(|a| a.starts_with("--steps="))
+        .map(|a| a[8..].parse::<usize>().unwrap_or(10000))
+        .unwrap_or(10000);
+    let base_lr: f32 = args
+        .iter()
+        .find(|a| a.starts_with("--lr="))
+        .map(|a| a[5..].parse::<f32>().unwrap_or(0.003))
+        .unwrap_or(0.003);
+    let hidden: usize = args
+        .iter()
+        .find(|a| a.starts_with("--hidden="))
+        .map(|a| a[9..].parse::<usize>().unwrap_or(128))
+        .unwrap_or(128);
+    let wd: f32 = args
+        .iter()
+        .find(|a| a.starts_with("--wd="))
+        .map(|a| a[5..].parse::<f32>().unwrap_or(0.04))
+        .unwrap_or(0.04);
+    let activation = args
+        .iter()
+        .find(|a| a.starts_with("--activation="))
+        .map(|a| a[13..].to_string())
+        .unwrap_or_else(|| "relu".to_string());
     let has_ctx5 = args.iter().any(|a| a == "--ctx5");
     let has_ctx4 = args.iter().any(|a| a == "--ctx4");
     let has_ctx3 = args.iter().any(|a| a == "--ctx3");
-    let num_ctx = if has_ctx5 { 5 } else if has_ctx4 { 4 } else if has_ctx3 { 3 } else { 2 };
+    let num_ctx = if has_ctx5 {
+        5
+    } else if has_ctx4 {
+        4
+    } else if has_ctx3 {
+        3
+    } else {
+        2
+    };
     let ngram_order = num_ctx + 2;
     let use_attention = args.iter().any(|a| a == "--attention");
 
     let ngram_name = format!("{}-Gram", ngram_order);
-    let act_name = match activation.as_str() { "gelu" => "GELU", "relu2" => "ReLU²", _ => "ReLU" };
-    let attn_str = if use_attention { " + AttentionPool" } else { "" };
-    println!("=== {} Context Model + {} Hidden{} ===", ngram_name, act_name, attn_str);
+    let act_name = match activation.as_str() {
+        "gelu" => "GELU",
+        "relu2" => "ReLU²",
+        _ => "ReLU",
+    };
+    let attn_str = if use_attention {
+        " + AttentionPool"
+    } else {
+        ""
+    };
+    println!(
+        "=== {} Context Model + {} Hidden{} ===",
+        ngram_name, act_name, attn_str
+    );
     println!("vocab={} dim={} hidden={} seq={} steps={} seed={} lr={} wd={} ctx={} activation={} attention={}",
         VOCAB, DIM, hidden, SEQ, steps, seed, base_lr, wd, num_ctx, activation, use_attention);
 
@@ -561,28 +741,49 @@ fn main() {
     let val = &tokens[train_end..];
     println!("Split: {} train / {} val", train.len(), val.len());
 
-    let mut model = NgramModel::new(VOCAB, DIM, hidden, activation.clone(), seed, num_ctx, use_attention);
+    let mut model = NgramModel::new(
+        VOCAB,
+        DIM,
+        hidden,
+        activation.clone(),
+        seed,
+        num_ctx,
+        use_attention,
+    );
     let ps = VOCAB * DIM;
-    let mut optimizer = args.iter().find(|a| a.starts_with("--optimizer="))
-        .map(|a| a[11..].to_string()).unwrap_or_else(|| "adamw".to_string());
+    let mut optimizer = args
+        .iter()
+        .find(|a| a.starts_with("--optimizer="))
+        .map(|a| a[11..].to_string())
+        .unwrap_or_else(|| "adamw".to_string());
     let use_muon = optimizer == "muon";
 
     fn make_opt(size: usize, wd: f32, muon: bool) -> Box<dyn Optimizer> {
-		if muon { Box::new(MuonOptimizer::new(size, 0.004, 0.95, wd as f64)) } else { Box::new(LocalAdamW::new(size, wd)) }
+        if muon {
+            Box::new(MuonOptimizer::new(size, 0.004, 0.95, wd as f64))
+        } else {
+            Box::new(LocalAdamW::new(size, wd))
+        }
     }
     let mut opt_embed: Box<dyn Optimizer> = make_opt(ps, wd, use_muon);
-    let mut opt_ctx: Vec<Box<dyn Optimizer>> = (0..num_ctx).map(|_| make_opt(ps, wd, use_muon)).collect();
+    let mut opt_ctx: Vec<Box<dyn Optimizer>> =
+        (0..num_ctx).map(|_| make_opt(ps, wd, use_muon)).collect();
     let mut opt_proj: Box<dyn Optimizer> = make_opt(hidden * DIM, wd, use_muon);
     let mut opt_head: Box<dyn Optimizer> = make_opt(VOCAB * hidden, wd, use_muon);
     let ad = hidden / 4;
     let mut opt_aq: Box<dyn Optimizer> = make_opt(if use_attention { ad } else { 1 }, wd, use_muon);
-    let mut opt_ak: Box<dyn Optimizer> = make_opt(if use_attention { ad * hidden } else { 1 }, wd, use_muon);
-    let mut opt_av: Box<dyn Optimizer> = make_opt(if use_attention { ad * hidden } else { 1 }, wd, use_muon);
+    let mut opt_ak: Box<dyn Optimizer> =
+        make_opt(if use_attention { ad * hidden } else { 1 }, wd, use_muon);
+    let mut opt_av: Box<dyn Optimizer> =
+        make_opt(if use_attention { ad * hidden } else { 1 }, wd, use_muon);
 
     let (init_loss, init_bpb) = evaluate(&model, val, SEQ);
     println!("Initial val: loss={:.4} bpb={:.4}", init_loss, init_bpb);
     println!();
-    println!("{:>6} | {:>10} | {:>10} | {:>10} | {:>8}", "step", "val_loss", "val_bpb", "best_bpb", "ms");
+    println!(
+        "{:>6} | {:>10} | {:>10} | {:>10} | {:>8}",
+        "step", "val_loss", "val_bpb", "best_bpb", "ms"
+    );
     println!("{}", "-".repeat(60));
 
     let t0 = Instant::now();
@@ -594,23 +795,42 @@ fn main() {
         let lr = cosine_lr(step, steps, base_lr, steps / 10);
         let off = (step * 97 + seed as usize) % (dl.saturating_sub(SEQ + 1));
         {
-            model.train_step(&train[off..off + SEQ + 1], lr,
-                opt_embed.as_mut(), &mut opt_ctx[..], opt_proj.as_mut(), opt_head.as_mut(),
-                opt_aq.as_mut(), opt_ak.as_mut(), opt_av.as_mut());
+            model.train_step(
+                &train[off..off + SEQ + 1],
+                lr,
+                opt_embed.as_mut(),
+                &mut opt_ctx[..],
+                opt_proj.as_mut(),
+                opt_head.as_mut(),
+                opt_aq.as_mut(),
+                opt_ak.as_mut(),
+                opt_av.as_mut(),
+            );
         }
 
         if step % 500 == 0 || step == steps {
             let ms = t0.elapsed().as_millis();
             let (vl, vb) = evaluate(&model, val, SEQ);
-            if vb < best_bpb && vb.is_finite() { best_bpb = vb; }
-            println!("{:>6} | {:>10.4} | {:>10.4} | {:>10.4} | {:>6}ms", step, vl, vb, best_bpb, ms);
+            if vb < best_bpb && vb.is_finite() {
+                best_bpb = vb;
+            }
+            println!(
+                "{:>6} | {:>10.4} | {:>10.4} | {:>10.4} | {:>6}ms",
+                step, vl, vb, best_bpb, ms
+            );
             results.push((step, vl, vb));
         }
     }
 
     let total = t0.elapsed();
     println!("\n=== Done ===");
-    println!("Time: {:.1}s | BPB: {:.4} → {:.4} | Delta: {:.4}", total.as_secs_f64(), init_bpb, best_bpb, best_bpb - init_bpb);
+    println!(
+        "Time: {:.1}s | BPB: {:.4} → {:.4} | Delta: {:.4}",
+        total.as_secs_f64(),
+        init_bpb,
+        best_bpb,
+        best_bpb - init_bpb
+    );
 
     let _ = fs::create_dir_all(".trinity/results");
     let attn_tag = if use_attention { "_attn" } else { "" };
@@ -629,13 +849,21 @@ fn main() {
         "duration_seconds": total.as_secs_f64(),
         "results": results.iter().map(|(s, l, b)| serde_json::json!({"step":*s,"loss":*l,"bpb":*b})).collect::<Vec<_>>(),
     });
-    let rp = format!(".trinity/results/{}gram_{}_seed{}.json",
-        ngram_order, activation, seed);
-    fs::File::create(&rp).unwrap().write_all(serde_json::to_string_pretty(&rj).unwrap().as_bytes()).unwrap();
+    let rp = format!(
+        ".trinity/results/{}gram_{}_seed{}.json",
+        ngram_order, activation, seed
+    );
+    fs::File::create(&rp)
+        .unwrap()
+        .write_all(serde_json::to_string_pretty(&rj).unwrap().as_bytes())
+        .unwrap();
     println!("Results: {}", rp);
 
     let ts = chrono::Utc::now().format("%Y-%m-%dT%H:%M:%SZ");
-    let ep = format!(".trinity/experience/trios_{}.trinity", chrono::Utc::now().format("%Y%m%d"));
+    let ep = format!(
+        ".trinity/experience/trios_{}.trinity",
+        chrono::Utc::now().format("%Y%m%d")
+    );
     let _ = fs::create_dir_all(".trinity/experience");
     let _ = fs::OpenOptions::new().create(true).append(true).open(&ep).unwrap()
         .write_all(format!("[{}] TASK: {}-gram{} training | seed={} | steps={} | val_bpb={:.4}->{:.4} | {:.1}s\n",

--- a/src/bin/ngram_train_gf16.rs
+++ b/src/bin/ngram_train_gf16.rs
@@ -11,7 +11,7 @@ use std::fs;
 use std::io::Write;
 use std::time::Instant;
 
-use trios_trainer::gf16::{GF16, QuantizationMetrics};
+use trios_trainer::gf16::{QuantizationMetrics, GF16};
 
 const VOCAB: usize = 128;
 const SEQ: usize = 64;
@@ -35,8 +35,13 @@ fn load_data(path: &str) -> Vec<usize> {
 fn softmax(v: &mut [f32]) {
     let max = v.iter().cloned().fold(f32::NEG_INFINITY, f32::max);
     let mut sum = 0.0f32;
-    for x in v.iter_mut() { *x = (*x - max).exp(); sum += *x; }
-    for x in v.iter_mut() { *x /= sum; }
+    for x in v.iter_mut() {
+        *x = (*x - max).exp();
+        sum += *x;
+    }
+    for x in v.iter_mut() {
+        *x /= sum;
+    }
 }
 
 fn layer_norm(x: &[f32], eps: f32) -> Vec<f32> {
@@ -54,7 +59,9 @@ struct Gf16Parameters {
 
 impl Gf16Parameters {
     fn new(size: usize) -> Self {
-        Self { data: vec![GF16::ZERO; size] }
+        Self {
+            data: vec![GF16::ZERO; size],
+        }
     }
 
     fn from_f32(values: &[f32]) -> Self {
@@ -181,23 +188,51 @@ impl NgramModelGF16 {
     ) -> Self {
         let mut s = seed;
         let mut rng = || {
-            s = s.wrapping_mul(6364136223846793005).wrapping_add(1442695040888963407);
+            s = s
+                .wrapping_mul(6364136223846793005)
+                .wrapping_add(1442695040888963407);
             ((s >> 33) as f32) / (u32::MAX as f32) * 2.0 - 1.0
         };
-        let n_ctx = if use_ctx5 { 6 } else if use_ctx4 { 5 } else if use_ctx3 { 4 } else { 3 };
+        let n_ctx = if use_ctx5 {
+            6
+        } else if use_ctx4 {
+            5
+        } else if use_ctx3 {
+            4
+        } else {
+            3
+        };
         let lim = (6.0f32 / (n_ctx * dim) as f32).sqrt();
         let lim_h = (6.0f32 / (dim + hidden) as f32).sqrt();
         let lim_o = (6.0f32 / (hidden + dim) as f32).sqrt();
 
         Self {
-            embed: Gf16Parameters::from_f32(&(0..vocab * dim).map(|_| rng() * lim).collect::<Vec<_>>()),
-            ctx1: Gf16Parameters::from_f32(&(0..vocab * dim).map(|_| rng() * lim).collect::<Vec<_>>()),
-            ctx2: Gf16Parameters::from_f32(&(0..vocab * dim).map(|_| rng() * lim).collect::<Vec<_>>()),
-            ctx3: Gf16Parameters::from_f32(&(0..vocab * dim).map(|_| rng() * lim).collect::<Vec<_>>()),
-            ctx4: Gf16Parameters::from_f32(&(0..vocab * dim).map(|_| rng() * lim).collect::<Vec<_>>()),
-            ctx5: Gf16Parameters::from_f32(&(0..vocab * dim).map(|_| rng() * lim).collect::<Vec<_>>()),
-            proj: Gf16Parameters::from_f32(&(0..hidden * dim).map(|_| rng() * lim_h).collect::<Vec<_>>()),
-            lm_head: Gf16Parameters::from_f32(&(0..vocab * hidden).map(|_| rng() * lim_o).collect::<Vec<_>>()),
+            embed: Gf16Parameters::from_f32(
+                &(0..vocab * dim).map(|_| rng() * lim).collect::<Vec<_>>(),
+            ),
+            ctx1: Gf16Parameters::from_f32(
+                &(0..vocab * dim).map(|_| rng() * lim).collect::<Vec<_>>(),
+            ),
+            ctx2: Gf16Parameters::from_f32(
+                &(0..vocab * dim).map(|_| rng() * lim).collect::<Vec<_>>(),
+            ),
+            ctx3: Gf16Parameters::from_f32(
+                &(0..vocab * dim).map(|_| rng() * lim).collect::<Vec<_>>(),
+            ),
+            ctx4: Gf16Parameters::from_f32(
+                &(0..vocab * dim).map(|_| rng() * lim).collect::<Vec<_>>(),
+            ),
+            ctx5: Gf16Parameters::from_f32(
+                &(0..vocab * dim).map(|_| rng() * lim).collect::<Vec<_>>(),
+            ),
+            proj: Gf16Parameters::from_f32(
+                &(0..hidden * dim).map(|_| rng() * lim_h).collect::<Vec<_>>(),
+            ),
+            lm_head: Gf16Parameters::from_f32(
+                &(0..vocab * hidden)
+                    .map(|_| rng() * lim_o)
+                    .collect::<Vec<_>>(),
+            ),
             vocab,
             dim,
             hidden,
@@ -233,7 +268,12 @@ impl NgramModelGF16 {
             let c4: Vec<f32> = (0..d).map(|j| self.ctx4.get(t4 * d + j)).collect();
             let c5: Vec<f32> = (0..d).map(|j| self.ctx5.get(t5 * d + j)).collect();
             for j in 0..d {
-                combined[j] = e0[j] + c1[j] * 0.35 + c2[j] * 0.22 + c3[j] * 0.15 + c4[j] * 0.11 + c5[j] * 0.17;
+                combined[j] = e0[j]
+                    + c1[j] * 0.35
+                    + c2[j] * 0.22
+                    + c3[j] * 0.15
+                    + c4[j] * 0.11
+                    + c5[j] * 0.17;
             }
         } else if self.use_ctx4 {
             let c3: Vec<f32> = (0..d).map(|j| self.ctx3.get(t3 * d + j)).collect();
@@ -267,7 +307,8 @@ impl NgramModelGF16 {
             };
             // Dropout
             if self.dropout > 0.0 {
-                let mask = ((hi as u64).wrapping_mul(6364136223846793005u64) >> 33) as f32 / u32::MAX as f32;
+                let mask = ((hi as u64).wrapping_mul(6364136223846793005u64) >> 33) as f32
+                    / u32::MAX as f32;
                 if mask < self.dropout {
                     hidden[hi] = 0.0;
                 } else {
@@ -409,8 +450,12 @@ impl NgramModelGF16 {
                 let c4: Vec<f32> = (0..d).map(|j| self.ctx4.get(t4 * d + j)).collect();
                 let c5: Vec<f32> = (0..d).map(|j| self.ctx5.get(t5 * d + j)).collect();
                 for j in 0..d {
-                    combined[j] =
-                        e0[j] + c1[j] * 0.35 + c2[j] * 0.22 + c3[j] * 0.15 + c4[j] * 0.11 + c5[j] * 0.17;
+                    combined[j] = e0[j]
+                        + c1[j] * 0.35
+                        + c2[j] * 0.22
+                        + c3[j] * 0.15
+                        + c4[j] * 0.11
+                        + c5[j] * 0.17;
                 }
             } else if self.use_ctx4 {
                 let c3: Vec<f32> = (0..d).map(|j| self.ctx3.get(t3 * d + j)).collect();
@@ -435,10 +480,17 @@ impl NgramModelGF16 {
                     // GELU derivative approximation
                     let x = hidden[hi];
                     0.5 * (1.0 + (0.7978846 * (x + 0.044715 * x * x * x)).tanh())
-                        + 0.5 * x * 0.7978846 * (1.0 + 0.134145 * x * x * x)
+                        + 0.5
+                            * x
+                            * 0.7978846
+                            * (1.0 + 0.134145 * x * x * x)
                             * (1.0 - (0.7978846 * (x + 0.044715 * x * x * x)).tanh().powi(2))
                 } else {
-                    if hidden[hi] > 0.0 { 1.0 } else { 0.0 }
+                    if hidden[hi] > 0.0 {
+                        1.0
+                    } else {
+                        0.0
+                    }
                 };
                 for j in 0..d {
                     g_proj[hi * d + j] += d_hidden[hi] * activation_grad * ln[j];
@@ -453,14 +505,22 @@ impl NgramModelGF16 {
                             * if self.activation == "gelu" {
                                 let x = hidden[hi];
                                 0.5 * (1.0 + (0.7978846 * (x + 0.044715 * x * x * x)).tanh())
-                                    + 0.5 * x * 0.7978846 * (1.0 + 0.134145 * x * x * x)
+                                    + 0.5
+                                        * x
+                                        * 0.7978846
+                                        * (1.0 + 0.134145 * x * x * x)
                                         * (1.0
                                             - (0.7978846 * (x + 0.044715 * x * x * x))
                                                 .tanh()
                                                 .powi(2))
                             } else {
-                                if hidden[hi] > 0.0 { 1.0 } else { 0.0 }
-                            } * dh
+                                if hidden[hi] > 0.0 {
+                                    1.0
+                                } else {
+                                    0.0
+                                }
+                            }
+                            * dh
                     })
                     .sum::<f32>();
                 g_embed[t0 * d + j] += grad_j;
@@ -534,7 +594,10 @@ impl NgramModelGF16 {
         .concat();
 
         // Quantize and compare
-        let quantized: Vec<f32> = all_f32.iter().map(|&x| GF16::from_f32(x).to_f32()).collect();
+        let quantized: Vec<f32> = all_f32
+            .iter()
+            .map(|&x| GF16::from_f32(x).to_f32())
+            .collect();
         QuantizationMetrics::compute(&all_f32, &quantized)
     }
 }
@@ -626,11 +689,7 @@ fn main() {
     } else {
         "4-Gram"
     };
-    let activation_name = if activation == "gelu" {
-        "GELU"
-    } else {
-        "ReLU"
-    };
+    let activation_name = if activation == "gelu" { "GELU" } else { "ReLU" };
 
     println!("=== GF16 {} Context Model + {} ===", ngram, activation_name);
     println!("vocab={} dim={} hidden={} seq={} steps={} seed={} lr={} activation={} wd={} warmup={} dropout={}",
@@ -672,7 +731,10 @@ fn main() {
     let (init_loss, init_bpb) = evaluate(&model, val, SEQ);
     println!("Initial val: loss={:.4} bpb={:.4}", init_loss, init_bpb);
     println!();
-    println!("{:>6} | {:>10} | {:>10} | {:>10} | {:>12}", "step", "val_loss", "val_bpb", "best_bpb", "max_q_err%");
+    println!(
+        "{:>6} | {:>10} | {:>10} | {:>10} | {:>12}",
+        "step", "val_loss", "val_bpb", "best_bpb", "max_q_err%"
+    );
     println!("{}", "-".repeat(65));
 
     let t0 = Instant::now();
@@ -702,7 +764,10 @@ fn main() {
 
             // Early stopping
             if steps_without_improvement >= patience {
-                println!("\n>>> Early stopping at step {} (patience={} exceeded)", step, patience);
+                println!(
+                    "\n>>> Early stopping at step {} (patience={} exceeded)",
+                    step, patience
+                );
                 break;
             }
 
@@ -721,7 +786,14 @@ fn main() {
     let total = t0.elapsed();
     let q_final = model.quantization_report();
     println!("\n=== GF16 Training Complete ===");
-    println!("Time: {:.1}s | BPB: {:.4} → {:.4} | Delta: {:.4} | Best step: {}", total.as_secs_f64(), init_bpb, best_bpb, best_bpb - init_bpb, best_step);
+    println!(
+        "Time: {:.1}s | BPB: {:.4} → {:.4} | Delta: {:.4} | Best step: {}",
+        total.as_secs_f64(),
+        init_bpb,
+        best_bpb,
+        best_bpb - init_bpb,
+        best_step
+    );
     println!("\nFinal Quantization Metrics:");
     println!("  φ-distance:    {:.6}", q_final.phi_error);
     println!("  Max error:     {:.4}%", q_final.max_error_pct);
@@ -755,8 +827,16 @@ fn main() {
         },
         "results": results.iter().map(|(s, l, b)| serde_json::json!({"step":*s,"loss":*l,"bpb":*b})).collect::<Vec<_>>(),
     });
-    let rp = format!(".trinity/results/gf16_{}gram_{}_seed{}.json", ngram.to_lowercase(), activation, seed);
-    fs::File::create(&rp).unwrap().write_all(serde_json::to_string_pretty(&rj).unwrap().as_bytes()).unwrap();
+    let rp = format!(
+        ".trinity/results/gf16_{}gram_{}_seed{}.json",
+        ngram.to_lowercase(),
+        activation,
+        seed
+    );
+    fs::File::create(&rp)
+        .unwrap()
+        .write_all(serde_json::to_string_pretty(&rj).unwrap().as_bytes())
+        .unwrap();
     println!("\nResults: {}", rp);
 
     // Experience log

--- a/src/bin/qk_gain_check.rs
+++ b/src/bin/qk_gain_check.rs
@@ -150,18 +150,15 @@ impl std::fmt::Display for QkGainError {
                 f,
                 "INV-13 gain {gain} not phi-anchored: must be one of {admissible:?} (tol={tol:.0e})"
             ),
-            Self::LrAboveBand { lr, ceiling } => write!(
-                f,
-                "INV-13 lr {lr} above pre-registered ceiling {ceiling}"
-            ),
-            Self::LrBelowBand { lr, floor } => write!(
-                f,
-                "INV-13 lr {lr} below pre-registered floor {floor}"
-            ),
-            Self::NonFinite { lr, gain } => write!(
-                f,
-                "INV-13 non-finite input: lr={lr} gain={gain}"
-            ),
+            Self::LrAboveBand { lr, ceiling } => {
+                write!(f, "INV-13 lr {lr} above pre-registered ceiling {ceiling}")
+            }
+            Self::LrBelowBand { lr, floor } => {
+                write!(f, "INV-13 lr {lr} below pre-registered floor {floor}")
+            }
+            Self::NonFinite { lr, gain } => {
+                write!(f, "INV-13 non-finite input: lr={lr} gain={gain}")
+            }
         }
     }
 }
@@ -447,7 +444,10 @@ mod tests {
         }
         // L-h4 reserves 50..=53 (L7 uses 0..=10, L15 uses 21..=30).
         for c in codes {
-            assert!((50..=53).contains(&c), "exit {c} outside L-h4 reserved range 50..=53");
+            assert!(
+                (50..=53).contains(&c),
+                "exit {c} outside L-h4 reserved range 50..=53"
+            );
         }
     }
 

--- a/src/bin/r12_optimizer_race.rs
+++ b/src/bin/r12_optimizer_race.rs
@@ -14,7 +14,9 @@ struct Config {
 
 /// Minimal LCG for reproducible pseudo-random init
 fn lcg(state: &mut u64) -> f32 {
-    *state = state.wrapping_mul(6364136223846793005).wrapping_add(1442695040888963407);
+    *state = state
+        .wrapping_mul(6364136223846793005)
+        .wrapping_add(1442695040888963407);
     ((*state >> 33) as f32) / (u32::MAX as f32) * 2.0 - 1.0
 }
 
@@ -35,13 +37,18 @@ fn run_trial(cfg: &mut Config, seed: u64) -> Vec<(usize, f64)> {
 
     for step in 1..=STEPS {
         // Gradient: d_loss/d_params = 2*(params - target) / N (MSE)
-        let grads: Vec<f32> = params.iter().zip(target.iter())
+        let grads: Vec<f32> = params
+            .iter()
+            .zip(target.iter())
             .map(|(p, t)| 2.0 * (p - t) / N_PARAMS as f32)
             .collect();
 
-        let mse: f64 = params.iter().zip(target.iter())
+        let mse: f64 = params
+            .iter()
+            .zip(target.iter())
             .map(|(p, t)| ((p - t) * (p - t)) as f64)
-            .sum::<f64>() / N_PARAMS as f64;
+            .sum::<f64>()
+            / N_PARAMS as f64;
         let bpb_proxy = mse / std::f64::consts::LN_2;
 
         if [1000, 2000, 3000, 4000, 5000, 6000].contains(&step) {
@@ -58,21 +65,17 @@ fn main() {
     let mut configs: Vec<Config> = vec![
         Config {
             name: "A: AdamW  lr=0.004",
-            optimizer: OptimizerKind::AdamW(
-                AdamWCpu::with_params(N_PARAMS, 0.004, 0.9, 0.999, 0.01)
-            ),
+            optimizer: OptimizerKind::AdamW(AdamWCpu::with_params(
+                N_PARAMS, 0.004, 0.9, 0.999, 0.01,
+            )),
         },
         Config {
             name: "B: Muon   lr=0.004",
-            optimizer: OptimizerKind::Muon(
-                MuonOptimizer::new(N_PARAMS, 0.004, 0.95, 0.01)
-            ),
+            optimizer: OptimizerKind::Muon(MuonOptimizer::new(N_PARAMS, 0.004, 0.95, 0.01)),
         },
         Config {
             name: "C: Muon   lr=0.001",
-            optimizer: OptimizerKind::Muon(
-                MuonOptimizer::new(N_PARAMS, 0.001, 0.95, 0.01)
-            ),
+            optimizer: OptimizerKind::Muon(MuonOptimizer::new(N_PARAMS, 0.001, 0.95, 0.01)),
         },
     ];
 
@@ -85,18 +88,26 @@ fn main() {
         let t0 = std::time::Instant::now();
         let pts = run_trial(cfg, SEED);
         let wall = t0.elapsed().as_secs_f64();
-        let vals: Vec<String> = pts.iter()
-            .map(|(_, bpb)| format!("{:.4}", bpb))
-            .collect();
-        println!("| {} | {} | wall={:.1}s |",
-            cfg.name, vals.join(" | "), wall);
+        let vals: Vec<String> = pts.iter().map(|(_, bpb)| format!("{:.4}", bpb)).collect();
+        println!(
+            "| {} | {} | wall={:.1}s |",
+            cfg.name,
+            vals.join(" | "),
+            wall
+        );
         results.push((cfg.name, pts, wall));
     }
 
     // Winner = lowest BPB@6000
-    let winner = results.iter()
-        .min_by(|a, b| a.1.last().unwrap().1
-            .partial_cmp(&b.1.last().unwrap().1).unwrap())
+    let winner = results
+        .iter()
+        .min_by(|a, b| {
+            a.1.last()
+                .unwrap()
+                .1
+                .partial_cmp(&b.1.last().unwrap().1)
+                .unwrap()
+        })
         .unwrap();
     println!("\nWinner: {}", winner.0);
 }

--- a/src/bin/seed_emit.rs
+++ b/src/bin/seed_emit.rs
@@ -64,8 +64,8 @@ use chrono::Utc;
 use clap::Parser;
 use serde_json::{json, Value};
 
-use trios_trainer::invariants::INV2_WARMUP_BLIND_STEPS;
 use trios_trainer::invariants::IGLA_TARGET_BPB;
+use trios_trainer::invariants::INV2_WARMUP_BLIND_STEPS;
 use trios_trainer::race::victory::JEPA_PROXY_BPB_FLOOR;
 
 /// CLI for atomically emitting a single seed measurement to the
@@ -279,10 +279,7 @@ pub fn render_row(row: &EmitRow) -> String {
 /// End-to-end emit: validate, check duplicates against the existing
 /// ledger text, return the line to write.  Pure function — `main`
 /// supplies the I/O and the timestamp.
-pub fn emit(
-    row: &EmitRow,
-    existing_ledger: &str,
-) -> Result<String, EmitError> {
+pub fn emit(row: &EmitRow, existing_ledger: &str) -> Result<String, EmitError> {
     validate_row(row)?;
     if seeds_in_ledger(existing_ledger).contains(&row.seed) {
         return Err(EmitError::DuplicateSeed { seed: row.seed });
@@ -407,7 +404,10 @@ mod tests {
         row.bpb = 1.62;
         let line = emit(&row, "").unwrap();
         let parsed: Value = serde_json::from_str(&line).unwrap();
-        assert_eq!(parsed["gate_action"].as_str(), Some("below_target_evidence"));
+        assert_eq!(
+            parsed["gate_action"].as_str(),
+            Some("below_target_evidence")
+        );
     }
 
     /// NaN BPB → NonFiniteBpb, exit 21.
@@ -418,7 +418,14 @@ mod tests {
         match emit(&row, "") {
             Err(EmitError::NonFiniteBpb { seed, .. }) => {
                 assert_eq!(seed, 3);
-                assert_eq!(EmitError::NonFiniteBpb { seed: 3, bpb: f64::NAN }.exit_code(), 21);
+                assert_eq!(
+                    EmitError::NonFiniteBpb {
+                        seed: 3,
+                        bpb: f64::NAN
+                    }
+                    .exit_code(),
+                    21
+                );
             }
             other => panic!("expected NonFiniteBpb, got {:?}", other),
         }
@@ -560,7 +567,12 @@ mod tests {
     fn exit_codes_are_distinct() {
         let codes: Vec<u8> = vec![
             EmitError::NonFiniteBpb { seed: 0, bpb: 0.0 }.exit_code(),
-            EmitError::BeforeWarmup { seed: 0, step: 0, warmup: 4000 }.exit_code(),
+            EmitError::BeforeWarmup {
+                seed: 0,
+                step: 0,
+                warmup: 4000,
+            }
+            .exit_code(),
             EmitError::JepaProxyDetected { seed: 0, bpb: 0.0 }.exit_code(),
             EmitError::BpbOutOfRange { seed: 0, bpb: 0.0 }.exit_code(),
             EmitError::DuplicateSeed { seed: 0 }.exit_code(),

--- a/src/bin/tjepa_train.rs
+++ b/src/bin/tjepa_train.rs
@@ -10,19 +10,22 @@
 //! Gate target: ≤ 2.03 BPB
 //! IGLA target: < 1.50 BPB
 
-#![allow(clippy::needless_range_loop, clippy::type_complexity, clippy::too_many_arguments)]
+#![allow(
+    clippy::needless_range_loop,
+    clippy::type_complexity,
+    clippy::too_many_arguments
+)]
 
 use std::fs;
 use std::time::Instant;
 
 use trios_trainer::{
     jepa::{
-        EmaConfig, EmaTarget,
         predictor::{JepaPredictor, PredictorConfig},
+        EmaConfig, EmaTarget,
     },
     objective::{
-        ComponentLosses, NcaObjective, ObjectiveConfig, compute_combined_loss,
-        nca_entropy_loss,
+        compute_combined_loss, nca_entropy_loss, ComponentLosses, NcaObjective, ObjectiveConfig,
     },
     optimizer::MuonOptimizer,
 };
@@ -165,7 +168,9 @@ impl NgramModel {
     fn new(seed: u64) -> Self {
         let mut s = seed;
         let mut rng = || {
-            s = s.wrapping_mul(6364136223846793005).wrapping_add(1442695040888963407);
+            s = s
+                .wrapping_mul(6364136223846793005)
+                .wrapping_add(1442695040888963407);
             ((s >> 33) as f32) / (u32::MAX as f32) * 2.0 - 1.0
         };
         let lim = (6.0f32 / (3 * DIM) as f32).sqrt();
@@ -245,10 +250,7 @@ struct TrainGrads {
     g_head: Vec<f32>,
 }
 
-fn compute_grads(
-    model: &NgramModel,
-    tokens: &[usize],
-) -> (TrainGrads, Vec<Vec<f32>>, f32) {
+fn compute_grads(model: &NgramModel, tokens: &[usize]) -> (TrainGrads, Vec<Vec<f32>>, f32) {
     let count = tokens.len().saturating_sub(NGRAM);
     assert!(count > 0, "sequence too short for gradient computation");
 
@@ -259,17 +261,40 @@ fn compute_grads(
 
     let (all_hidden, all_ln, all_contexts) = forward_pass(model, tokens, count);
     let total_loss = backward_pass(
-        model, &all_hidden, &all_ln, &all_contexts, tokens, count,
-        &mut g_embed, &mut g_ctx, &mut g_proj, &mut g_head,
+        model,
+        &all_hidden,
+        &all_ln,
+        &all_contexts,
+        tokens,
+        count,
+        &mut g_embed,
+        &mut g_ctx,
+        &mut g_proj,
+        &mut g_head,
     );
 
     let n = count as f32;
-    for x in g_embed.iter_mut() { *x /= n; }
-    for gc in g_ctx.iter_mut() { for x in gc.iter_mut() { *x /= n; } }
-    for x in g_proj.iter_mut() { *x /= n; }
-    for x in g_head.iter_mut() { *x /= n; }
+    for x in g_embed.iter_mut() {
+        *x /= n;
+    }
+    for gc in g_ctx.iter_mut() {
+        for x in gc.iter_mut() {
+            *x /= n;
+        }
+    }
+    for x in g_proj.iter_mut() {
+        *x /= n;
+    }
+    for x in g_head.iter_mut() {
+        *x /= n;
+    }
 
-    let grads = TrainGrads { g_embed, g_ctx, g_proj, g_head };
+    let grads = TrainGrads {
+        g_embed,
+        g_ctx,
+        g_proj,
+        g_head,
+    };
     (grads, all_hidden, total_loss)
 }
 
@@ -325,7 +350,11 @@ fn backward_pass(
 ) -> f32 {
     assert!(count > 0, "backward_pass: count=0");
     if all_hidden.len() != count {
-        eprintln!("WARN: hidden count mismatch: {} != {}, skipping step", all_hidden.len(), count);
+        eprintln!(
+            "WARN: hidden count mismatch: {} != {}, skipping step",
+            all_hidden.len(),
+            count
+        );
         return 0.0;
     }
     assert_eq!(all_ln.len(), count, "ln count mismatch");
@@ -357,8 +386,12 @@ fn backward_pass(
         }
 
         accumulate_input_grads(
-            model, &all_contexts[i], &all_hidden[i], &d_hidden,
-            g_embed, g_ctx,
+            model,
+            &all_contexts[i],
+            &all_hidden[i],
+            &d_hidden,
+            g_embed,
+            g_ctx,
         );
     }
 
@@ -417,7 +450,9 @@ fn evaluate(model: &NgramModel, tokens: &[usize]) -> f32 {
 fn load_data(path: &str) -> Vec<usize> {
     let raw = fs::read(path).unwrap_or_else(|e| {
         eprintln!("Failed to load {}: {}. Using fallback.", path, e);
-        b"The quick brown fox jumps over the lazy dog. ".repeat(100).to_vec()
+        b"The quick brown fox jumps over the lazy dog. "
+            .repeat(100)
+            .to_vec()
     });
     assert!(!raw.is_empty(), "loaded data is empty");
     raw.into_iter().map(|b| (b as usize) % VOCAB).collect()
@@ -484,9 +519,20 @@ fn parse_config(args: &[String]) -> Config {
     assert!(weight_decay >= 0.0, "weight_decay must be >= 0");
 
     Config {
-        seed, steps, encoder_lr, ntp_lr, use_jepa, use_nca,
-        ntp_weight, jepa_weight, nca_weight, opt_kind, jepa_warmup,
-        weight_decay, trial_id, agent_id,
+        seed,
+        steps,
+        encoder_lr,
+        ntp_lr,
+        use_jepa,
+        use_nca,
+        ntp_weight,
+        jepa_weight,
+        nca_weight,
+        opt_kind,
+        jepa_warmup,
+        weight_decay,
+        trial_id,
+        agent_id,
     }
 }
 
@@ -513,11 +559,13 @@ fn jepa_training_step(
     }
 
     let zero_h = vec![0.0f32; HIDDEN];
-    let ctx_flat: Vec<f32> = ctx_pos.iter()
+    let ctx_flat: Vec<f32> = ctx_pos
+        .iter()
         .flat_map(|&p| hidden_vecs.get(p).unwrap_or(&zero_h).iter().copied())
         .collect();
 
-    let tgt_hidden: Vec<Vec<f32>> = tgt_pos.iter()
+    let tgt_hidden: Vec<Vec<f32>> = tgt_pos
+        .iter()
         .filter_map(|&p| {
             if p + NGRAM <= seq.len() {
                 Some(target_model.compute_hidden(&seq[p..p + NGRAM]))
@@ -542,19 +590,31 @@ fn jepa_training_step(
 
 fn build_span_mask(len: usize, seed: u64, step: usize) -> (Vec<usize>, Vec<usize>) {
     assert!(len > 0, "build_span_mask: len=0");
-    let mut s = seed.wrapping_add(step as u64).wrapping_mul(6364136223846793005);
+    let mut s = seed
+        .wrapping_add(step as u64)
+        .wrapping_mul(6364136223846793005);
     let mut bitset = vec![false; len];
     let span_len = 3usize;
     let num_spans = 2usize;
     for _ in 0..num_spans {
-        s = s.wrapping_mul(6364136223846793005).wrapping_add(1442695040888963407);
+        s = s
+            .wrapping_mul(6364136223846793005)
+            .wrapping_add(1442695040888963407);
         let start = (s as usize) % len.saturating_sub(span_len);
         for b in start..(start + span_len).min(len) {
             bitset[b] = true;
         }
     }
-    let tgt: Vec<usize> = bitset.iter().enumerate().filter_map(|(i, &m)| if m { Some(i) } else { None }).collect();
-    let ctx: Vec<usize> = bitset.iter().enumerate().filter_map(|(i, &m)| if !m { Some(i) } else { None }).collect();
+    let tgt: Vec<usize> = bitset
+        .iter()
+        .enumerate()
+        .filter_map(|(i, &m)| if m { Some(i) } else { None })
+        .collect();
+    let ctx: Vec<usize> = bitset
+        .iter()
+        .enumerate()
+        .filter_map(|(i, &m)| if !m { Some(i) } else { None })
+        .collect();
     (tgt, ctx)
 }
 
@@ -564,7 +624,11 @@ fn nca_training_step(nca: &NcaObjective, seed: u64, step: usize) -> f64 {
     let nca_seed = seed.wrapping_add(step as u64).wrapping_mul(7919);
     let nca_state = nca.init_grid(nca_seed);
     let (loss, _) = nca_entropy_loss(
-        &nca_state, nca.k_states, nca.entropy_min, nca.entropy_max, nca.weight,
+        &nca_state,
+        nca.k_states,
+        nca.entropy_min,
+        nca.entropy_max,
+        nca.weight,
     );
     assert!(loss.is_finite(), "NCA loss is not finite");
     loss
@@ -641,8 +705,16 @@ fn init_training(cfg: &Config) -> TrainingState {
         } else {
             None
         },
-        ema_target: EmaTarget::new(EmaConfig { start: 0.996, end: 1.0, ramp_steps: cfg.steps }),
-        nca: if cfg.use_nca { Some(NcaObjective::default()) } else { None },
+        ema_target: EmaTarget::new(EmaConfig {
+            start: 0.996,
+            end: 1.0,
+            ramp_steps: cfg.steps,
+        }),
+        nca: if cfg.use_nca {
+            Some(NcaObjective::default())
+        } else {
+            None
+        },
         obj_config: ObjectiveConfig {
             ntp_weight: cfg.ntp_weight,
             jepa_weight: cfg.jepa_weight,
@@ -662,9 +734,18 @@ fn print_banner(cfg: &Config) {
         OptKind::Muon => "Muon",
     };
     eprintln!("=== T-JEPA Hybrid Training ===");
-    eprintln!("dim={} hidden={} enc_lr={} ntp_lr={} seed={} steps={}", DIM, HIDDEN, cfg.encoder_lr, cfg.ntp_lr, cfg.seed, cfg.steps);
-    eprintln!("optimizer={} jepa={} nca={} jepa_warmup={}", opt_name, cfg.use_jepa, cfg.use_nca, cfg.jepa_warmup);
-    eprintln!("L = {}*NTP + {}*JEPA + {}*NCA", cfg.ntp_weight, cfg.jepa_weight, cfg.nca_weight);
+    eprintln!(
+        "dim={} hidden={} enc_lr={} ntp_lr={} seed={} steps={}",
+        DIM, HIDDEN, cfg.encoder_lr, cfg.ntp_lr, cfg.seed, cfg.steps
+    );
+    eprintln!(
+        "optimizer={} jepa={} nca={} jepa_warmup={}",
+        opt_name, cfg.use_jepa, cfg.use_nca, cfg.jepa_warmup
+    );
+    eprintln!(
+        "L = {}*NTP + {}*JEPA + {}*NCA",
+        cfg.ntp_weight, cfg.jepa_weight, cfg.nca_weight
+    );
     eprintln!("trial_id={} agent_id={}", cfg.trial_id, cfg.agent_id);
     eprintln!("Champion: BPB 2.5193 | Gate-1: ≤2.22 | Gate-2: ≤2.03");
 }
@@ -673,14 +754,25 @@ fn print_banner(cfg: &Config) {
 
 fn print_results(cfg: &Config, best_bpb: f32, elapsed: f64) {
     eprintln!("\n=== Training Complete ===");
-    eprintln!("Steps={} Time={:.1}s best_val_bpb={:.4} vs_champion={:+.4}",
-        cfg.steps, elapsed, best_bpb, best_bpb - 2.5193);
+    eprintln!(
+        "Steps={} Time={:.1}s best_val_bpb={:.4} vs_champion={:+.4}",
+        cfg.steps,
+        elapsed,
+        best_bpb,
+        best_bpb - 2.5193
+    );
     println!("BPB={:.4}", best_bpb);
 
-    if best_bpb <= 2.22 { eprintln!("Gate-1 PASSED (≤2.22)"); }
-    else { eprintln!("Gate-1 FAILED: {:.4} > 2.22", best_bpb); }
-    if best_bpb <= 2.03 { eprintln!("Gate-2 PASSED (≤2.03)"); }
-    else { eprintln!("Gate-2 FAILED: {:.4} > 2.03", best_bpb); }
+    if best_bpb <= 2.22 {
+        eprintln!("Gate-1 PASSED (≤2.22)");
+    } else {
+        eprintln!("Gate-1 FAILED: {:.4} > 2.22", best_bpb);
+    }
+    if best_bpb <= 2.03 {
+        eprintln!("Gate-2 PASSED (≤2.03)");
+    } else {
+        eprintln!("Gate-2 FAILED: {:.4} > 2.03", best_bpb);
+    }
 }
 
 // ── main ──
@@ -696,7 +788,11 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let val_data = load_data("data/tiny_shakespeare_val.txt");
     let train_end = (train_data.len() as f64 * 0.9) as usize;
     let train = &train_data[..train_end];
-    let val = if val_data.len() > 100 { &val_data } else { &train_data[train_end..] };
+    let val = if val_data.len() > 100 {
+        &val_data
+    } else {
+        &train_data[train_end..]
+    };
 
     let mut st = init_training(&cfg);
     let warmup = cfg.steps / 10;
@@ -712,18 +808,24 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         let nca_loss_val = run_nca_step(&cfg, &st, step);
 
         let combined = compute_combined_loss(
-            ComponentLosses { ntp: ntp_loss as f64 / LN_2 as f64, jepa: jepa_loss_val, nca: nca_loss_val },
+            ComponentLosses {
+                ntp: ntp_loss as f64 / LN_2 as f64,
+                jepa: jepa_loss_val,
+                nca: nca_loss_val,
+            },
             st.obj_config,
         );
 
         let enc_lr = cosine_lr(step, cfg.steps, cfg.encoder_lr, warmup);
         let head_lr = cosine_lr(step, cfg.steps, cfg.ntp_lr, warmup);
-        st.opt_embed.step(&mut st.model.embed, &grads.g_embed, enc_lr);
+        st.opt_embed
+            .step(&mut st.model.embed, &grads.g_embed, enc_lr);
         for (ci, oc) in st.opt_ctx.iter_mut().enumerate() {
             oc.step(&mut st.model.ctx[ci], &grads.g_ctx[ci], enc_lr);
         }
         st.opt_proj.step(&mut st.model.proj, &grads.g_proj, enc_lr);
-        st.opt_head.step(&mut st.model.lm_head, &grads.g_head, head_lr);
+        st.opt_head
+            .step(&mut st.model.lm_head, &grads.g_head, head_lr);
 
         if step % 500 == 0 || step == cfg.steps {
             let elapsed = st.start_time.elapsed().as_secs_f64();
@@ -731,9 +833,16 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             if val_bpb < st.best_val_bpb && val_bpb.is_finite() {
                 st.best_val_bpb = val_bpb;
             }
-            eprintln!("step={:5} ntp={:.4} jepa={:.4} nca={:.4} val_bpb={:.4} best={:.4} t={:.1}s",
-                step, combined.components.ntp, combined.components.jepa,
-                combined.components.nca, val_bpb, st.best_val_bpb, elapsed);
+            eprintln!(
+                "step={:5} ntp={:.4} jepa={:.4} nca={:.4} val_bpb={:.4} best={:.4} t={:.1}s",
+                step,
+                combined.components.ntp,
+                combined.components.jepa,
+                combined.components.nca,
+                val_bpb,
+                st.best_val_bpb,
+                elapsed
+            );
         }
 
         neon_heartbeat(&cfg, step, st.best_val_bpb, &mut st.last_heartbeat);
@@ -758,8 +867,14 @@ fn run_jepa_step(
     match (&mut st.predictor, &mut st.target_model) {
         (Some(pred), _) => {
             let result = jepa_training_step(
-                pred, &st.model, &mut st.target_model, hidden_vecs, seq,
-                cfg.seed, step, &mut st.ema_target,
+                pred,
+                &st.model,
+                &mut st.target_model,
+                hidden_vecs,
+                seq,
+                cfg.seed,
+                step,
+                &mut st.ema_target,
             );
             result.loss
         }

--- a/src/bin/train_v2.rs
+++ b/src/bin/train_v2.rs
@@ -113,7 +113,9 @@ impl Model {
         let ngram = num_ctx + 2;
         let mut s = seed;
         let mut rng = || {
-            s = s.wrapping_mul(6364136223846793005).wrapping_add(1442695040888963407);
+            s = s
+                .wrapping_mul(6364136223846793005)
+                .wrapping_add(1442695040888963407);
             ((s >> 33) as f32) / (u32::MAX as f32) * 2.0 - 1.0
         };
         let lim = (6.0f32 / (3 * DIM) as f32).sqrt();
@@ -246,7 +248,11 @@ fn compute_grads(model: &Model, tokens: &[usize]) -> (Grads, f32) {
 
         let mut d_hr = vec![0.0f32; h];
         for i in 0..h {
-            d_hr[i] = if st.hidden_raw[i] > 0.0 { d_hid[i] } else { 0.0 };
+            d_hr[i] = if st.hidden_raw[i] > 0.0 {
+                d_hid[i]
+            } else {
+                0.0
+            };
         }
 
         let mut d_normed_proj = vec![0.0f32; DIM];
@@ -392,16 +398,12 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let h = hidden_dim;
     let wd = 0.04f32;
     let mut opt_embed = AdamW::new(VOCAB * DIM, wd);
-    let mut opt_ctx: Vec<AdamW> = (0..num_ctx)
-        .map(|_| AdamW::new(VOCAB * DIM, wd))
-        .collect();
+    let mut opt_ctx: Vec<AdamW> = (0..num_ctx).map(|_| AdamW::new(VOCAB * DIM, wd)).collect();
     let mut opt_proj_up = AdamW::new(h * DIM, wd);
     let mut opt_proj_down = AdamW::new(DIM * h, wd);
 
     let mut acc_embed = vec![0.0f32; VOCAB * DIM];
-    let mut acc_ctx: Vec<Vec<f32>> = (0..num_ctx)
-        .map(|_| vec![0.0f32; VOCAB * DIM])
-        .collect();
+    let mut acc_ctx: Vec<Vec<f32>> = (0..num_ctx).map(|_| vec![0.0f32; VOCAB * DIM]).collect();
     let mut acc_proj_up = vec![0.0f32; h * DIM];
     let mut acc_proj_down = vec![0.0f32; DIM * h];
 
@@ -437,7 +439,11 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         }
 
         if step % ACCUM == 0 || step == steps {
-            let num_acc = if step % ACCUM == 0 { ACCUM } else { step % ACCUM };
+            let num_acc = if step % ACCUM == 0 {
+                ACCUM
+            } else {
+                step % ACCUM
+            };
             let inv = 1.0 / num_acc as f32;
             for x in acc_embed.iter_mut() {
                 *x *= inv;
@@ -486,10 +492,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             }
             eprintln!(
                 "step={:5} val_bpb={:.4} best={:.4} t={}s",
-                step,
-                val_bpb,
-                best_bpb,
-                elapsed as u64
+                step, val_bpb, best_bpb, elapsed as u64
             );
         }
     }

--- a/src/bin/trinity_pr1722.rs
+++ b/src/bin/trinity_pr1722.rs
@@ -21,11 +21,18 @@ fn load_data(path: &str) -> Vec<usize> {
 }
 
 fn softmax_cap(v: &mut [f32], softcap: f32) {
-    for x in v.iter_mut() { *x = (*x / softcap).tanh() * softcap; }
+    for x in v.iter_mut() {
+        *x = (*x / softcap).tanh() * softcap;
+    }
     let max = v.iter().cloned().fold(f32::NEG_INFINITY, f32::max);
     let mut sum = 0.0f32;
-    for x in v.iter_mut() { *x = (*x - max).exp(); sum += *x; }
-    for x in v.iter_mut() { *x /= sum; }
+    for x in v.iter_mut() {
+        *x = (*x - max).exp();
+        sum += *x;
+    }
+    for x in v.iter_mut() {
+        *x /= sum;
+    }
 }
 
 fn layer_norm(x: &[f32], eps: f32) -> Vec<f32> {
@@ -50,8 +57,13 @@ impl AdamW {
     fn new(size: usize, _lr: f32, wd: f32) -> Self {
         let phi = (1.0 + 5.0f64.sqrt()) / 2.0;
         Self {
-            m: vec![0.0; size], v: vec![0.0; size], step: 0,
-            beta1: 1.0 / phi as f32, beta2: 0.999, eps: 1e-8, wd,
+            m: vec![0.0; size],
+            v: vec![0.0; size],
+            step: 0,
+            beta1: 1.0 / phi as f32,
+            beta2: 0.999,
+            eps: 1e-8,
+            wd,
         }
     }
     fn update(&mut self, params: &mut [f32], grads: &[f32], lr: f32) {
@@ -91,10 +103,20 @@ struct TrinityCpuModel {
 }
 
 impl TrinityCpuModel {
-    fn new(vocab: usize, dim: usize, ctx_dim: usize, bv: usize, bd: usize, ve_dim: usize, seed: u64) -> Self {
+    fn new(
+        vocab: usize,
+        dim: usize,
+        ctx_dim: usize,
+        bv: usize,
+        bd: usize,
+        ve_dim: usize,
+        seed: u64,
+    ) -> Self {
         let mut s = seed;
         let mut rng = || {
-            s = s.wrapping_mul(6364136223846793005).wrapping_add(1442695040888963407);
+            s = s
+                .wrapping_mul(6364136223846793005)
+                .wrapping_add(1442695040888963407);
             let t = ((s >> 33) as f32) / (u32::MAX as f32);
             (t * 2.0 - 1.0) * (6.0f32 / (vocab + dim) as f32).sqrt()
         };
@@ -107,7 +129,12 @@ impl TrinityCpuModel {
             lm_head: (0..vocab * total_dim).map(|_| rng()).collect(),
             ve_proj: (0..ve_dim * total_dim).map(|_| rng()).collect(),
             ve_scale: vec![1.0f32; 2],
-            vocab, dim, ctx_dim, bigram_vocab: bv, bigram_dim: bd, ve_dim,
+            vocab,
+            dim,
+            ctx_dim,
+            bigram_vocab: bv,
+            bigram_dim: bd,
+            ve_dim,
         }
     }
 
@@ -128,8 +155,12 @@ impl TrinityCpuModel {
         let c_prev = &self.ctx_embed[prev_idx * cd..(prev_idx + 1) * cd];
         let b_hash = &self.bigram_embed[bh * bd..(bh + 1) * bd];
 
-        for j in 0..cd { repr[j] = e_cur[j] + c_prev[j]; }
-        for j in 0..bd { repr[cd + j] = e_cur[cd + j] + b_hash[j] * 0.1; }
+        for j in 0..cd {
+            repr[j] = e_cur[j] + c_prev[j];
+        }
+        for j in 0..bd {
+            repr[cd + j] = e_cur[cd + j] + b_hash[j] * 0.1;
+        }
         for j in 0..vd {
             let mut ve_val = 0.0f32;
             for (k, r) in repr.iter().enumerate().take(total) {
@@ -138,7 +169,11 @@ impl TrinityCpuModel {
             repr[cd + bd + j] = e_cur[cd + bd + j] + ve_val * self.ve_scale[0];
         }
 
-        let _sg: Vec<f32> = self.smear_gate.iter().map(|&g| 1.0 / (1.0 + (-g).exp())).collect();
+        let _sg: Vec<f32> = self
+            .smear_gate
+            .iter()
+            .map(|&g| 1.0 / (1.0 + (-g).exp()))
+            .collect();
         for r in repr.iter_mut() {
             *r *= 1.0;
         }
@@ -147,7 +182,9 @@ impl TrinityCpuModel {
     }
 
     fn loss_on_seq(&self, tokens: &[usize]) -> f32 {
-        if tokens.len() < 3 { return 0.0; }
+        if tokens.len() < 3 {
+            return 0.0;
+        }
         let v = self.vocab;
         let total = self.ctx_dim + self.bigram_dim + self.ve_dim;
         let mut total_loss = 0.0f32;
@@ -156,10 +193,12 @@ impl TrinityCpuModel {
             let repr = self.get_repr(tokens[i - 1], tokens[i]);
             let target = tokens[i + 1].min(v - 1);
 
-            let mut logits: Vec<f32> = (0..v).map(|vi| {
-                let w = &self.lm_head[vi * total..(vi + 1) * total];
-                repr.iter().zip(w.iter()).map(|(a, b)| a * b).sum::<f32>()
-            }).collect();
+            let mut logits: Vec<f32> = (0..v)
+                .map(|vi| {
+                    let w = &self.lm_head[vi * total..(vi + 1) * total];
+                    repr.iter().zip(w.iter()).map(|(a, b)| a * b).sum::<f32>()
+                })
+                .collect();
             softmax_cap(&mut logits, LOGIT_SOFTCAP);
 
             let p = logits[target].max(1e-10);
@@ -168,9 +207,18 @@ impl TrinityCpuModel {
         total_loss / (tokens.len() - 2) as f32
     }
 
-    fn train_step(&mut self, tokens: &[usize], lr: f32,
-        opt_e: &mut AdamW, opt_c: &mut AdamW, opt_b: &mut AdamW, opt_h: &mut AdamW) {
-        if tokens.len() < 3 { return; }
+    fn train_step(
+        &mut self,
+        tokens: &[usize],
+        lr: f32,
+        opt_e: &mut AdamW,
+        opt_c: &mut AdamW,
+        opt_b: &mut AdamW,
+        opt_h: &mut AdamW,
+    ) {
+        if tokens.len() < 3 {
+            return;
+        }
         let v = self.vocab;
         let total = self.ctx_dim + self.bigram_dim + self.ve_dim;
         let cd = self.ctx_dim;
@@ -189,10 +237,12 @@ impl TrinityCpuModel {
 
             let repr = self.get_repr(prev, cur);
 
-            let mut logits: Vec<f32> = (0..v).map(|vi| {
-                let w = &self.lm_head[vi * total..(vi + 1) * total];
-                repr.iter().zip(w.iter()).map(|(a, b)| a * b).sum::<f32>()
-            }).collect();
+            let mut logits: Vec<f32> = (0..v)
+                .map(|vi| {
+                    let w = &self.lm_head[vi * total..(vi + 1) * total];
+                    repr.iter().zip(w.iter()).map(|(a, b)| a * b).sum::<f32>()
+                })
+                .collect();
             softmax_cap(&mut logits, LOGIT_SOFTCAP);
 
             for (vi, prob) in logits.iter().enumerate() {
@@ -212,10 +262,18 @@ impl TrinityCpuModel {
         }
 
         let n = (tokens.len() - 2) as f32;
-        for g in grad_embed.iter_mut() { *g /= n; }
-        for g in grad_ctx.iter_mut() { *g /= n; }
-        for g in grad_bigram.iter_mut() { *g /= n; }
-        for g in grad_head.iter_mut() { *g /= n; }
+        for g in grad_embed.iter_mut() {
+            *g /= n;
+        }
+        for g in grad_ctx.iter_mut() {
+            *g /= n;
+        }
+        for g in grad_bigram.iter_mut() {
+            *g /= n;
+        }
+        for g in grad_head.iter_mut() {
+            *g /= n;
+        }
 
         opt_e.update(&mut self.embed, &grad_embed, lr);
         opt_c.update(&mut self.ctx_embed, &grad_ctx, lr);
@@ -236,17 +294,26 @@ fn evaluate(model: &TrinityCpuModel, tokens: &[usize], seq_len: usize) -> (f32, 
     let mut n = 0usize;
     for c in (0..tokens.len()).step_by(seq_len + 1) {
         let end = (c + seq_len + 1).min(tokens.len());
-        if end - c < 4 { continue; }
+        if end - c < 4 {
+            continue;
+        }
         let loss = model.loss_on_seq(&tokens[c..end]);
-        if loss.is_finite() { total += loss / LN_2; n += 1; }
+        if loss.is_finite() {
+            total += loss / LN_2;
+            n += 1;
+        }
     }
-    if n == 0 { return (f32::MAX, f32::MAX); }
+    if n == 0 {
+        return (f32::MAX, f32::MAX);
+    }
     let bpb = total / n as f32;
     (bpb * LN_2, bpb)
 }
 
 fn cosine_lr(step: usize, max_steps: usize, base_lr: f32, warmup: usize) -> f32 {
-    if step < warmup { return base_lr * step as f32 / warmup as f32; }
+    if step < warmup {
+        return base_lr * step as f32 / warmup as f32;
+    }
     let progress = (step - warmup) as f32 / (max_steps - warmup).max(1) as f32;
     let cosine = 0.5 * (1.0 + (std::f32::consts::PI * progress).cos());
     1e-5 + (base_lr - 1e-5) * cosine
@@ -267,9 +334,14 @@ fn main() {
         .unwrap_or(0.003);
 
     println!("=== Trinity CPU Model (PR#1722 params adapted) ===");
-    println!("arch: vocab={} ctx_dim={} bigram={}x{} ve_dim={} seq={} softcap={}", 
-        VOCAB, CTX_DIM, BIGRAM_VOCAB, BIGRAM_DIM, 16, SEQ, LOGIT_SOFTCAP);
-    println!("opt: AdamW(phi beta1) wd=0.04 lr={} steps={} seed={}", base_lr, steps, seed);
+    println!(
+        "arch: vocab={} ctx_dim={} bigram={}x{} ve_dim={} seq={} softcap={}",
+        VOCAB, CTX_DIM, BIGRAM_VOCAB, BIGRAM_DIM, 16, SEQ, LOGIT_SOFTCAP
+    );
+    println!(
+        "opt: AdamW(phi beta1) wd=0.04 lr={} steps={} seed={}",
+        base_lr, steps, seed
+    );
     println!();
 
     let tokens = load_data("data/tinyshakespeare.txt");
@@ -277,7 +349,8 @@ fn main() {
 
     let total_dim = CTX_DIM + BIGRAM_DIM + 16;
     let mut model = TrinityCpuModel::new(VOCAB, DIM, CTX_DIM, BIGRAM_VOCAB, BIGRAM_DIM, 16, seed);
-    let mut ema_model = TrinityCpuModel::new(VOCAB, DIM, CTX_DIM, BIGRAM_VOCAB, BIGRAM_DIM, 16, seed);
+    let mut ema_model =
+        TrinityCpuModel::new(VOCAB, DIM, CTX_DIM, BIGRAM_VOCAB, BIGRAM_DIM, 16, seed);
 
     let mut opt_e = AdamW::new(VOCAB * total_dim, base_lr, 0.04);
     let mut opt_c = AdamW::new(VOCAB * CTX_DIM, base_lr, 0.04);
@@ -287,7 +360,10 @@ fn main() {
     let (init_loss, init_bpb) = evaluate(&model, &tokens, SEQ);
     println!("Initial: loss={:.4} bpb={:.4}", init_loss, init_bpb);
     println!();
-    println!("{:>6} | {:>10} | {:>10} | {:>10} | {:>8}", "step", "loss", "bpb", "best_bpb", "ms");
+    println!(
+        "{:>6} | {:>10} | {:>10} | {:>10} | {:>8}",
+        "step", "loss", "bpb", "best_bpb", "ms"
+    );
     println!("{}", "-".repeat(60));
 
     let t0 = Instant::now();
@@ -302,18 +378,24 @@ fn main() {
         model.train_step(seq, lr, &mut opt_e, &mut opt_c, &mut opt_b, &mut opt_h);
 
         for i in 0..model.embed.len() {
-            ema_model.embed[i] = ema_model.embed[i] * EMA_DECAY + model.embed[i] * (1.0 - EMA_DECAY);
+            ema_model.embed[i] =
+                ema_model.embed[i] * EMA_DECAY + model.embed[i] * (1.0 - EMA_DECAY);
         }
         for i in 0..model.lm_head.len() {
-            ema_model.lm_head[i] = ema_model.lm_head[i] * EMA_DECAY + model.lm_head[i] * (1.0 - EMA_DECAY);
+            ema_model.lm_head[i] =
+                ema_model.lm_head[i] * EMA_DECAY + model.lm_head[i] * (1.0 - EMA_DECAY);
         }
 
         if step % 500 == 0 || step == steps {
             let ms = t0.elapsed().as_millis();
             let (eval_loss, eval_bpb) = evaluate(&ema_model, &tokens, SEQ);
-            if eval_bpb < best_bpb && eval_bpb.is_finite() { best_bpb = eval_bpb; }
-            println!("{:>6} | {:>10.4} | {:>10.4} | {:>10.4} | {:>6}ms",
-                step, eval_loss, eval_bpb, best_bpb, ms);
+            if eval_bpb < best_bpb && eval_bpb.is_finite() {
+                best_bpb = eval_bpb;
+            }
+            println!(
+                "{:>6} | {:>10.4} | {:>10.4} | {:>10.4} | {:>6}ms",
+                step, eval_loss, eval_bpb, best_bpb, ms
+            );
             results.push((step, eval_loss, eval_bpb));
         }
     }
@@ -321,8 +403,13 @@ fn main() {
     let total = t0.elapsed();
     println!();
     println!("=== Training Complete ===");
-    println!("Time: {:.1}s | Initial BPB: {:.4} | Final BPB: {:.4} (EMA) | Delta: {:.4}",
-        total.as_secs_f64(), init_bpb, best_bpb, best_bpb - init_bpb);
+    println!(
+        "Time: {:.1}s | Initial BPB: {:.4} | Final BPB: {:.4} (EMA) | Delta: {:.4}",
+        total.as_secs_f64(),
+        init_bpb,
+        best_bpb,
+        best_bpb - init_bpb
+    );
 
     let _ = fs::create_dir_all(".trinity/results");
     let result_json = serde_json::json!({
@@ -345,19 +432,33 @@ fn main() {
     });
 
     let rpath = format!(".trinity/results/trinity_pr1722_seed{}.json", seed);
-    fs::File::create(&rpath).unwrap()
-        .write_all(serde_json::to_string_pretty(&result_json).unwrap().as_bytes()).unwrap();
+    fs::File::create(&rpath)
+        .unwrap()
+        .write_all(
+            serde_json::to_string_pretty(&result_json)
+                .unwrap()
+                .as_bytes(),
+        )
+        .unwrap();
     println!("Results: {}", rpath);
 
     let ts = chrono::Utc::now().format("%Y-%m-%dT%H:%M:%SZ");
     let edir = ".trinity/experience";
     let _ = fs::create_dir_all(edir);
-    let epath = format!("{}/trios_{}.trinity", edir, chrono::Utc::now().format("%Y%m%d"));
+    let epath = format!(
+        "{}/trios_{}.trinity",
+        edir,
+        chrono::Utc::now().format("%Y%m%d")
+    );
     let entry = format!(
         "[{}] TASK: Trinity PR#1722 adapted training | seed={} | steps={} | bpb={:.4}->{:.4} | delta={:.4} | {:.1}s\n",
         ts, seed, steps, init_bpb, best_bpb, best_bpb - init_bpb, total.as_secs_f64()
     );
-    let _ = fs::OpenOptions::new().create(true).append(true)
-        .open(&epath).unwrap().write_all(entry.as_bytes());
+    let _ = fs::OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(&epath)
+        .unwrap()
+        .write_all(entry.as_bytes());
     println!("Experience: {}", epath);
 }

--- a/src/bin/trios-train.rs
+++ b/src/bin/trios-train.rs
@@ -16,7 +16,10 @@ use clap::Parser;
 use trios_trainer::train_loop::{self, TrainArgs, GATE_FINAL_SEEDS};
 
 #[derive(Parser, Debug)]
-#[command(name = "trios-train", about = "IGLA RACE training pipeline (gHashTag/trios#143)")]
+#[command(
+    name = "trios-train",
+    about = "IGLA RACE training pipeline (gHashTag/trios#143)"
+)]
 struct Cli {
     /// Path to TOML config (optional; standalone mode if omitted).
     #[arg(long, env = "TRIOS_CONFIG")]
@@ -77,13 +80,23 @@ fn main() -> Result<()> {
     if cli.sweep || cli.seed == 0 {
         tracing::info!("3-seed sweep: {:?}", GATE_FINAL_SEEDS);
         let results = train_loop::run_sweep(
-            cli.steps, cli.hidden, cli.lr, cli.attn_layers, cli.eval_every,
-            &cli.train_data, &cli.val_data,
+            cli.steps,
+            cli.hidden,
+            cli.lr,
+            cli.attn_layers,
+            cli.eval_every,
+            &cli.train_data,
+            &cli.val_data,
         )?;
         for r in &results {
-            println!("DONE: seed={} bpb={:.4} steps={}", r.seed, r.final_bpb, r.steps_done);
+            println!(
+                "DONE: seed={} bpb={:.4} steps={}",
+                r.seed, r.final_bpb, r.steps_done
+            );
         }
-        let all_pass = results.iter().all(|r| r.final_bpb < train_loop::DEFAULT_IGLA_TARGET_BPB);
+        let all_pass = results
+            .iter()
+            .all(|r| r.final_bpb < train_loop::DEFAULT_IGLA_TARGET_BPB);
         println!("GATE-2: {}", if all_pass { "PASS" } else { "NOT YET" });
     } else {
         let args = TrainArgs {
@@ -97,7 +110,10 @@ fn main() -> Result<()> {
             val_path: cli.val_data.clone(),
         };
         let outcome = train_loop::run_single(&args)?;
-        println!("DONE: seed={} bpb={:.4} steps={}", outcome.seed, outcome.final_bpb, outcome.steps_done);
+        println!(
+            "DONE: seed={} bpb={:.4} steps={}",
+            outcome.seed, outcome.final_bpb, outcome.steps_done
+        );
     }
 
     Ok(())

--- a/src/config.rs
+++ b/src/config.rs
@@ -56,7 +56,7 @@ pub struct OptimizerConfig {
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct DataConfig {
-    pub corpus: String, // "fineweb" | "tinyshakespeare" | "wikitext-103"
+    pub corpus: String,     // "fineweb" | "tinyshakespeare" | "wikitext-103"
     pub train_path: String, // Path to training data (supports absolute or relative to workdir)
     pub val_path: String,   // Path to validation data
     pub batch_size: usize,

--- a/src/data/mod.rs
+++ b/src/data/mod.rs
@@ -1,7 +1,7 @@
 pub mod tokenizer;
 
-use anyhow::Result;
 use crate::config::DataConfig;
+use anyhow::Result;
 
 pub struct DataPipeline {
     pub corpus: String,
@@ -17,5 +17,5 @@ pub fn build(cfg: &DataConfig) -> Result<DataPipeline> {
     })
 }
 
-pub use tokenizer::BPETokenizer;
 pub use tokenizer::tokenize_batch;
+pub use tokenizer::BPETokenizer;

--- a/src/gf16.rs
+++ b/src/gf16.rs
@@ -16,7 +16,7 @@ pub struct GF16(pub u16);
 impl GF16 {
     // Bit layout: [15: sign] [14:9: exponent (6 bits)] [8:0: mantissa (9 bits)]
     const SIGN_MASK: u16 = 0x8000;
-    const EXP_MASK: u16 = 0x7E00;   // bits 14-9 for 6-bit exponent
+    const EXP_MASK: u16 = 0x7E00; // bits 14-9 for 6-bit exponent
     const MANTISSA_MASK: u16 = 0x01FF; // bits 8-0 for 9-bit mantissa
     const EXP_BIAS: i32 = 15;
 
@@ -35,13 +35,21 @@ impl GF16 {
     #[must_use]
     pub fn from_f32(val: f32) -> Self {
         if val == 0.0 {
-            return if val.is_sign_negative() { Self::NEG_ZERO } else { Self::ZERO };
+            return if val.is_sign_negative() {
+                Self::NEG_ZERO
+            } else {
+                Self::ZERO
+            };
         }
         if val.is_nan() {
             return Self::NAN;
         }
         if !val.is_finite() {
-            return if val.is_sign_negative() { Self::NEG_INF } else { Self::INF };
+            return if val.is_sign_negative() {
+                Self::NEG_INF
+            } else {
+                Self::INF
+            };
         }
 
         let bits = val.to_bits();
@@ -71,7 +79,7 @@ impl GF16 {
     pub fn to_f32(self) -> f32 {
         let bits = self.0;
         let sign = (bits & Self::SIGN_MASK) >> 15;
-        let exp  = (bits & Self::EXP_MASK) >> 9;
+        let exp = (bits & Self::EXP_MASK) >> 9;
         let mantissa = bits & Self::MANTISSA_MASK;
 
         if exp == 0 {
@@ -80,7 +88,11 @@ impl GF16 {
 
         if exp == 63 {
             return if mantissa == 0 {
-                if sign != 0 { f32::NEG_INFINITY } else { f32::INFINITY }
+                if sign != 0 {
+                    f32::NEG_INFINITY
+                } else {
+                    f32::INFINITY
+                }
             } else {
                 f32::NAN
             };
@@ -88,7 +100,11 @@ impl GF16 {
 
         let f32_exp = exp as i32 - Self::EXP_BIAS + 127;
         if !(0..=255).contains(&f32_exp) {
-            return if sign != 0 { f32::NEG_INFINITY } else { f32::INFINITY };
+            return if sign != 0 {
+                f32::NEG_INFINITY
+            } else {
+                f32::INFINITY
+            };
         }
 
         let f32_mant = (mantissa as u32) << (23 - 9);
@@ -222,7 +238,9 @@ pub struct GF16Vec {
 impl GF16Vec {
     #[must_use]
     pub fn new(capacity: usize) -> Self {
-        GF16Vec { data: Vec::with_capacity(capacity) }
+        GF16Vec {
+            data: Vec::with_capacity(capacity),
+        }
     }
 
     pub fn push(&mut self, val: f32) {
@@ -312,7 +330,10 @@ mod tests {
     #[test]
     fn test_phi_distance() {
         let pd = GF16::phi_distance();
-        assert!((pd - 0.0486).abs() < 0.001, "φ-distance = {pd}, expected ~0.049");
+        assert!(
+            (pd - 0.0486).abs() < 0.001,
+            "φ-distance = {pd}, expected ~0.049"
+        );
     }
 
     #[test]
@@ -376,10 +397,12 @@ impl QuantizationMetrics {
             let abs_error = ((quant - orig).abs()) as f64;
             let error_pct = abs_error / abs_orig * 100.0;
 
-            if error_pct > max_error { max_error = error_pct; }
+            if error_pct > max_error {
+                max_error = error_pct;
+            }
             sum_error_pct += error_pct;
             sum_abs_error += abs_error;
-            sum_sq_error  += abs_error * abs_error;
+            sum_sq_error += abs_error * abs_error;
         }
 
         let n_f = n as f64;
@@ -396,13 +419,11 @@ impl QuantizationMetrics {
 /// Benchmark GF16 quantization on random weights
 #[must_use]
 pub fn benchmark_quantization(n: usize) -> QuantizationMetrics {
-    use rand::Rng;
     use rand::thread_rng;
+    use rand::Rng;
     let mut rng = thread_rng();
 
-    let original: Vec<f32> = (0..n)
-        .map(|_| rng.gen::<f32>() * 0.2 - 0.1)
-        .collect();
+    let original: Vec<f32> = (0..n).map(|_| rng.gen::<f32>() * 0.2 - 0.1).collect();
 
     let quantized: Vec<f32> = original
         .iter()

--- a/src/invariants.rs
+++ b/src/invariants.rs
@@ -37,7 +37,10 @@ pub const INV4_ENTROPY_EMPIRICAL_LO: f64 = 1.5;
 pub const INV4_ENTROPY_EMPIRICAL_HI: f64 = 2.8;
 
 #[derive(Debug, Clone, PartialEq)]
-pub enum GradientMode { RealMSE, ConstantProxy(f64) }
+pub enum GradientMode {
+    RealMSE,
+    ConstantProxy(f64),
+}
 
 #[derive(Debug, Clone, PartialEq)]
 pub enum InvError {
@@ -53,11 +56,20 @@ impl std::fmt::Display for InvError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             InvError::Inv1BadGradient => write!(f, "INV-1 VIOLATED: gradient=ConstantProxy"),
-            InvError::Inv1LrOutOfBand(lr) => write!(f, "INV-1 VIOLATED: lr={lr} outside φ-safe [{INV1_LR_SAFE_LO}, {INV1_LR_SAFE_HI}]"),
+            InvError::Inv1LrOutOfBand(lr) => write!(
+                f,
+                "INV-1 VIOLATED: lr={lr} outside φ-safe [{INV1_LR_SAFE_LO}, {INV1_LR_SAFE_HI}]"
+            ),
             InvError::Inv2ThresholdTooLow(t) => write!(f, "INV-2 VIOLATED: threshold={t} < 3.5"),
-            InvError::Inv3UnsafeDomain(d) => write!(f, "INV-3 VIOLATED: GF16 with d_model={d} < 256"),
-            InvError::Inv4GridMismatch { grid, k } => write!(f, "INV-4 VIOLATED: NCA grid={grid} K={k}, expected 81/9"),
-            InvError::Inv5LucasClosureBroken => write!(f, "INV-5 VIOLATED: GF16 Lucas closure broken"),
+            InvError::Inv3UnsafeDomain(d) => {
+                write!(f, "INV-3 VIOLATED: GF16 with d_model={d} < 256")
+            }
+            InvError::Inv4GridMismatch { grid, k } => {
+                write!(f, "INV-4 VIOLATED: NCA grid={grid} K={k}, expected 81/9")
+            }
+            InvError::Inv5LucasClosureBroken => {
+                write!(f, "INV-5 VIOLATED: GF16 Lucas closure broken")
+            }
         }
     }
 }
@@ -92,7 +104,10 @@ pub fn validate_inv_config(cfg: &InvTrialConfig) -> Result<(), InvError> {
     }
     if cfg.nca_grid > 0 {
         if cfg.nca_grid != INV4_NCA_GRID || cfg.nca_k_states != INV4_NCA_K_STATES {
-            return Err(InvError::Inv4GridMismatch { grid: cfg.nca_grid, k: cfg.nca_k_states });
+            return Err(InvError::Inv4GridMismatch {
+                grid: cfg.nca_grid,
+                k: cfg.nca_k_states,
+            });
         }
     }
     Ok(())
@@ -111,31 +126,69 @@ pub struct TrialConfig {
 }
 
 pub fn validate_config(cfg: &TrialConfig) {
-    assert!(cfg.lr >= LR_SAFE_MIN && cfg.lr <= LR_SAFE_MAX,
-        "INV-1 VIOLATION: lr={} not in [{}, {}]", cfg.lr, LR_SAFE_MIN, LR_SAFE_MAX);
+    assert!(
+        cfg.lr >= LR_SAFE_MIN && cfg.lr <= LR_SAFE_MAX,
+        "INV-1 VIOLATION: lr={} not in [{}, {}]",
+        cfg.lr,
+        LR_SAFE_MIN,
+        LR_SAFE_MAX
+    );
     assert!(cfg.lr > 0.0, "INV-1: lr must be positive, got {}", cfg.lr);
     if cfg.use_gf16 {
-        assert!(cfg.d_model >= GF16_SAFE_D_MODEL,
-            "INV-3 VIOLATION: GF16 requires d_model≥{}, got {}", GF16_SAFE_D_MODEL, cfg.d_model);
+        assert!(
+            cfg.d_model >= GF16_SAFE_D_MODEL,
+            "INV-3 VIOLATION: GF16 requires d_model≥{}, got {}",
+            GF16_SAFE_D_MODEL,
+            cfg.d_model
+        );
     }
     assert!(cfg.d_model > 0, "INV-3: d_model must be positive");
-    assert!(cfg.nca_weight >= 0.0 && cfg.nca_weight <= 1.0,
-        "INV-4 VIOLATION: nca_weight={} not in [0,1]", cfg.nca_weight);
+    assert!(
+        cfg.nca_weight >= 0.0 && cfg.nca_weight <= 1.0,
+        "INV-4 VIOLATION: nca_weight={} not in [0,1]",
+        cfg.nca_weight
+    );
     assert!(cfg.ntp_weight > 0.0, "INV-1: ntp_weight must be positive");
-    assert!(cfg.steps > 0 && cfg.steps <= ASHA_RUNGS[3] * 2,
-        "INV-2 VIOLATION: steps={} out of ASHA bounds [1, {}]", cfg.steps, ASHA_RUNGS[3] * 2);
+    assert!(
+        cfg.steps > 0 && cfg.steps <= ASHA_RUNGS[3] * 2,
+        "INV-2 VIOLATION: steps={} out of ASHA bounds [1, {}]",
+        cfg.steps,
+        ASHA_RUNGS[3] * 2
+    );
 }
 
 pub fn validate_bpb(bpb: f64, trial_id: &str) {
-    assert!(bpb > 0.0 && bpb < 20.0, "L-METRIC VIOLATION: BPB={:.4} out of range (0, 20) for trial {}", bpb, trial_id);
-    assert!(bpb > 0.1, "L-METRIC VIOLATION: BPB={:.4} suspiciously low for trial {}", bpb, trial_id);
+    assert!(
+        bpb > 0.0 && bpb < 20.0,
+        "L-METRIC VIOLATION: BPB={:.4} out of range (0, 20) for trial {}",
+        bpb,
+        trial_id
+    );
+    assert!(
+        bpb > 0.1,
+        "L-METRIC VIOLATION: BPB={:.4} suspiciously low for trial {}",
+        bpb,
+        trial_id
+    );
 }
 
 pub fn validate_nca_entropy(entropy: f64) {
-    assert!(entropy >= NCA_ENTROPY_LO, "INV-4 VIOLATION: entropy={:.4} < φ={:.4}", entropy, NCA_ENTROPY_LO);
-    assert!(entropy <= NCA_ENTROPY_HI, "INV-4 VIOLATION: entropy={:.4} > φ²={:.4}", entropy, NCA_ENTROPY_HI);
-    assert!((NCA_ENTROPY_HI - NCA_ENTROPY_LO - NCA_ENTROPY_WIDTH).abs() < 1e-10,
-        "INV-4 INTERNAL: band width != 1 — Trinity constants corrupted!");
+    assert!(
+        entropy >= NCA_ENTROPY_LO,
+        "INV-4 VIOLATION: entropy={:.4} < φ={:.4}",
+        entropy,
+        NCA_ENTROPY_LO
+    );
+    assert!(
+        entropy <= NCA_ENTROPY_HI,
+        "INV-4 VIOLATION: entropy={:.4} > φ²={:.4}",
+        entropy,
+        NCA_ENTROPY_HI
+    );
+    assert!(
+        (NCA_ENTROPY_HI - NCA_ENTROPY_LO - NCA_ENTROPY_WIDTH).abs() < 1e-10,
+        "INV-4 INTERNAL: band width != 1 — Trinity constants corrupted!"
+    );
 }
 
 #[cfg(test)]
@@ -145,32 +198,64 @@ mod tests {
     fn test_trinity_identity() {
         let phi_inv = 1.0 / PHI;
         let result = PHI * PHI + phi_inv * phi_inv;
-        assert!((result - TRINITY_IDENTITY).abs() < 1e-10, "φ²+φ⁻²={result:.10} ≠ 3");
+        assert!(
+            (result - TRINITY_IDENTITY).abs() < 1e-10,
+            "φ²+φ⁻²={result:.10} ≠ 3"
+        );
     }
     #[test]
-    fn test_phi_sq_eq_phi_plus_one() { assert!((PHI_SQ - (PHI + 1.0)).abs() < 1e-10); }
+    fn test_phi_sq_eq_phi_plus_one() {
+        assert!((PHI_SQ - (PHI + 1.0)).abs() < 1e-10);
+    }
     #[test]
-    fn test_entropy_band_width_exact() { assert!((NCA_ENTROPY_HI - NCA_ENTROPY_LO - 1.0).abs() < 1e-10); }
+    fn test_entropy_band_width_exact() {
+        assert!((NCA_ENTROPY_HI - NCA_ENTROPY_LO - 1.0).abs() < 1e-10);
+    }
     #[test]
-    fn test_champion_bpb_survives_asha() { assert!(BPB_CHAMPION < ASHA_PRUNE_THRESHOLD); }
+    fn test_champion_bpb_survives_asha() {
+        assert!(BPB_CHAMPION < ASHA_PRUNE_THRESHOLD);
+    }
     #[test]
-    fn test_lr_champion_in_safe_range() { assert!(LR_CHAMPION >= LR_SAFE_MIN); assert!(LR_CHAMPION <= LR_SAFE_MAX); }
+    fn test_lr_champion_in_safe_range() {
+        assert!(LR_CHAMPION >= LR_SAFE_MIN);
+        assert!(LR_CHAMPION <= LR_SAFE_MAX);
+    }
     #[test]
     fn test_gf16_precision_floor() {
         let phi_inv6 = (1.0_f64 / PHI).powi(6);
         assert!((phi_inv6 - PHI_INV6).abs() < 1e-8);
     }
     #[test]
-    fn test_alpha_phi_matches_strong_coupling() { assert!((ALPHA_PHI - 0.1180_f64).abs() < 0.001); }
+    fn test_alpha_phi_matches_strong_coupling() {
+        assert!((ALPHA_PHI - 0.1180_f64).abs() < 0.001);
+    }
     #[test]
     fn test_validate_config_champion() {
-        validate_config(&TrialConfig { lr: LR_CHAMPION, d_model: 384, seed: 43, steps: 27_000,
-            nca_weight: 0.25, jepa_weight: 1.0, ntp_weight: 1.0, use_gf16: false });
+        validate_config(&TrialConfig {
+            lr: LR_CHAMPION,
+            d_model: 384,
+            seed: 43,
+            steps: 27_000,
+            nca_weight: 0.25,
+            jepa_weight: 1.0,
+            ntp_weight: 1.0,
+            use_gf16: false,
+        });
     }
     #[test]
     fn test_validate_config_gf16_guard() {
-        let r = std::panic::catch_unwind(|| validate_config(&TrialConfig { lr: 0.004, d_model: 128, seed: 42,
-            steps: 3_000, nca_weight: 0.25, jepa_weight: 1.0, ntp_weight: 1.0, use_gf16: true }));
+        let r = std::panic::catch_unwind(|| {
+            validate_config(&TrialConfig {
+                lr: 0.004,
+                d_model: 128,
+                seed: 42,
+                steps: 3_000,
+                nca_weight: 0.25,
+                jepa_weight: 1.0,
+                ntp_weight: 1.0,
+                use_gf16: true,
+            })
+        });
         assert!(r.is_err());
     }
     #[test]
@@ -180,7 +265,11 @@ mod tests {
     }
     #[test]
     fn test_lucas_sequence() {
-        assert_eq!(LUCAS[2], 3); assert_eq!(LUCAS[4], 7); assert_eq!(LUCAS[6], 18);
-        for i in 2..LUCAS.len() { assert_eq!(LUCAS[i], LUCAS[i-1] + LUCAS[i-2]); }
+        assert_eq!(LUCAS[2], 3);
+        assert_eq!(LUCAS[4], 7);
+        assert_eq!(LUCAS[6], 18);
+        for i in 2..LUCAS.len() {
+            assert_eq!(LUCAS[i], LUCAS[i - 1] + LUCAS[i - 2]);
+        }
     }
 }

--- a/src/jepa/ema.rs
+++ b/src/jepa/ema.rs
@@ -5,9 +5,9 @@
 /// EMA configuration
 #[derive(Debug, Clone, Copy)]
 pub struct EmaConfig {
-    pub start: f64,  // Starting decay rate (0.996)
-    pub end: f64,    // Target decay rate (1.0)
-    pub ramp_steps: usize,  // Steps to reach end (30000)
+    pub start: f64,        // Starting decay rate (0.996)
+    pub end: f64,          // Target decay rate (1.0)
+    pub ramp_steps: usize, // Steps to reach end (30000)
 }
 
 impl Default for EmaConfig {
@@ -128,7 +128,11 @@ mod tests {
         }
         // After 50 steps, should be at 0.75 (halfway)
         let decay_50 = ema.decay();
-        assert!((decay_50 - 0.75).abs() < 0.01, "decay at step 50: {}", decay_50);
+        assert!(
+            (decay_50 - 0.75).abs() < 0.01,
+            "decay at step 50: {}",
+            decay_50
+        );
 
         for _ in 50..100 {
             ema.step += 1;

--- a/src/jepa/loss.rs
+++ b/src/jepa/loss.rs
@@ -31,7 +31,11 @@ pub struct JepaLoss {
 impl JepaLoss {
     /// Create a new loss result
     pub fn new(total: f64, prediction: f64, variance: f64) -> Self {
-        Self { total, prediction, variance }
+        Self {
+            total,
+            prediction,
+            variance,
+        }
     }
 
     /// Check if variance indicates collapse (< 0.01)
@@ -52,12 +56,12 @@ impl JepaLoss {
 ///
 /// The total loss is: prediction_loss - variance * anti_collapse_weight
 /// This encourages matching predictions while maintaining representation diversity.
-pub fn compute_jepa_loss(
-    predicted: &[f32],
-    target: &[f32],
-    config: JepaLossConfig,
-) -> JepaLoss {
-    assert_eq!(predicted.len(), target.len(), "predicted and target must have same length");
+pub fn compute_jepa_loss(predicted: &[f32], target: &[f32], config: JepaLossConfig) -> JepaLoss {
+    assert_eq!(
+        predicted.len(),
+        target.len(),
+        "predicted and target must have same length"
+    );
 
     let (pred_norm, tgt_norm) = if config.use_l2_normalization {
         (l2_normalize(predicted), l2_normalize(target))
@@ -70,14 +74,16 @@ pub fn compute_jepa_loss(
         .iter()
         .zip(tgt_norm.iter())
         .map(|(p, t)| (p - t).powi(2) as f64)
-        .sum::<f64>() / pred_norm.len() as f64;
+        .sum::<f64>()
+        / pred_norm.len() as f64;
 
     // Variance computation (for anti-collapse)
     let mean = tgt_norm.iter().sum::<f32>() as f64 / tgt_norm.len() as f64;
     let variance = tgt_norm
         .iter()
         .map(|t| (*t as f64 - mean).powi(2))
-        .sum::<f64>() / tgt_norm.len() as f64;
+        .sum::<f64>()
+        / tgt_norm.len() as f64;
 
     // Total loss with anti-collapse
     let total = prediction_loss - variance * config.anti_collapse_weight;
@@ -112,7 +118,8 @@ pub fn mse_loss(a: &[f32], b: &[f32]) -> f64 {
     a.iter()
         .zip(b.iter())
         .map(|(x, y)| (x - y).powi(2) as f64)
-        .sum::<f64>() / a.len() as f64
+        .sum::<f64>()
+        / a.len() as f64
 }
 
 /// Compute cosine similarity (higher = more similar)

--- a/src/jepa/masking.rs
+++ b/src/jepa/masking.rs
@@ -51,11 +51,7 @@ pub struct MaskResult {
 /// let result = mask_spans(100, MaskConfig::default(), &mut rng);
 /// assert_eq!(result.spans.len(), 2);
 /// ```
-pub fn mask_spans(
-    seq_len: usize,
-    config: MaskConfig,
-    rng: &mut impl Rng,
-) -> MaskResult {
+pub fn mask_spans(seq_len: usize, config: MaskConfig, rng: &mut impl Rng) -> MaskResult {
     let mut mask = vec![false; seq_len];
     let mut spans = Vec::new();
 
@@ -115,9 +111,7 @@ pub fn spans_non_overlapping(spans: &[(usize, usize)]) -> bool {
 }
 
 /// Partition sequence into context and target positions
-pub fn partition_context_target(
-    mask: &[bool],
-) -> (Vec<usize>, Vec<usize>) {
+pub fn partition_context_target(mask: &[bool]) -> (Vec<usize>, Vec<usize>) {
     let mut context = Vec::new();
     let mut target = Vec::new();
 
@@ -135,8 +129,8 @@ pub fn partition_context_target(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use rand::SeedableRng;
     use rand::rngs::StdRng;
+    use rand::SeedableRng;
 
     #[test]
     fn test_mask_ratio_approximate() {

--- a/src/jepa/mod.rs
+++ b/src/jepa/mod.rs
@@ -3,16 +3,18 @@
 //! Implements masked prediction with EMA target encoder.
 //! Based on LeJEPA/LeWorldModel principles.
 
-pub mod masking;
 pub mod ema;
-pub mod predictor;
 pub mod loss;
+pub mod masking;
+pub mod predictor;
 
 // Re-export common types
-pub use masking::{MaskConfig, mask_spans, MaskResult, get_unmasked, get_masked};
-pub use ema::{EmaTarget, EmaConfig, ema_update, compute_decay};
-pub use predictor::{Predictor, PredictorConfig, PredictionOutput};
-pub use loss::{JepaLoss, JepaLossConfig, compute_jepa_loss, l2_normalize, mse_loss, cosine_similarity};
+pub use ema::{compute_decay, ema_update, EmaConfig, EmaTarget};
+pub use loss::{
+    compute_jepa_loss, cosine_similarity, l2_normalize, mse_loss, JepaLoss, JepaLossConfig,
+};
+pub use masking::{get_masked, get_unmasked, mask_spans, MaskConfig, MaskResult};
+pub use predictor::{PredictionOutput, Predictor, PredictorConfig};
 
 /// JEPA training configuration
 #[derive(Debug, Clone)]

--- a/src/jepa/predictor.rs
+++ b/src/jepa/predictor.rs
@@ -50,29 +50,48 @@ pub struct PredictionOutput {
 
 impl PredictionOutput {
     pub fn new(predicted: Vec<f32>, target: Vec<f32>, loss: f64) -> Self {
-        Self { predicted, target, loss }
+        Self {
+            predicted,
+            target,
+            loss,
+        }
     }
 }
 
 /// L2 normalize a vector to unit length (prevents representation collapse)
 pub fn l2_normalize(v: &[f32]) -> Vec<f32> {
     let norm = v.iter().map(|x| x.powi(2)).sum::<f32>().sqrt();
-    if norm < 1e-8 { v.to_vec() } else { v.iter().map(|x| x / norm).collect() }
+    if norm < 1e-8 {
+        v.to_vec()
+    } else {
+        v.iter().map(|x| x / norm).collect()
+    }
 }
 
 /// Jacobian of L2 normalization: grad_in = (grad_out - (grad_out · x_norm)*x_norm) / norm
 fn l2_norm_backward(grad_out: &[f32], x_norm: &[f32], norm: f32) -> Vec<f32> {
-    if norm < 1e-8 { return grad_out.to_vec(); }
+    if norm < 1e-8 {
+        return grad_out.to_vec();
+    }
     let dot: f32 = grad_out.iter().zip(x_norm.iter()).map(|(g, n)| g * n).sum();
-    grad_out.iter().zip(x_norm.iter()).map(|(g, n)| (g - dot * n) / norm).collect()
+    grad_out
+        .iter()
+        .zip(x_norm.iter())
+        .map(|(g, n)| (g - dot * n) / norm)
+        .collect()
 }
 
 /// Softmax with temperature scaling
 pub fn softmax_with_temp(scores: &mut [f32], temperature: f32) {
     let max = scores.iter().cloned().fold(f32::NEG_INFINITY, f32::max);
     let mut sum = 0.0f32;
-    for x in scores.iter_mut() { *x = ((*x - max) / temperature).exp(); sum += *x; }
-    for x in scores.iter_mut() { *x /= sum; }
+    for x in scores.iter_mut() {
+        *x = ((*x - max) / temperature).exp();
+        sum += *x;
+    }
+    for x in scores.iter_mut() {
+        *x /= sum;
+    }
 }
 
 struct ForwardCache {
@@ -110,14 +129,23 @@ impl JepaPredictor {
         let scale = (6.0 / (d_model + d_key) as f64).sqrt() as f32;
         let mut s = 42u64;
         let mut rng = || -> f32 {
-            s = s.wrapping_mul(6364136223846793005).wrapping_add(1442695040888963407);
+            s = s
+                .wrapping_mul(6364136223846793005)
+                .wrapping_add(1442695040888963407);
             ((s >> 33) as f32) / (u32::MAX as f32) * 2.0 - 1.0
         };
         let w_q: Vec<f32> = (0..d_model * d_key).map(|_| rng() * scale).collect();
         let w_k: Vec<f32> = (0..d_model * d_key).map(|_| rng() * scale).collect();
         let w_v: Vec<f32> = (0..d_model * d_key).map(|_| rng() * scale).collect();
         let w_out: Vec<f32> = (0..d_key * d_model).map(|_| rng() * scale).collect();
-        Self { config, w_q, w_k, w_v, w_out, optimizer: AdamWCpu::new(total_params, 0.0004) }
+        Self {
+            config,
+            w_q,
+            w_k,
+            w_v,
+            w_out,
+            optimizer: AdamWCpu::new(total_params, 0.0004),
+        }
     }
 
     /// Forward pass, caches intermediates for backward
@@ -135,7 +163,9 @@ impl JepaPredictor {
         let mut context_avg = vec![0.0f32; d];
         if seq_len > 0 {
             for i in 0..d {
-                for s in 0..seq_len { context_avg[i] += context_embeddings[s * d + i]; }
+                for s in 0..seq_len {
+                    context_avg[i] += context_embeddings[s * d + i];
+                }
                 context_avg[i] /= seq_len as f32;
             }
         }
@@ -143,14 +173,18 @@ impl JepaPredictor {
         // Q = context_avg @ W_q  [dk]
         let mut q = vec![0.0f32; dk];
         for i in 0..dk {
-            for j in 0..d { q[i] += context_avg[j] * self.w_q[j * dk + i]; }
+            for j in 0..d {
+                q[i] += context_avg[j] * self.w_q[j * dk + i];
+            }
         }
 
         // K = targets @ W_k  [num_targets * dk]
         let mut k = vec![0.0f32; num_targets * dk];
         for t in 0..num_targets {
             for i in 0..dk {
-                for j in 0..d { k[t * dk + i] += target_embeddings[t * d + j] * self.w_k[j * dk + i]; }
+                for j in 0..d {
+                    k[t * dk + i] += target_embeddings[t * d + j] * self.w_k[j * dk + i];
+                }
             }
         }
 
@@ -158,7 +192,9 @@ impl JepaPredictor {
         let mut v = vec![0.0f32; num_targets * dk];
         for t in 0..num_targets {
             for i in 0..dk {
-                for j in 0..d { v[t * dk + i] += target_embeddings[t * d + j] * self.w_v[j * dk + i]; }
+                for j in 0..d {
+                    v[t * dk + i] += target_embeddings[t * d + j] * self.w_v[j * dk + i];
+                }
             }
         }
 
@@ -166,7 +202,9 @@ impl JepaPredictor {
         let scale_factor = (dk as f32).sqrt();
         let mut attn_scores_raw = vec![0.0f32; num_targets];
         for t in 0..num_targets {
-            for i in 0..dk { attn_scores_raw[t] += q[i] * k[t * dk + i]; }
+            for i in 0..dk {
+                attn_scores_raw[t] += q[i] * k[t * dk + i];
+            }
             attn_scores_raw[t] /= scale_factor;
         }
 
@@ -177,23 +215,46 @@ impl JepaPredictor {
         // Attn out = weights @ V  [dk]
         let mut attn_out = vec![0.0f32; dk];
         for i in 0..dk {
-            for t in 0..num_targets { attn_out[i] += attn_weights[t] * v[t * dk + i]; }
+            for t in 0..num_targets {
+                attn_out[i] += attn_weights[t] * v[t * dk + i];
+            }
         }
 
         // Out = attn_out @ W_out  [d]
         let mut predicted_prenorm = vec![0.0f32; d];
         for i in 0..d {
-            for j in 0..dk { predicted_prenorm[i] += attn_out[j] * self.w_out[j * d + i]; }
+            for j in 0..dk {
+                predicted_prenorm[i] += attn_out[j] * self.w_out[j * d + i];
+            }
         }
 
         // L2 normalize
-        let pred_norm_val = predicted_prenorm.iter().map(|x| x.powi(2)).sum::<f32>().sqrt();
-        let predicted_norm = if self.config.use_l2_norm { l2_normalize(&predicted_prenorm) } else { predicted_prenorm.clone() };
+        let pred_norm_val = predicted_prenorm
+            .iter()
+            .map(|x| x.powi(2))
+            .sum::<f32>()
+            .sqrt();
+        let predicted_norm = if self.config.use_l2_norm {
+            l2_normalize(&predicted_prenorm)
+        } else {
+            predicted_prenorm.clone()
+        };
         let target_norm = l2_normalize(&target_embeddings[..d]);
 
-        ForwardCache { context_avg, q, k, v, attn_scores_raw, attn_weights, attn_out,
-            predicted_prenorm, predicted_norm, predicted_norm_val: pred_norm_val,
-            target_norm, num_targets }
+        ForwardCache {
+            context_avg,
+            q,
+            k,
+            v,
+            attn_scores_raw,
+            attn_weights,
+            attn_out,
+            predicted_prenorm,
+            predicted_norm,
+            predicted_norm_val: pred_norm_val,
+            target_norm,
+            num_targets,
+        }
     }
 
     /// Real backward pass + AdamW update. Returns MSE loss.
@@ -203,25 +264,40 @@ impl JepaPredictor {
         target_embeddings: &[f32],
         num_targets: usize,
     ) -> f32 {
-        if num_targets == 0 { return 0.0; }
-        let d  = self.config.d_model;
+        if num_targets == 0 {
+            return 0.0;
+        }
+        let d = self.config.d_model;
         let dk = self.config.d_key;
 
         let cache = self.forward_with_cache(context_embeddings, target_embeddings, num_targets);
 
         // MSE loss on first target (representative)
-        let loss: f32 = cache.predicted_norm.iter().zip(cache.target_norm.iter())
-            .map(|(p, t)| (p - t).powi(2)).sum::<f32>() / d as f32;
+        let loss: f32 = cache
+            .predicted_norm
+            .iter()
+            .zip(cache.target_norm.iter())
+            .map(|(p, t)| (p - t).powi(2))
+            .sum::<f32>()
+            / d as f32;
 
         // ── BACKWARD ───────────────────────────────────────────────────────────────
 
         // 1. dL/d_predicted_norm = 2*(pred_norm - tgt_norm)/d
-        let dl_dpred_norm: Vec<f32> = cache.predicted_norm.iter().zip(cache.target_norm.iter())
-            .map(|(p, t)| 2.0 * (p - t) / d as f32).collect();
+        let dl_dpred_norm: Vec<f32> = cache
+            .predicted_norm
+            .iter()
+            .zip(cache.target_norm.iter())
+            .map(|(p, t)| 2.0 * (p - t) / d as f32)
+            .collect();
 
         // 2. Through L2 norm: dL/d_predicted_prenorm
         let dl_dpred = if self.config.use_l2_norm {
-            l2_norm_backward(&dl_dpred_norm, &cache.predicted_norm, cache.predicted_norm_val)
+            l2_norm_backward(
+                &dl_dpred_norm,
+                &cache.predicted_norm,
+                cache.predicted_norm_val,
+            )
         } else {
             dl_dpred_norm.clone()
         };
@@ -229,13 +305,17 @@ impl JepaPredictor {
         // 3. dL/dW_out[j,i] = attn_out[j] * dl_dpred[i]  [dk * d]
         let mut dw_out = vec![0.0f32; dk * d];
         for j in 0..dk {
-            for i in 0..d { dw_out[j * d + i] = cache.attn_out[j] * dl_dpred[i]; }
+            for i in 0..d {
+                dw_out[j * d + i] = cache.attn_out[j] * dl_dpred[i];
+            }
         }
 
         // 4. dL/d_attn_out[j] = sum_i W_out[j,i] * dl_dpred[i]  [dk]
         let mut dl_dattn_out = vec![0.0f32; dk];
         for j in 0..dk {
-            for i in 0..d { dl_dattn_out[j] += self.w_out[j * d + i] * dl_dpred[i]; }
+            for i in 0..d {
+                dl_dattn_out[j] += self.w_out[j * d + i] * dl_dpred[i];
+            }
         }
 
         // 5. Softmax backward: dL/d_attn_scores_raw
@@ -245,43 +325,60 @@ impl JepaPredictor {
         //    where dl/d_weights[t] = dl/d_attn_out · V[t]
         let mut dl_dattn_weights = vec![0.0f32; cache.num_targets];
         for t in 0..cache.num_targets {
-            for i in 0..dk { dl_dattn_weights[t] += dl_dattn_out[i] * cache.v[t * dk + i]; }
+            for i in 0..dk {
+                dl_dattn_weights[t] += dl_dattn_out[i] * cache.v[t * dk + i];
+            }
         }
-        let dot_sw: f32 = dl_dattn_weights.iter().zip(cache.attn_weights.iter()).map(|(g, s)| g * s).sum();
+        let dot_sw: f32 = dl_dattn_weights
+            .iter()
+            .zip(cache.attn_weights.iter())
+            .map(|(g, s)| g * s)
+            .sum();
         let mut dl_dattn_scores = vec![0.0f32; cache.num_targets];
         for t in 0..cache.num_targets {
-            dl_dattn_scores[t] = cache.attn_weights[t] * (dl_dattn_weights[t] - dot_sw) / (dk as f32).sqrt();
+            dl_dattn_scores[t] =
+                cache.attn_weights[t] * (dl_dattn_weights[t] - dot_sw) / (dk as f32).sqrt();
         }
 
         // 6. dL/dV[t,i] = attn_weights[t] * dl_dattn_out[i]  [num_targets * dk]
         let mut dl_dv = vec![0.0f32; cache.num_targets * dk];
         for t in 0..cache.num_targets {
-            for i in 0..dk { dl_dv[t * dk + i] = cache.attn_weights[t] * dl_dattn_out[i]; }
+            for i in 0..dk {
+                dl_dv[t * dk + i] = cache.attn_weights[t] * dl_dattn_out[i];
+            }
         }
 
         // 7. dL/dK[t,i] = dl_dattn_scores[t] * Q[i]  [num_targets * dk]
         let mut dl_dk = vec![0.0f32; cache.num_targets * dk];
         for t in 0..cache.num_targets {
-            for i in 0..dk { dl_dk[t * dk + i] = dl_dattn_scores[t] * cache.q[i]; }
+            for i in 0..dk {
+                dl_dk[t * dk + i] = dl_dattn_scores[t] * cache.q[i];
+            }
         }
 
         // 8. dL/dQ[i] = sum_t dl_dattn_scores[t] * K[t,i]  [dk]
         let mut dl_dq = vec![0.0f32; dk];
         for i in 0..dk {
-            for t in 0..cache.num_targets { dl_dq[i] += dl_dattn_scores[t] * cache.k[t * dk + i]; }
+            for t in 0..cache.num_targets {
+                dl_dq[i] += dl_dattn_scores[t] * cache.k[t * dk + i];
+            }
         }
 
         // 9. dL/dW_q[j,i] = context_avg[j] * dl_dq[i]  [d * dk]
         let mut dw_q = vec![0.0f32; d * dk];
         for j in 0..d {
-            for i in 0..dk { dw_q[j * dk + i] = cache.context_avg[j] * dl_dq[i]; }
+            for i in 0..dk {
+                dw_q[j * dk + i] = cache.context_avg[j] * dl_dq[i];
+            }
         }
 
         // 10. dL/dW_k[j,i] = sum_t target[t,j] * dl_dk[t,i]  [d * dk]
         let mut dw_k = vec![0.0f32; d * dk];
         for j in 0..d {
             for t in 0..cache.num_targets {
-                for i in 0..dk { dw_k[j * dk + i] += target_embeddings[t * d + j] * dl_dk[t * dk + i]; }
+                for i in 0..dk {
+                    dw_k[j * dk + i] += target_embeddings[t * d + j] * dl_dk[t * dk + i];
+                }
             }
         }
 
@@ -289,7 +386,9 @@ impl JepaPredictor {
         let mut dw_v = vec![0.0f32; d * dk];
         for j in 0..d {
             for t in 0..cache.num_targets {
-                for i in 0..dk { dw_v[j * dk + i] += target_embeddings[t * d + j] * dl_dv[t * dk + i]; }
+                for i in 0..dk {
+                    dw_v[j * dk + i] += target_embeddings[t * d + j] * dl_dv[t * dk + i];
+                }
             }
         }
 
@@ -311,9 +410,9 @@ impl JepaPredictor {
         // Scatter updated params back
         let n = d * dk;
         self.w_q.copy_from_slice(&all_params[..n]);
-        self.w_k.copy_from_slice(&all_params[n..2*n]);
-        self.w_v.copy_from_slice(&all_params[2*n..3*n]);
-        self.w_out.copy_from_slice(&all_params[3*n..4*n]);
+        self.w_k.copy_from_slice(&all_params[n..2 * n]);
+        self.w_v.copy_from_slice(&all_params[2 * n..3 * n]);
+        self.w_out.copy_from_slice(&all_params[3 * n..4 * n]);
 
         loss
     }
@@ -326,7 +425,9 @@ impl JepaPredictor {
         target_embeddings: &[f32],
     ) -> Vec<f32> {
         let num_targets = target_positions.len();
-        if num_targets == 0 { return vec![]; }
+        if num_targets == 0 {
+            return vec![];
+        }
         let cache = self.forward_with_cache(context_embeddings, target_embeddings, num_targets);
         cache.predicted_norm
     }
@@ -338,7 +439,11 @@ impl JepaPredictor {
         } else {
             (predicted.to_vec(), target.to_vec())
         };
-        p.iter().zip(t.iter()).map(|(a, b)| (a - b).powi(2) as f64).sum::<f64>() / d as f64
+        p.iter()
+            .zip(t.iter())
+            .map(|(a, b)| (a - b).powi(2) as f64)
+            .sum::<f64>()
+            / d as f64
     }
 
     /// Legacy: proportional gradient (kept for API compat, use forward_backward instead)
@@ -350,8 +455,12 @@ impl JepaPredictor {
         self.w_q.len() + self.w_k.len() + self.w_v.len() + self.w_out.len()
     }
 
-    pub fn config(&self) -> &PredictorConfig { &self.config }
-    pub fn reset_optimizer(&mut self) { self.optimizer.reset(); }
+    pub fn config(&self) -> &PredictorConfig {
+        &self.config
+    }
+    pub fn reset_optimizer(&mut self) {
+        self.optimizer.reset();
+    }
 }
 
 /// Backward-compatible Predictor wrapper
@@ -361,7 +470,9 @@ pub struct Predictor {
 
 impl Predictor {
     pub fn new(config: PredictorConfig) -> Self {
-        Self { inner: JepaPredictor::new(config) }
+        Self {
+            inner: JepaPredictor::new(config),
+        }
     }
 
     pub fn default_with_dim(d_model: usize) -> Self {
@@ -370,7 +481,11 @@ impl Predictor {
 
     pub fn forward(&mut self, _context: &[f32], _target_positions: &[usize]) -> PredictionOutput {
         let d = self.inner.config.d_model;
-        PredictionOutput { predicted: vec![0.0; _target_positions.len() * d], target: vec![0.0; _target_positions.len() * d], loss: 0.0 }
+        PredictionOutput {
+            predicted: vec![0.0; _target_positions.len() * d],
+            target: vec![0.0; _target_positions.len() * d],
+            loss: 0.0,
+        }
     }
 
     pub fn compute_loss(&self, predicted: &[f32], target: &[f32]) -> f64 {
@@ -480,7 +595,8 @@ impl Predictor {
 
         total_loss /= (n_tgt * d_model) as f64;
         let _loss_f32 = total_loss as f32;
-        self.inner.optimizer_step(total_loss, &all_predicted, target_embeddings);
+        self.inner
+            .optimizer_step(total_loss, &all_predicted, target_embeddings);
 
         PredictionOutput::new(all_predicted, target_embeddings.to_vec(), total_loss)
     }
@@ -492,19 +608,26 @@ impl Predictor {
         target_embeddings: &[f32],
         num_targets: usize,
     ) -> f32 {
-        self.inner.forward_backward(context, target_embeddings, num_targets)
+        self.inner
+            .forward_backward(context, target_embeddings, num_targets)
     }
 
-    pub fn num_params(&self) -> usize { self.inner.num_params() }
-    pub fn config(&self) -> &PredictorConfig { self.inner.config() }
+    pub fn num_params(&self) -> usize {
+        self.inner.num_params()
+    }
+    pub fn config(&self) -> &PredictorConfig {
+        self.inner.config()
+    }
 }
 
 pub fn reshape_to_matrix(flat: &[f32], d_model: usize) -> Vec<Vec<f32>> {
     let n = flat.len() / d_model;
-    (0..n).map(|i| {
-        let start = i * d_model;
-        flat[start..(start + d_model).min(flat.len())].to_vec()
-    }).collect()
+    (0..n)
+        .map(|i| {
+            let start = i * d_model;
+            flat[start..(start + d_model).min(flat.len())].to_vec()
+        })
+        .collect()
 }
 
 pub fn flatten_matrix(matrix: &[Vec<f32>]) -> Vec<f32> {
@@ -560,7 +683,12 @@ mod tests {
         for _ in 0..100 {
             loss_last = predictor.forward_backward(&context, &target_emb, 1);
         }
-        assert!(loss_last < loss0 || loss_last.is_finite(), "loss should decrease or be finite: {} -> {}", loss0, loss_last);
+        assert!(
+            loss_last < loss0 || loss_last.is_finite(),
+            "loss should decrease or be finite: {} -> {}",
+            loss0,
+            loss_last
+        );
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,6 @@
 //! trios-trainer — portable IGLA RACE training pipeline.
 //! Single-source-of-truth for `gHashTag/trios#143`. Anchor: phi^2 + phi^-2 = 3.
 
-pub mod phi_numbers;
 pub mod checkpoint;
 pub mod config;
 pub mod data;
@@ -13,6 +12,7 @@ pub mod model;
 pub mod model_hybrid_attn;
 pub mod objective;
 pub mod optimizer;
+pub mod phi_numbers;
 pub mod race;
 pub mod train_loop;
 

--- a/src/model.rs
+++ b/src/model.rs
@@ -1,5 +1,5 @@
-use anyhow::Result;
 use crate::config::ModelConfig;
+use anyhow::Result;
 
 pub struct Model {
     pub d_model: usize,
@@ -8,5 +8,9 @@ pub struct Model {
 }
 
 pub fn build(cfg: &ModelConfig) -> Result<Model> {
-    Ok(Model { d_model: cfg.d_model, n_layers: cfg.n_layers, hybrid: cfg.hybrid_attn })
+    Ok(Model {
+        d_model: cfg.d_model,
+        n_layers: cfg.n_layers,
+        hybrid: cfg.hybrid_attn,
+    })
 }

--- a/src/model_hybrid_attn.rs
+++ b/src/model_hybrid_attn.rs
@@ -102,10 +102,7 @@ impl std::fmt::Display for HybridAttnError {
                 "INV-13 violation: qk_gain={qk_gain} not in pre-registered \
                  set {{φ²={PHI_SQ}, φ³={PHI_CUBE}}}",
             ),
-            Self::Shape {
-                d_model,
-                num_heads,
-            } => write!(
+            Self::Shape { d_model, num_heads } => write!(
                 f,
                 "shape invariant failed: d_model={d_model}, num_heads={num_heads} \
                  (both must be > 0 and d_model % num_heads == 0)",
@@ -171,9 +168,7 @@ impl HybridAttnConfig {
                 qk_gain: self.qk_gain,
             });
         }
-        if self.d_model == 0
-            || self.num_heads == 0
-            || !self.d_model.is_multiple_of(self.num_heads)
+        if self.d_model == 0 || self.num_heads == 0 || !self.d_model.is_multiple_of(self.num_heads)
         {
             return Err(HybridAttnError::Shape {
                 d_model: self.d_model,
@@ -318,11 +313,7 @@ impl HybridAttn {
     /// pre-registered block, because the measured quantity is the
     /// learning dynamic (`val_bpb_at_step_54000`) not wall-clock.
     /// Optimisation lives downstream in `hybrid_train.rs` (L-h1).
-    pub fn forward(
-        &self,
-        tokens: &[f32],
-        seq_len: usize,
-    ) -> Result<Vec<f32>, HybridAttnError> {
+    pub fn forward(&self, tokens: &[f32], seq_len: usize) -> Result<Vec<f32>, HybridAttnError> {
         if tokens.iter().any(|x| !x.is_finite()) {
             return Err(HybridAttnError::NonFinite);
         }
@@ -335,7 +326,8 @@ impl HybridAttn {
             seq_len * d,
         );
 
-        let layer1_out = self.forward_single_layer(tokens, seq_len, &self.wq, &self.wk, &self.wv, &self.wo)?;
+        let layer1_out =
+            self.forward_single_layer(tokens, seq_len, &self.wq, &self.wk, &self.wv, &self.wo)?;
         let residual1 = add_residual(tokens, &layer1_out);
         let normed1 = layer_norm_rows(&residual1, seq_len, d);
 
@@ -346,7 +338,9 @@ impl HybridAttn {
             return Ok(normed1);
         }
 
-        let layer2_out = self.forward_single_layer(&normed1, seq_len, &self.wq2, &self.wk2, &self.wv2, &self.wo2)?;
+        let layer2_out = self.forward_single_layer(
+            &normed1, seq_len, &self.wq2, &self.wk2, &self.wv2, &self.wo2,
+        )?;
         let residual2 = add_residual(&normed1, &layer2_out);
         let out = layer_norm_rows(&residual2, seq_len, d);
 
@@ -392,8 +386,7 @@ impl HybridAttn {
                 for j in 0..=i {
                     let w = scores[j];
                     for k_idx in 0..d_head {
-                        attn_out[i * d + head_offset + k_idx] +=
-                            w * v[j * d + head_offset + k_idx];
+                        attn_out[i * d + head_offset + k_idx] += w * v[j * d + head_offset + k_idx];
                     }
                 }
             }
@@ -584,7 +577,10 @@ mod falsifiers {
         let tokens = vec![0.0_f32; seq_len * d];
         let out = block.forward(&tokens, seq_len).unwrap();
         assert_eq!(out.len(), seq_len * d);
-        assert!(out.iter().all(|x| x.is_finite()), "2-layer output must be finite");
+        assert!(
+            out.iter().all(|x| x.is_finite()),
+            "2-layer output must be finite"
+        );
     }
 
     /// L-f1 Gate-final: 1-layer mode must still work (backward compat).

--- a/src/objective.rs
+++ b/src/objective.rs
@@ -19,7 +19,11 @@ pub struct ObjectiveConfig {
 
 impl Default for ObjectiveConfig {
     fn default() -> Self {
-        Self { ntp_weight: 0.5, jepa_weight: 0.25, nca_weight: 0.25 }
+        Self {
+            ntp_weight: 0.5,
+            jepa_weight: 0.25,
+            nca_weight: 0.25,
+        }
     }
 }
 
@@ -48,19 +52,23 @@ pub fn nca_entropy_constraint(entropy: f64) -> f64 {
     const MIN: f64 = 1.5;
     const MAX: f64 = 2.8;
     const SCALE: f64 = 100.0;
-    if entropy < MIN { (MIN - entropy).powi(2) * SCALE }
-    else if entropy > MAX { (entropy - MAX).powi(2) * SCALE }
-    else { 0.0 }
+    if entropy < MIN {
+        (MIN - entropy).powi(2) * SCALE
+    } else if entropy > MAX {
+        (entropy - MAX).powi(2) * SCALE
+    } else {
+        0.0
+    }
 }
 
 /// ASHA rung schedule per architecture
 /// Law L-R10: JEPA first rung = 3000 (1.4x slower convergence)
 pub fn get_rung_schedule(arch: &str) -> Vec<u32> {
     match arch {
-        "jepa"   => vec![3000, 9000, 27000],
-        "attn"   => vec![1000, 3000, 9000, 27000],
+        "jepa" => vec![3000, 9000, 27000],
+        "attn" => vec![1000, 3000, 9000, 27000],
         "hybrid" => vec![2000, 6000, 18000],
-        _        => vec![1000, 3000, 9000, 27000],
+        _ => vec![1000, 3000, 9000, 27000],
     }
 }
 
@@ -103,7 +111,10 @@ impl Default for NcaObjective {
 
 impl NcaObjective {
     pub fn new(weight: f64) -> Self {
-        Self { weight, ..Self::default() }
+        Self {
+            weight,
+            ..Self::default()
+        }
     }
 
     pub fn grid_dim(&self) -> usize {
@@ -116,7 +127,9 @@ impl NcaObjective {
         let mut state = Vec::with_capacity(n);
         let mut s = seed;
         for _ in 0..n {
-            s = s.wrapping_mul(6364136223846793005).wrapping_add(1442695040888963407);
+            s = s
+                .wrapping_mul(6364136223846793005)
+                .wrapping_add(1442695040888963407);
             let idx = (s >> 33) as usize % self.k_states;
             state.push(idx as f32);
         }
@@ -140,7 +153,9 @@ impl NcaObjective {
                     let s = state[nidx] as usize;
                     counts[s.min(self.k_states - 1)] += rule.neighbor_weight;
                 }
-                let best = counts.iter().enumerate()
+                let best = counts
+                    .iter()
+                    .enumerate()
                     .max_by_key(|(_, &c)| c)
                     .map(|(i, _)| i)
                     .unwrap_or(0);
@@ -169,12 +184,7 @@ impl NcaObjective {
 
     /// Compute NCA auxiliary loss for one rollout
     /// Loss = MSE(predicted_embed, target_embed) + entropy_penalty
-    pub fn compute_loss(
-        &self,
-        predicted: &[f32],
-        target: &[f32],
-        nca_state: &[f32],
-    ) -> f64 {
+    pub fn compute_loss(&self, predicted: &[f32], target: &[f32], nca_state: &[f32]) -> f64 {
         let mse = mse_loss(predicted, target);
         let entropy = shannon_entropy(nca_state, self.k_states);
         let penalty = nca_entropy_constraint(entropy);
@@ -221,7 +231,9 @@ pub struct NcaRolloutResult {
 /// Shannon entropy: H = -Σ p_i * log(p_i)
 pub fn shannon_entropy(state: &[f32], k_states: usize) -> f64 {
     let n = state.len() as f64;
-    if n == 0.0 { return 0.0; }
+    if n == 0.0 {
+        return 0.0;
+    }
     let mut counts = vec![0usize; k_states];
     for &s in state {
         let idx = (s.round() as usize).min(k_states - 1);
@@ -240,11 +252,15 @@ pub fn shannon_entropy(state: &[f32], k_states: usize) -> f64 {
 /// MSE loss between two vectors
 pub fn mse_loss(a: &[f32], b: &[f32]) -> f64 {
     assert_eq!(a.len(), b.len());
-    if a.is_empty() { return 0.0; }
+    if a.is_empty() {
+        return 0.0;
+    }
     let n = a.len() as f64;
-    a.iter().zip(b.iter())
+    a.iter()
+        .zip(b.iter())
         .map(|(&x, &y)| (x - y) as f64 * (x - y) as f64)
-        .sum::<f64>() / n
+        .sum::<f64>()
+        / n
 }
 
 /// Differentiable NCA entropy loss for use as auxiliary training signal.
@@ -256,8 +272,16 @@ pub fn mse_loss(a: &[f32], b: &[f32]) -> f64 {
 /// Returns (loss, entropy) tuple so caller can log entropy for monitoring.
 ///
 /// Law L-R11: NCA entropy [1.5, 2.8] = hard penalty
-pub fn nca_entropy_loss(state: &[f32], k_states: usize, entropy_min: f64, entropy_max: f64, weight: f64) -> (f64, f64) {
-    if state.is_empty() { return (0.0, 0.0); }
+pub fn nca_entropy_loss(
+    state: &[f32],
+    k_states: usize,
+    entropy_min: f64,
+    entropy_max: f64,
+    weight: f64,
+) -> (f64, f64) {
+    if state.is_empty() {
+        return (0.0, 0.0);
+    }
     let entropy = shannon_entropy(state, k_states);
     let penalty = if entropy < entropy_min {
         (entropy_min - entropy).powi(2) * 100.0
@@ -275,7 +299,11 @@ mod tests {
 
     #[test]
     fn test_combined_loss_weights() {
-        let c = ComponentLosses { ntp: 2.0, jepa: 1.0, nca: 0.5 };
+        let c = ComponentLosses {
+            ntp: 2.0,
+            jepa: 1.0,
+            nca: 0.5,
+        };
         let r = compute_combined_loss(c, ObjectiveConfig::default());
         assert!((r.total - 1.375).abs() < 1e-9, "total={}", r.total);
     }
@@ -337,14 +365,22 @@ mod tests {
     fn test_shannon_entropy_uniform() {
         let state: Vec<f32> = (0..81).map(|i| (i % 9) as f32).collect();
         let h = shannon_entropy(&state, 9);
-        assert!((h - (9.0f64).ln()).abs() < 0.01, "uniform entropy should be ln(9)={}", (9.0f64).ln());
+        assert!(
+            (h - (9.0f64).ln()).abs() < 0.01,
+            "uniform entropy should be ln(9)={}",
+            (9.0f64).ln()
+        );
     }
 
     #[test]
     fn test_shannon_entropy_single_state() {
         let state = vec![0.0f32; 81];
         let h = shannon_entropy(&state, 9);
-        assert!(h.abs() < 1e-9, "single state entropy should be 0, got {}", h);
+        assert!(
+            h.abs() < 1e-9,
+            "single state entropy should be 0, got {}",
+            h
+        );
     }
 
     #[test]
@@ -375,10 +411,15 @@ mod tests {
     fn test_nca_entropy_in_band_during_rollout() {
         let nca = NcaObjective::default();
         let result = nca.rollout(42, &NcaTransitionRule::default());
-        let in_band = result.entropies.iter()
+        let in_band = result
+            .entropies
+            .iter()
             .filter(|&&h| h >= 1.5 && h <= 2.8)
             .count();
-        assert!(in_band > 0, "some steps should have entropy in band [1.5, 2.8]");
+        assert!(
+            in_band > 0,
+            "some steps should have entropy in band [1.5, 2.8]"
+        );
     }
 
     #[test]

--- a/src/optimizer.rs
+++ b/src/optimizer.rs
@@ -521,7 +521,11 @@ pub fn phi_lr_schedule(step: usize, base_lr: f64, warmup_steps: usize) -> f64 {
 /// Learning rate as f64
 #[cfg(feature = "trios-integration")]
 #[inline]
-pub fn lr_schedule_54_f64(schedule_type: trios_phi_schedule::LrScheduleType, step: usize, max_steps: usize) -> f64 {
+pub fn lr_schedule_54_f64(
+    schedule_type: trios_phi_schedule::LrScheduleType,
+    step: usize,
+    max_steps: usize,
+) -> f64 {
     trios_phi_schedule::lr_schedule_54(schedule_type, step, max_steps) as f64
 }
 
@@ -686,10 +690,15 @@ mod tests {
 
     #[test]
     fn test_newton_schulz_cubic_legacy() {
-        let identity: Vec<f32> = (0..4).map(|i| if i % 5 == 0 { 1.0f32 } else { 0.0f32 }).collect();
+        let identity: Vec<f32> = (0..4)
+            .map(|i| if i % 5 == 0 { 1.0f32 } else { 0.0f32 })
+            .collect();
         let result = newton_schulz_cubic(&identity, 2, 2);
         for i in 0..4 {
-            assert!((result[i] - identity[i]).abs() < 0.01, "cubic NS should preserve identity");
+            assert!(
+                (result[i] - identity[i]).abs() < 0.01,
+                "cubic NS should preserve identity"
+            );
         }
     }
 
@@ -709,7 +718,9 @@ mod tests {
 
     #[test]
     fn test_newton_schulz_5_finite_output() {
-        let identity: Vec<f32> = (0..4).map(|i| if i % 5 == 0 { 1.0f32 } else { 0.0f32 }).collect();
+        let identity: Vec<f32> = (0..4)
+            .map(|i| if i % 5 == 0 { 1.0f32 } else { 0.0f32 })
+            .collect();
         let result = newton_schulz_5(&identity, 2, 2, 3.4445, -4.7750, 2.0315);
         for &r in &result {
             assert!(r.is_finite(), "NS5 output should be finite");
@@ -739,8 +750,7 @@ mod tests {
 
     #[test]
     fn test_muon_custom_ns_coefficients() {
-        let opt = MuonOptimizer::new(16, 0.02, 0.95, 0.01)
-            .with_ns_coefficients(1.5, -0.5, 0.0);
+        let opt = MuonOptimizer::new(16, 0.02, 0.95, 0.01).with_ns_coefficients(1.5, -0.5, 0.0);
         assert!((opt.ns_a - 1.5).abs() < 1e-4);
         assert!((opt.ns_b - (-0.5)).abs() < 1e-4);
         assert!((opt.ns_c - 0.0).abs() < 1e-4);

--- a/src/phi_numbers/fibonacci_dims.rs
+++ b/src/phi_numbers/fibonacci_dims.rs
@@ -55,7 +55,11 @@ pub fn nearest_fibonacci(value: u64) -> u64 {
             let upper = FIBONACCI[i + 1];
             let diff_lower = value - lower;
             let diff_upper = upper - value;
-            return if diff_lower < diff_upper { lower } else { upper };
+            return if diff_lower < diff_upper {
+                lower
+            } else {
+                upper
+            };
         }
     }
     FIBONACCI[FIBONACCI.len() - 1]
@@ -79,26 +83,24 @@ pub fn is_fibonacci(value: u64) -> bool {
 }
 
 /// Recommended model dimensions (Fibonacci-based)
-pub const RECOMMENDED_DIMS: [usize; 10] = [
-    8, 13, 21, 34, 55, 89, 144, 233, 377, 610,
-];
+pub const RECOMMENDED_DIMS: [usize; 10] = [8, 13, 21, 34, 55, 89, 144, 233, 377, 610];
 
 /// Get a recommended dimension for a given size category
 /// category: 0=tiny, 1=small, 2=medium, 3=large, 4=xlarge
 pub fn recommended_dim(category: usize) -> usize {
-    let idx = if category >= RECOMMENDED_DIMS.len() { RECOMMENDED_DIMS.len() - 1 } else { category };
+    let idx = if category >= RECOMMENDED_DIMS.len() {
+        RECOMMENDED_DIMS.len() - 1
+    } else {
+        category
+    };
     RECOMMENDED_DIMS[idx]
 }
 
 /// Fibonacci-based hidden sizes for N-gram models
-pub const NGRAM_HIDDEN_SIZES: [usize; 6] = [
-    8, 13, 21, 34, 55, 89,
-];
+pub const NGRAM_HIDDEN_SIZES: [usize; 6] = [8, 13, 21, 34, 55, 89];
 
 /// Fibonacci-based embedding dimensions
-pub const EMBEDDING_DIMS: [usize; 6] = [
-    8, 13, 21, 34, 55, 89,
-];
+pub const EMBEDDING_DIMS: [usize; 6] = [8, 13, 21, 34, 55, 89];
 
 /// φ-based layer count progression (powers of φ)
 /// φ^1 ≈ 1.6 → 2 layers
@@ -190,9 +192,9 @@ mod tests {
         assert_eq!(nearest_fibonacci(0), 1);
         assert_eq!(nearest_fibonacci(1), 1);
         assert_eq!(nearest_fibonacci(2), 2);
-        assert_eq!(nearest_fibonacci(4), 5);  // 4 is closer to 5 than to 3
-        assert_eq!(nearest_fibonacci(6), 5);  // 6 is closer to 5 than to 8
-        assert_eq!(nearest_fibonacci(7), 8);  // 7 is closer to 8 than to 5
+        assert_eq!(nearest_fibonacci(4), 5); // 4 is closer to 5 than to 3
+        assert_eq!(nearest_fibonacci(6), 5); // 6 is closer to 5 than to 8
+        assert_eq!(nearest_fibonacci(7), 8); // 7 is closer to 8 than to 5
     }
 
     #[test]
@@ -260,9 +262,9 @@ mod tests {
         assert!(is_phi_optimized(34));
 
         // Within 10% tolerance
-        assert!(!is_phi_optimized(64));  // 64/55 ≈ 1.16 > 1.1
-        assert!(!is_phi_optimized(72));  // 72/89 ≈ 0.81 < 0.9
-        assert!(is_phi_optimized(96));   // 96/89 ≈ 1.08 < 1.1
+        assert!(!is_phi_optimized(64)); // 64/55 ≈ 1.16 > 1.1
+        assert!(!is_phi_optimized(72)); // 72/89 ≈ 0.81 < 0.9
+        assert!(is_phi_optimized(96)); // 96/89 ≈ 1.08 < 1.1
     }
 
     #[test]
@@ -273,7 +275,7 @@ mod tests {
         assert_eq!(phi_distance(21), 0.0);
 
         // Midpoint should have distance 1.0
-        assert!((phi_distance(6) - 1.0).abs() < 0.01);  // Between 5 and 8
+        assert!((phi_distance(6) - 1.0).abs() < 0.01); // Between 5 and 8
         assert!((phi_distance(10) - 1.0).abs() < 0.01); // Between 8 and 13
     }
 
@@ -292,7 +294,7 @@ mod tests {
     fn test_trinity_identity_with_fibonacci() {
         // Test φ² + 1/φ² = 3 using Fibonacci relationship
         // φ ≈ F(n+1)/F(n) for large n
-        let n = 10;  // Use F(10) = 55, F(11) = 89
+        let n = 10; // Use F(10) = 55, F(11) = 89
         let phi_approx = FIBONACCI[n + 1] as f64 / FIBONACCI[n] as f64;
         let phi_sq_approx = phi_approx * phi_approx;
         let phi_inv_sq_approx = 1.0 / phi_sq_approx;
@@ -300,7 +302,11 @@ mod tests {
 
         // Should be close to 3
         let error = (sum - 3.0).abs();
-        assert!(error < 0.1, "Trinity identity with Fibonacci approximation: error = {}", error);
+        assert!(
+            error < 0.1,
+            "Trinity identity with Fibonacci approximation: error = {}",
+            error
+        );
     }
 
     #[test]
@@ -333,7 +339,11 @@ mod tests {
 
         for (input, expected) in suggestions {
             let suggested = nearest_fibonacci(input as u64);
-            assert_eq!(suggested as usize, expected, "For input {}, expected {}", input, expected);
+            assert_eq!(
+                suggested as usize, expected,
+                "For input {}, expected {}",
+                input, expected
+            );
         }
     }
 
@@ -343,7 +353,13 @@ mod tests {
         for i in 5..FIBONACCI.len() - 1 {
             let ratio = FIBONACCI[i + 1] as f64 / FIBONACCI[i] as f64;
             let error = (ratio - PHI).abs();
-            assert!(error < 0.01, "Growth at step {}: {} (error: {})", i, ratio, error);
+            assert!(
+                error < 0.01,
+                "Growth at step {}: {} (error: {})",
+                i,
+                ratio,
+                error
+            );
         }
     }
 
@@ -372,7 +388,11 @@ mod tests {
     fn test_recommended_dims_are_fibonacci() {
         // All recommended dimensions should be Fibonacci numbers
         for &dim in &RECOMMENDED_DIMS {
-            assert!(is_fibonacci(dim as u64), "Recommended dim {} is not Fibonacci", dim);
+            assert!(
+                is_fibonacci(dim as u64),
+                "Recommended dim {} is not Fibonacci",
+                dim
+            );
         }
     }
 
@@ -384,7 +404,11 @@ mod tests {
             let nearest = nearest_fibonacci(size as u64);
             let dist = phi_distance(size as u64);
             // All should have some φ-optimized alternative
-            assert!(dist <= 1.0, "Size {} has no close Fibonacci alternative", size);
+            assert!(
+                dist <= 1.0,
+                "Size {} has no close Fibonacci alternative",
+                size
+            );
         }
     }
 }

--- a/src/phi_numbers/gf32.rs
+++ b/src/phi_numbers/gf32.rs
@@ -12,13 +12,13 @@ pub struct GF32 {
 
 impl GF32 {
     const SIGN_BIT: u32 = 0x80000000;
-    const EXP_MASK: u32 = 0x7FFE0000;  // 13 bits
+    const EXP_MASK: u32 = 0x7FFE0000; // 13 bits
     const MANT_MASK: u32 = 0x0003FFFF; // 18 bits
 
     const EXP_BITS: u8 = 13;
     const MANT_BITS: u8 = 18;
 
-    const EXP_BIAS: i16 = 4095;  // 2^(13-1) - 1
+    const EXP_BIAS: i16 = 4095; // 2^(13-1) - 1
 
     /// Create GF32 from f32
     pub fn from_f32(value: f32) -> Self {
@@ -84,7 +84,11 @@ impl GF32 {
             return 0.0;
         }
 
-        let sign = if (self.bits & Self::SIGN_BIT) != 0 { -1.0f32 } else { 1.0f32 };
+        let sign = if (self.bits & Self::SIGN_BIT) != 0 {
+            -1.0f32
+        } else {
+            1.0f32
+        };
         let exp = ((self.bits & Self::EXP_MASK) >> Self::MANT_BITS) as i32;
         let mant = (self.bits & Self::MANT_MASK) as u32;
 
@@ -286,8 +290,18 @@ mod tests {
         let test_values = [0.001, 0.1, 1.0, 10.0, PHI as f32, PHI_SQUARED as f32];
         for v in test_values {
             let (decoded, abs_err, rel_err) = GF32::compare_with_f32(v);
-            assert!(abs_err < v.abs() * 1e-4, "Absolute error too high for {}: {}", v, abs_err);
-            assert!(rel_err < 1e-4, "Relative error too high for {}: {}", v, rel_err);
+            assert!(
+                abs_err < v.abs() * 1e-4,
+                "Absolute error too high for {}: {}",
+                v,
+                abs_err
+            );
+            assert!(
+                rel_err < 1e-4,
+                "Relative error too high for {}: {}",
+                v,
+                rel_err
+            );
         }
     }
 
@@ -333,10 +347,10 @@ mod tests {
     fn test_phi_power_series() {
         // Verify φ^n = F_n * φ + F_{n-1} in GF32
         let cases = [
-            (1, 1.0, 0.0),   // φ^1 = 1*φ + 0
-            (2, 1.0, 1.0),   // φ^2 = 1*φ + 1
-            (3, 2.0, 1.0),   // φ^3 = 2*φ + 1
-            (4, 3.0, 2.0),   // φ^4 = 3*φ + 2
+            (1, 1.0, 0.0), // φ^1 = 1*φ + 0
+            (2, 1.0, 1.0), // φ^2 = 1*φ + 1
+            (3, 2.0, 1.0), // φ^3 = 2*φ + 1
+            (4, 3.0, 2.0), // φ^4 = 3*φ + 2
         ];
 
         for (n, f_n, f_n_minus_1) in cases {

--- a/src/phi_numbers/gf64.rs
+++ b/src/phi_numbers/gf64.rs
@@ -19,7 +19,7 @@ impl GF64 {
     const EXP_BITS: u8 = 21;
     const MANT_BITS: u8 = 42;
 
-    const EXP_BIAS: i32 = 1048575;  // 2^(21-1) - 1
+    const EXP_BIAS: i32 = 1048575; // 2^(21-1) - 1
 
     /// Create GF64 from f64
     pub fn from_f64(value: f64) -> Self {
@@ -85,7 +85,11 @@ impl GF64 {
             return 0.0;
         }
 
-        let sign = if (self.bits & Self::SIGN_BIT) != 0 { -1.0f64 } else { 1.0f64 };
+        let sign = if (self.bits & Self::SIGN_BIT) != 0 {
+            -1.0f64
+        } else {
+            1.0f64
+        };
         let exp = ((self.bits & Self::EXP_MASK) >> Self::MANT_BITS) as i32;
         let mant = (self.bits & Self::MANT_MASK) as u64;
 
@@ -142,8 +146,8 @@ impl GF64 {
 
     /// Range constants
     /// Note: powi not const in Rust 1.90, using f64 bounds instead
-    pub const MIN_POSITIVE: f64 = f64::MIN_POSITIVE;  // ~2.23e-308 (effectively 0)
-    pub const MAX: f64 = f64::MAX;  // ~1.80e308 (effectively infinity)
+    pub const MIN_POSITIVE: f64 = f64::MIN_POSITIVE; // ~2.23e-308 (effectively 0)
+    pub const MAX: f64 = f64::MAX; // ~1.80e308 (effectively infinity)
 }
 
 impl Clone for GF64 {
@@ -303,8 +307,18 @@ mod tests {
         let test_values = [0.001, 0.1, 1.0, 10.0, PHI, PHI_SQUARED, PHI_CUBED];
         for v in test_values {
             let (decoded, abs_err, rel_err) = GF64::compare_with_f64(v);
-            assert!(abs_err < v.abs() * 1e-10, "Absolute error too high for {}: {}", v, abs_err);
-            assert!(rel_err < 1e-10, "Relative error too high for {}: {}", v, rel_err);
+            assert!(
+                abs_err < v.abs() * 1e-10,
+                "Absolute error too high for {}: {}",
+                v,
+                abs_err
+            );
+            assert!(
+                rel_err < 1e-10,
+                "Relative error too high for {}: {}",
+                v,
+                rel_err
+            );
         }
     }
 
@@ -332,12 +346,12 @@ mod tests {
     fn test_phi_power_series_exact() {
         // Verify φ^n = F_n * φ + F_{n-1} in GF64
         let cases = [
-            (1, 1.0, 0.0),   // φ^1 = 1*φ + 0
-            (2, 1.0, 1.0),   // φ^2 = 1*φ + 1
-            (3, 2.0, 1.0),   // φ^3 = 2*φ + 1
-            (4, 3.0, 2.0),   // φ^4 = 3*φ + 2
-            (5, 5.0, 3.0),   // φ^5 = 5*φ + 3
-            (6, 8.0, 5.0),   // φ^6 = 8*φ + 5
+            (1, 1.0, 0.0), // φ^1 = 1*φ + 0
+            (2, 1.0, 1.0), // φ^2 = 1*φ + 1
+            (3, 2.0, 1.0), // φ^3 = 2*φ + 1
+            (4, 3.0, 2.0), // φ^4 = 3*φ + 2
+            (5, 5.0, 3.0), // φ^5 = 5*φ + 3
+            (6, 8.0, 5.0), // φ^6 = 8*φ + 5
         ];
 
         for (n, f_n, f_n_minus_1) in cases {
@@ -421,7 +435,11 @@ mod tests {
 
         // φ² + 1/φ² = 3
         let trinity = gf_phi_sq.to_f64() + gf_phi_inv_sq.to_f64();
-        assert!((trinity - 3.0).abs() < 1e-10, "Trinity identity failed: {}", trinity);
+        assert!(
+            (trinity - 3.0).abs() < 1e-10,
+            "Trinity identity failed: {}",
+            trinity
+        );
 
         // φ - 1/φ = 1
         let diff = gf_phi.to_f64() - gf_phi_conj.to_f64();

--- a/src/phi_numbers/gf8.rs
+++ b/src/phi_numbers/gf8.rs
@@ -11,14 +11,14 @@ pub struct GF8 {
 }
 
 impl GF8 {
-    const SIGN_BIT: u8 = 0x80;  // 1000_0000
-    const EXP_MASK: u8 = 0x70;   // 0111_0000
-    const MANT_MASK: u8 = 0x0F;  // 0000_1111
+    const SIGN_BIT: u8 = 0x80; // 1000_0000
+    const EXP_MASK: u8 = 0x70; // 0111_0000
+    const MANT_MASK: u8 = 0x0F; // 0000_1111
 
     const EXP_BITS: u8 = 3;
     const MANT_BITS: u8 = 4;
 
-    const EXP_BIAS: i8 = 3;  // 2^(3-1) - 1
+    const EXP_BIAS: i8 = 3; // 2^(3-1) - 1
 
     /// Create GF8 from f32 (quantization)
     pub fn from_f32(value: f32) -> Self {
@@ -53,10 +53,12 @@ impl GF8 {
 
         // Clamp exponent
         if gf8_exp < 0 {
-            return Self { bits: 0 };  // Underflow to zero
+            return Self { bits: 0 }; // Underflow to zero
         }
         if gf8_exp > 7 {
-            return Self { bits: (sign << 7) | 0x70 };
+            return Self {
+                bits: (sign << 7) | 0x70,
+            };
         }
 
         // Round mantissa: 23 bits → 4 bits
@@ -73,7 +75,9 @@ impl GF8 {
             mant_rounded = 0;
             gf8_exp += 1;
             if gf8_exp > 6 {
-                return Self { bits: (sign << 7) | 0x70 };
+                return Self {
+                    bits: (sign << 7) | 0x70,
+                };
             }
         }
 
@@ -88,7 +92,11 @@ impl GF8 {
             return 0.0;
         }
 
-        let sign = if (self.bits & Self::SIGN_BIT) != 0 { -1.0 } else { 1.0 };
+        let sign = if (self.bits & Self::SIGN_BIT) != 0 {
+            -1.0
+        } else {
+            1.0
+        };
         let exp = ((self.bits & Self::EXP_MASK) >> 4) as i32;
         let mant = (self.bits & Self::MANT_MASK) as u32;
 
@@ -138,8 +146,8 @@ impl GF8 {
     }
 
     /// Range of representable values
-    pub const MIN_POSITIVE: f32 = 0.125_f32;  // 2^(-3) = 0.125 (powi not const in Rust 1.90)
-    pub const MAX: f32 = 15.75;  // (2 - 1/16) * 2^4
+    pub const MIN_POSITIVE: f32 = 0.125_f32; // 2^(-3) = 0.125 (powi not const in Rust 1.90)
+    pub const MAX: f32 = 15.75; // (2 - 1/16) * 2^4
 }
 
 impl Clone for GF8 {

--- a/src/phi_numbers/gfternary.rs
+++ b/src/phi_numbers/gfternary.rs
@@ -110,9 +110,9 @@ impl GFTernary {
     /// Encode as 2 bits
     pub fn encode_bits(self) -> u8 {
         match self {
-            Self::NegPhi => 0b01,  // -1 in ternary (but we use 01 for -φ)
-            Self::Zero => 0b10,  // 0
-            Self::PosPhi => 0b11,  // +1 (but we use 11 for +φ)
+            Self::NegPhi => 0b01, // -1 in ternary (but we use 01 for -φ)
+            Self::Zero => 0b10,   // 0
+            Self::PosPhi => 0b11, // +1 (but we use 11 for +φ)
         }
     }
 
@@ -435,7 +435,12 @@ mod tests {
         for v in phi_vals {
             let gf = GFTernary::from_f64(v);
             // All should be PosPhi (positive > φ/2)
-            assert_eq!(gf, GFTernary::PosPhi, "φ-family value {} should be PosPhi", v);
+            assert_eq!(
+                gf,
+                GFTernary::PosPhi,
+                "φ-family value {} should be PosPhi",
+                v
+            );
         }
     }
 
@@ -532,7 +537,11 @@ mod tests {
 
         // Also verify negative step
         let step_neg = GFTernary::Zero.to_f64() - GFTernary::NegPhi.to_f64();
-        assert!((step_neg - PHI).abs() < 1e-10, "Negative step should be φ: {}", step_neg);
+        assert!(
+            (step_neg - PHI).abs() < 1e-10,
+            "Negative step should be φ: {}",
+            step_neg
+        );
     }
 
     #[test]
@@ -543,7 +552,11 @@ mod tests {
         let gf_bits = GFTernary::PosPhi.bit_width();
         let f16_bits = 16;
         let compression = f16_bits as f64 / gf_bits as f64;
-        assert!((compression - 8.0).abs() < 1e-10, "Compression ratio should be 8×: {}", compression);
+        assert!(
+            (compression - 8.0).abs() < 1e-10,
+            "Compression ratio should be 8×: {}",
+            compression
+        );
     }
 
     #[test]
@@ -566,7 +579,11 @@ mod tests {
 
         // Test identity
         assert_eq!(a + GFTernary::Zero, a, "Zero not additive identity");
-        assert_eq!(a * GFTernary::PosPhi, a, "PosPhi not multiplicative identity");
+        assert_eq!(
+            a * GFTernary::PosPhi,
+            a,
+            "PosPhi not multiplicative identity"
+        );
     }
 
     #[test]
@@ -580,7 +597,11 @@ mod tests {
             // GFTernary has very high quantization error (coarse quantization)
             // But it's predictable and uses only 2 bits
             assert!(gf_err >= 0.0);
-            assert!(gf_err <= 1.0, "Relative error should be reasonable: {}", gf_err);
+            assert!(
+                gf_err <= 1.0,
+                "Relative error should be reasonable: {}",
+                gf_err
+            );
         }
     }
 }

--- a/src/phi_numbers/mod.rs
+++ b/src/phi_numbers/mod.rs
@@ -2,19 +2,19 @@
 //!
 //! Implements φ-optimized floating point formats and related golden ratio constants.
 
-pub mod gf8;
+pub mod fibonacci_dims;
 pub mod gf32;
 pub mod gf64;
+pub mod gf8;
 pub mod gfternary;
 pub mod phi_constants;
-pub mod fibonacci_dims;
 
-pub use phi_constants::*;
-pub use gf8::GF8;
+pub use fibonacci_dims::*;
 pub use gf32::GF32;
 pub use gf64::GF64;
+pub use gf8::GF8;
 pub use gfternary::GFTernary;
-pub use fibonacci_dims::*;
+pub use phi_constants::*;
 
 /// Main Trinity identity: φ² + 1/φ² = 3
 pub const TRINITY_IDENTITY: f64 = 3.0;

--- a/src/phi_numbers/phi_constants.rs
+++ b/src/phi_numbers/phi_constants.rs
@@ -12,7 +12,8 @@ pub const PHI_CONJUGATE: f64 = 0.61803398874989484820458683436563811772030917980
 pub const PHI_SQUARED: f64 = 2.6180339887498948482045868343656381177203091798057628621354486227;
 
 /// 1/φ² = 2 - φ ≈ 0.3819660112501051518
-pub const PHI_INVERSE_SQUARED: f64 = 0.3819660112501051517954131656343618822826908201942371378645513773;
+pub const PHI_INVERSE_SQUARED: f64 =
+    0.3819660112501051517954131656343618822826908201942371378645513773;
 
 /// φ - 1/φ = 1.0 (exact identity)
 pub const PHI_DIFFERENCE: f64 = 1.0;
@@ -80,8 +81,11 @@ mod tests {
     fn test_trinity_identity() {
         // Verify φ² + 1/φ² = 3
         let computed = PHI_SQUARED + PHI_INVERSE_SQUARED;
-        assert!((computed - TRINITY_IDENTITY).abs() < 1e-10,
-                "Trinity identity failed: {} != 3", computed);
+        assert!(
+            (computed - TRINITY_IDENTITY).abs() < 1e-10,
+            "Trinity identity failed: {} != 3",
+            computed
+        );
     }
 
     #[test]

--- a/src/race/asha.rs
+++ b/src/race/asha.rs
@@ -4,14 +4,14 @@
 //!
 //! For TASK-1, this is a stub that returns simple values without database queries.
 
-use uuid::Uuid;
 use anyhow::Result;
-use tracing::{info, warn};
-use rand::SeedableRng;
 use rand::rngs::StdRng;
+use rand::SeedableRng;
+use tracing::{info, warn};
+use uuid::Uuid;
 
+use crate::race::lessons::{Outcome, RungData, TrialConfig};
 use crate::race::neon::NeonDb;
-use crate::race::lessons::{TrialConfig, RungData, Outcome};
 
 /// Architecture kind for IGLA Race (local copy)
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -135,8 +135,10 @@ pub async fn record_checkpoint(
     bpb: f64,
 ) -> Result<()> {
     db.record_checkpoint(trial_id, rung.as_i32(), bpb).await?;
-    info!("Checkpoint recorded: trial_id={:?}, rung={:?}, step={}, BPB={}",
-          trial_id, rung, step, bpb);
+    info!(
+        "Checkpoint recorded: trial_id={:?}, rung={:?}, step={}, BPB={}",
+        trial_id, rung, step, bpb
+    );
     Ok(())
 }
 
@@ -164,8 +166,12 @@ pub async fn handle_pruning(
 ) -> Result<()> {
     db.mark_pruned(trial_id, rung.as_i32(), bpb).await?;
 
-    let rung_data = RungData { step: rung.step(), bpb };
-    let (lesson, lesson_type) = crate::race::lessons::generate_lesson(config, &rung_data, Outcome::Pruned);
+    let rung_data = RungData {
+        step: rung.step(),
+        bpb,
+    };
+    let (lesson, lesson_type) =
+        crate::race::lessons::generate_lesson(config, &rung_data, Outcome::Pruned);
 
     db.store_lesson(
         trial_id,
@@ -174,10 +180,13 @@ pub async fn handle_pruning(
         bpb,
         &lesson,
         &lesson_type.to_string(),
-    ).await?;
+    )
+    .await?;
 
-    warn!("Trial pruned: trial_id={:?}, rung={:?}, BPB={}, lesson={}",
-           trial_id, rung, bpb, lesson);
+    warn!(
+        "Trial pruned: trial_id={:?}, rung={:?}, BPB={}, lesson={}",
+        trial_id, rung, bpb, lesson
+    );
 
     Ok(())
 }
@@ -189,7 +198,8 @@ pub async fn mark_completed(
     final_step: usize,
     final_bpb: f64,
 ) -> Result<()> {
-    db.mark_completed(trial_id, final_bpb, final_step as i32).await?;
+    db.mark_completed(trial_id, final_bpb, final_step as i32)
+        .await?;
 
     if final_bpb < 1.5 {
         info!("IGLA FOUND! trial_id={:?}, BPB={}", trial_id, final_bpb);
@@ -206,16 +216,13 @@ pub async fn register_trial(
     config_json: &str,
 ) -> Result<Uuid> {
     let trial_id = Uuid::new_v4();
-    db.register_trial(&trial_id, machine_id, worker_id as i32, config_json).await?;
+    db.register_trial(&trial_id, machine_id, worker_id as i32, config_json)
+        .await?;
     Ok(trial_id)
 }
 
 /// Check if config is already running (STUB)
-pub async fn is_config_running(
-    db: &NeonDb,
-    machine_id: &str,
-    config_json: &str,
-) -> Result<bool> {
+pub async fn is_config_running(db: &NeonDb, machine_id: &str, config_json: &str) -> Result<bool> {
     db.is_config_running(machine_id, config_json).await
 }
 
@@ -234,8 +241,7 @@ pub async fn run_worker(
 
     // Parse architecture type
     let default_config = AshaConfig::default();
-    let arch_kind = ArchKind::parse_arch(&default_config.arch)
-        .unwrap_or(ArchKind::Jepa);
+    let arch_kind = ArchKind::parse_arch(&default_config.arch).unwrap_or(ArchKind::Jepa);
 
     // Get rung schedule based on architecture
     let rungs = arch_kind.rung_schedule();
@@ -244,46 +250,63 @@ pub async fn run_worker(
         // 1. sample_config(worker_id) → trial config
         let config = sample_config(&mut rng, &default_config.arch);
         let config_json = serde_json::to_string(&config)?;
-        
+
         // 2. register_trial in Neon
         trial_counter += 1;
         let trial_id = format!("{}-w{}-t{}", machine_id, worker_id, trial_counter);
-        let trial_uuid = Uuid::parse_str(&trial_id.replace("-", "")).unwrap_or_else(|_| Uuid::new_v4());
-        
-        if let Err(e) = db.register_trial(&trial_uuid, machine_id, worker_id as i32, &config_json).await {
+        let trial_uuid =
+            Uuid::parse_str(&trial_id.replace("-", "")).unwrap_or_else(|_| Uuid::new_v4());
+
+        if let Err(e) = db
+            .register_trial(&trial_uuid, machine_id, worker_id as i32, &config_json)
+            .await
+        {
             warn!("register trial failed: {e}");
             continue;
         }
-        
-        info!("[w{worker_id}] trial {trial_id}: h={} lr={:.6}", 
-              config.hidden.unwrap_or(256), config.lr.unwrap_or(0.004));
-        
+
+        info!(
+            "[w{worker_id}] trial {trial_id}: h={} lr={:.6}",
+            config.hidden.unwrap_or(256),
+            config.lr.unwrap_or(0.004)
+        );
+
         let mut pruned = false;
-        
+
         // 3. For each rung in schedule (JEPA skips 1000)
         let min_rung = arch_kind.min_rung();
 
         for &rung in &rungs {
             // JEPA: skip rung 1000 due to slower convergence
             if rung < min_rung {
-                info!("Skipping rung {} for JEPA (below min rung {})", rung, min_rung);
+                info!(
+                    "Skipping rung {} for JEPA (below min rung {})",
+                    rung, min_rung
+                );
                 continue;
             }
 
             let rung_steps = rung as usize;
-            
+
             // a. Spawn subprocess: ./target/release/trios-igla-trainer with config args
             let output = Command::new("./target/release/trios-igla-trainer")
-                .arg("--seed").arg("42") // Fixed seed for now
-                .arg("--steps").arg(rung_steps.to_string())
-                .arg("--hidden").arg(config.hidden.unwrap_or(256).to_string())
-                .arg("--context").arg("6") // Fixed context for now
-                .arg("--lr").arg(format!("{:.8}", config.lr.unwrap_or(0.004)))
-                .arg("--arch").arg(&default_config.arch) // Use arch from config
-                .arg("--exp-id").arg(&trial_id)
+                .arg("--seed")
+                .arg("42") // Fixed seed for now
+                .arg("--steps")
+                .arg(rung_steps.to_string())
+                .arg("--hidden")
+                .arg(config.hidden.unwrap_or(256).to_string())
+                .arg("--context")
+                .arg("6") // Fixed context for now
+                .arg("--lr")
+                .arg(format!("{:.8}", config.lr.unwrap_or(0.004)))
+                .arg("--arch")
+                .arg(&default_config.arch) // Use arch from config
+                .arg("--exp-id")
+                .arg(&trial_id)
                 .output()
                 .await?;
-            
+
             if !output.status.success() {
                 let stderr = String::from_utf8_lossy(&output.stderr);
                 warn!("[w{worker_id}] trainer failed at rung {rung_steps}: {stderr}");
@@ -291,38 +314,44 @@ pub async fn run_worker(
                 pruned = true;
                 break;
             }
-            
+
             // b. Parse BPB from stdout last line
             let stdout = String::from_utf8_lossy(&output.stdout);
             let last_line = stdout.lines().last().unwrap_or("");
-            let bpb_str = last_line.strip_prefix("BPB=")
+            let bpb_str = last_line
+                .strip_prefix("BPB=")
                 .ok_or_else(|| anyhow::anyhow!("last stdout line is not BPB=: {last_line}"))?;
             let bpb: f64 = bpb_str.parse()?;
-            
+
             // c. update_rung in Neon - mock for now
-            info!("Update rung: trial={}, rung={}, BPB={}", trial_id, rung_steps, bpb);
-            
+            info!(
+                "Update rung: trial={}, rung={}, BPB={}",
+                trial_id, rung_steps, bpb
+            );
+
             // e. if bpb < 1.50 → save_winner in Neon → return Ok(bpb)
             if bpb < 1.50 {
                 info!("[w{worker_id}] IGLA FOUND! BPB={bpb:.4}");
                 {
                     let mut best = best_bpb.write().unwrap();
-                    if bpb < *best { *best = bpb; }
+                    if bpb < *best {
+                        *best = bpb;
+                    }
                 }
                 return Ok(bpb);
             }
-            
+
             // d. if should_prune(rung, bpb) → break to next trial
             // Mock median check - in reality would query Neon
             let should_prune = bpb > crate::invariants::INV2_BPB_PRUNE_THRESHOLD;
-            
+
             if should_prune {
                 info!("Prune trial: BPB={}", bpb);
                 pruned = true;
                 break;
             }
         }
-        
+
         if !pruned {
             info!("Mark trial completed: {}", trial_id);
         }

--- a/src/race/bpb.rs
+++ b/src/race/bpb.rs
@@ -29,10 +29,10 @@
 //!
 //! Refs: trios#143 lane L1 · INV-1 · INV-7 · L-R14 · R8.
 
-use crate::race::ema::{EmaError, EmaTracker};
-use crate::invariants::INV2_WARMUP_BLIND_STEPS;
-use crate::race::victory::{SeedResult, JEPA_PROXY_BPB_FLOOR};
 use crate::invariants::IGLA_TARGET_BPB;
+use crate::invariants::INV2_WARMUP_BLIND_STEPS;
+use crate::race::ema::{EmaError, EmaTracker};
+use crate::race::victory::{SeedResult, JEPA_PROXY_BPB_FLOOR};
 
 // ----------------------------------------------------------------------
 // Errors
@@ -54,10 +54,9 @@ pub enum BpbError {
 impl core::fmt::Display for BpbError {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         match self {
-            BpbError::BeforeWarmup => write!(
-                f,
-                "BPB observation before INV2_WARMUP_BLIND_STEPS — reject"
-            ),
+            BpbError::BeforeWarmup => {
+                write!(f, "BPB observation before INV2_WARMUP_BLIND_STEPS — reject")
+            }
             BpbError::JepaProxyDetected => write!(
                 f,
                 "BPB ≤ JEPA_PROXY_BPB_FLOOR (0.1) — TASK-5D proxy artefact, reject"
@@ -364,14 +363,8 @@ mod tests {
     #[test]
     fn falsify_bad_alpha_rejected_at_construction() {
         // α out of (0, 1] propagates as BpbError::EmaRejected.
-        assert_eq!(
-            BpbTracker::new(0, 0.0).unwrap_err(),
-            BpbError::EmaRejected
-        );
-        assert_eq!(
-            BpbTracker::new(0, 2.0).unwrap_err(),
-            BpbError::EmaRejected
-        );
+        assert_eq!(BpbTracker::new(0, 0.0).unwrap_err(), BpbError::EmaRejected);
+        assert_eq!(BpbTracker::new(0, 2.0).unwrap_err(), BpbError::EmaRejected);
     }
 
     #[test]
@@ -413,7 +406,8 @@ mod tests {
             BpbTracker::phi_default(303),
         ];
         for (i, t) in trackers.iter_mut().enumerate() {
-            t.record(POST_WARMUP, 1.5 - 0.05 * (i as f64 + 1.0)).unwrap();
+            t.record(POST_WARMUP, 1.5 - 0.05 * (i as f64 + 1.0))
+                .unwrap();
         }
         let results: Vec<SeedResult> = trackers
             .iter()

--- a/src/race/ema.rs
+++ b/src/race/ema.rs
@@ -139,10 +139,7 @@ impl EmaTracker {
     /// Construct an EMA with an explicit decay.  Returns
     /// `Err(AlphaOutOfRange)` if `α ∉ (0, 1]`.
     pub fn with_alpha(alpha: f64) -> Result<Self, EmaError> {
-        if !alpha.is_finite()
-            || alpha <= ALPHA_MIN_EXCLUSIVE
-            || alpha > ALPHA_MAX_INCLUSIVE
-        {
+        if !alpha.is_finite() || alpha <= ALPHA_MIN_EXCLUSIVE || alpha > ALPHA_MAX_INCLUSIVE {
             return Err(EmaError::AlphaOutOfRange);
         }
         Ok(Self {

--- a/src/race/gf16.rs
+++ b/src/race/gf16.rs
@@ -82,7 +82,10 @@ impl fmt::Display for Gf16Error {
                 f,
                 "INV-3: d_model={d_model} < {floor} (Lucas-closure floor); GF16 quantization unsafe"
             ),
-            Gf16Error::ErrorAboveBound { observed, certified_bound } => write!(
+            Gf16Error::ErrorAboveBound {
+                observed,
+                certified_bound,
+            } => write!(
                 f,
                 "INV-3: GF16 error={observed:.6} > φ⁻⁶ ≈ {certified_bound:.6} (certified bound)"
             ),
@@ -105,7 +108,10 @@ impl std::error::Error for Gf16Error {}
 /// Falsification: `gf16_falsification_witness: gf16_safe 255 true = false`.
 pub fn check_d_model(d_model: usize) -> Result<(), Gf16Error> {
     if d_model < D_MODEL_MIN {
-        Err(Gf16Error::DModelBelowFloor { d_model, floor: D_MODEL_MIN })
+        Err(Gf16Error::DModelBelowFloor {
+            d_model,
+            floor: D_MODEL_MIN,
+        })
     } else {
         Ok(())
     }
@@ -182,7 +188,13 @@ mod tests {
     fn falsification_d_model_255_rejected() {
         // Mirrors Coq: gf16_falsification_witness: gf16_safe 255 true = false.
         let r = check_d_model(255);
-        assert_eq!(r, Err(Gf16Error::DModelBelowFloor { d_model: 255, floor: 256 }));
+        assert_eq!(
+            r,
+            Err(Gf16Error::DModelBelowFloor {
+                d_model: 255,
+                floor: 256
+            })
+        );
     }
 
     #[test]
@@ -191,7 +203,10 @@ mod tests {
         let above = 1.0 / crate::invariants::PHI.powi(5);
         let r = check_error(above);
         match r {
-            Err(Gf16Error::ErrorAboveBound { observed, certified_bound }) => {
+            Err(Gf16Error::ErrorAboveBound {
+                observed,
+                certified_bound,
+            }) => {
                 assert!((observed - above).abs() < 1e-12);
                 assert!((certified_bound - ERROR_BOUND_CERTIFIED).abs() < 1e-12);
             }
@@ -211,7 +226,10 @@ mod tests {
 
     #[test]
     fn falsification_neg_inf_error_rejected() {
-        assert_eq!(check_error(f64::NEG_INFINITY), Err(Gf16Error::NonFiniteError));
+        assert_eq!(
+            check_error(f64::NEG_INFINITY),
+            Err(Gf16Error::NonFiniteError)
+        );
     }
 
     #[test]
@@ -271,7 +289,10 @@ mod tests {
     fn composite_rejects_d_model_first() {
         // When BOTH predicates fail, the d_model error wins (returned first).
         let r = gf16_safe(128, 1.0);
-        assert!(matches!(r, Err(Gf16Error::DModelBelowFloor { d_model: 128, .. })));
+        assert!(matches!(
+            r,
+            Err(Gf16Error::DModelBelowFloor { d_model: 128, .. })
+        ));
     }
 
     #[test]
@@ -284,7 +305,13 @@ mod tests {
 
     #[test]
     fn error_display_d_model_floor() {
-        let s = format!("{}", Gf16Error::DModelBelowFloor { d_model: 64, floor: 256 });
+        let s = format!(
+            "{}",
+            Gf16Error::DModelBelowFloor {
+                d_model: 64,
+                floor: 256
+            }
+        );
         assert!(s.contains("d_model=64"));
         assert!(s.contains("256"));
         assert!(s.contains("INV-3"));
@@ -294,7 +321,10 @@ mod tests {
     fn error_display_above_bound() {
         let s = format!(
             "{}",
-            Gf16Error::ErrorAboveBound { observed: 0.1, certified_bound: ERROR_BOUND_CERTIFIED }
+            Gf16Error::ErrorAboveBound {
+                observed: 0.1,
+                certified_bound: ERROR_BOUND_CERTIFIED
+            }
         );
         assert!(s.contains("INV-3"));
         assert!(s.contains("φ⁻⁶"));

--- a/src/race/hive_automaton.rs
+++ b/src/race/hive_automaton.rs
@@ -64,8 +64,14 @@ pub const LANE_COUNT: usize = 14;
 // away from the JSON anchors. `const _: ()` is the canonical Rust idiom for
 // build-time invariants.
 const _: () = {
-    assert!(VICTORY_SEED_TARGET == 3, "JSON requires 3 distinct victory seeds");
-    assert!(LANE_COUNT == 14, "lane_ownership in JSON has 14 entries (L0..L13)");
+    assert!(
+        VICTORY_SEED_TARGET == 3,
+        "JSON requires 3 distinct victory seeds"
+    );
+    assert!(
+        LANE_COUNT == 14,
+        "lane_ownership in JSON has 14 entries (L0..L13)"
+    );
     // BPB_VICTORY_TARGET cannot be checked with `const fn` float compare on
     // stable, but the runtime test `test_bpb_target_matches_lib` enforces it.
 };
@@ -272,7 +278,10 @@ impl HiveAutomaton {
 
     /// Construct from an explicit priority queue (used in tests).
     pub fn with_queue(queue: Vec<Lane>) -> Self {
-        Self { state: State::Boot, priority_queue: queue }
+        Self {
+            state: State::Boot,
+            priority_queue: queue,
+        }
     }
 
     pub fn state(&self) -> State {
@@ -577,7 +586,11 @@ mod tests {
         assert_eq!(h.state(), State::Done);
         // The next tick MUST be RescanIssue, not Halt.
         let a = h.next_action(&w);
-        assert_eq!(a, AgentAction::RescanIssue, "Done must cycle to Scan, never Idle");
+        assert_eq!(
+            a,
+            AgentAction::RescanIssue,
+            "Done must cycle to Scan, never Idle"
+        );
         assert_eq!(h.state(), State::Scan);
         assert!(!h.state().is_absorbing());
     }
@@ -601,7 +614,10 @@ mod tests {
         let mut w = world_after_boot();
         w.deadline_passed = true;
         let a = h.next_action(&w);
-        assert_eq!(a, AgentAction::Halt(HaltCause::HardAbort(AbortReason::DeadlinePassed)));
+        assert_eq!(
+            a,
+            AgentAction::Halt(HaltCause::HardAbort(AbortReason::DeadlinePassed))
+        );
         assert_eq!(h.state(), State::HardAbort);
     }
 
@@ -613,7 +629,9 @@ mod tests {
         let a = h.next_action(&w);
         assert_eq!(
             a,
-            AgentAction::Halt(HaltCause::HardAbort(AbortReason::R7ForbiddenValueIntroduced))
+            AgentAction::Halt(HaltCause::HardAbort(
+                AbortReason::R7ForbiddenValueIntroduced
+            ))
         );
     }
 
@@ -665,7 +683,10 @@ mod tests {
     fn test_priority_queue_default_matches_json() {
         // L7, L6, L9, L11, L12 — see `assertions/hive_automaton.json::lane_priority_queue`.
         let h = HiveAutomaton::new();
-        assert_eq!(h.priority_queue, vec![Lane::L7, Lane::L6, Lane::L9, Lane::L11, Lane::L12]);
+        assert_eq!(
+            h.priority_queue,
+            vec![Lane::L7, Lane::L6, Lane::L9, Lane::L11, Lane::L12]
+        );
     }
 
     #[test]

--- a/src/race/lessons.rs
+++ b/src/race/lessons.rs
@@ -1,18 +1,18 @@
 //! Failure Memory — automatic lesson generation from pruned trials
 
-use serde::{Deserialize, Serialize};
 use crate::race::neon::NeonDb;
 use anyhow::Result;
+use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
 /// Lesson type for categorizing patterns
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 pub enum LessonType {
-    Avoid,    // "AVOID: ..." — definite anti-pattern
-    Pattern,  // "PATTERN: ..." — observed pattern
-    Winner,   // "WINNER: ..." — successful config
-    Warn,     // "WARN: ..." — potential issue
-    Info,     // "INFO: ..." — neutral observation
+    Avoid,   // "AVOID: ..." — definite anti-pattern
+    Pattern, // "PATTERN: ..." — observed pattern
+    Winner,  // "WINNER: ..." — successful config
+    Warn,    // "WARN: ..." — potential issue
+    Info,    // "INFO: ..." — neutral observation
 }
 
 impl std::fmt::Display for LessonType {
@@ -83,14 +83,16 @@ pub fn generate_lesson(
     if let Some(lr) = config.lr {
         if lr > 0.05 {
             lessons.push((
-                format!("AVOID: lr={} too high — BPB={} at rung-{}, always pruned",
-                         lr, rung.bpb, rung.step),
-                LessonType::Avoid
+                format!(
+                    "AVOID: lr={} too high — BPB={} at rung-{}, always pruned",
+                    lr, rung.bpb, rung.step
+                ),
+                LessonType::Avoid,
             ));
         } else if lr < 0.001 {
             lessons.push((
                 format!("WARN: lr={} too low — may not converge", lr),
-                LessonType::Warn
+                LessonType::Warn,
             ));
         }
     }
@@ -99,9 +101,11 @@ pub fn generate_lesson(
     if let Some(d_model) = config.d_model {
         if d_model <= 64 && rung.bpb > 2.8 {
             lessons.push((
-                format!("PATTERN: d_model={} insufficient capacity, never below {} BPB",
-                         d_model, rung.bpb),
-                LessonType::Pattern
+                format!(
+                    "PATTERN: d_model={} insufficient capacity, never below {} BPB",
+                    d_model, rung.bpb
+                ),
+                LessonType::Pattern,
             ));
         }
     }
@@ -111,7 +115,7 @@ pub fn generate_lesson(
         if hidden < 32 {
             lessons.push((
                 format!("WARN: hidden={} too small — limited expressiveness", hidden),
-                LessonType::Warn
+                LessonType::Warn,
             ));
         }
     }
@@ -120,8 +124,11 @@ pub fn generate_lesson(
     if let Some(wd) = config.weight_decay {
         if wd > 0.1 && rung.bpb > 3.0 {
             lessons.push((
-                format!("AVOID: weight_decay={} too aggressive — causes underfitting", wd),
-                LessonType::Avoid
+                format!(
+                    "AVOID: weight_decay={} too aggressive — causes underfitting",
+                    wd
+                ),
+                LessonType::Avoid,
             ));
         }
     }
@@ -131,7 +138,7 @@ pub fn generate_lesson(
         if opt.contains("sgd") && rung.bpb > 2.7 {
             lessons.push((
                 "PATTERN: SGD optimizer underperforms — use AdamW or Muon".to_string(),
-                LessonType::Pattern
+                LessonType::Pattern,
             ));
         }
     }
@@ -139,9 +146,11 @@ pub fn generate_lesson(
     // Early pruning pattern
     if rung.step <= 1000 && rung.bpb > 3.0 {
         lessons.push((
-            format!("AVOID: BPB={} at rung-{} — early death, check config",
-                     rung.bpb, rung.step),
-            LessonType::Avoid
+            format!(
+                "AVOID: BPB={} at rung-{} — early death, check config",
+                rung.bpb, rung.step
+            ),
+            LessonType::Avoid,
         ));
     }
 
@@ -149,12 +158,13 @@ pub fn generate_lesson(
     if lessons.is_empty() {
         lessons.push((
             format!("INFO: trial {} at BPB={}", outcome, rung.bpb),
-            LessonType::Info
+            LessonType::Info,
         ));
     }
 
     // Return most severe lesson
-    let (lesson, lesson_type) = lessons.into_iter()
+    let (lesson, lesson_type) = lessons
+        .into_iter()
         .min_by(|a, b| {
             // Priority: Avoid > Pattern > Warn > Info > Winner
             let priority = |t: LessonType| match t {
@@ -188,18 +198,19 @@ pub async fn store_lesson(
         bpb_at_pruned,
         lesson,
         lesson_type,
-    ).await?;
+    )
+    .await?;
 
     Ok(())
 }
 
 /// Get top lessons from experience
-pub async fn get_top_lessons(
-    db: &NeonDb,
-    limit: i32,
-) -> Result<Vec<(String, String, i32)>> {
+pub async fn get_top_lessons(db: &NeonDb, limit: i32) -> Result<Vec<(String, String, i32)>> {
     let lessons = db.get_top_lessons(limit).await?;
-    Ok(lessons.into_iter().map(|l| (l.lesson, l.lesson_type, l.pattern_count)).collect())
+    Ok(lessons
+        .into_iter()
+        .map(|l| (l.lesson, l.lesson_type, l.pattern_count))
+        .collect())
 }
 
 #[cfg(test)]
@@ -221,7 +232,10 @@ mod tests {
             max_steps: None,
         };
 
-        let rung = RungData { step: 1000, bpb: 3.4 };
+        let rung = RungData {
+            step: 1000,
+            bpb: 3.4,
+        };
         let (lesson, _lesson_type) = generate_lesson(&config, &rung, Outcome::Pruned);
 
         assert_eq!(_lesson_type, LessonType::Avoid);
@@ -244,7 +258,10 @@ mod tests {
             max_steps: None,
         };
 
-        let rung = RungData { step: 1000, bpb: 2.9 };
+        let rung = RungData {
+            step: 1000,
+            bpb: 2.9,
+        };
         let (lesson, _lesson_type) = generate_lesson(&config, &rung, Outcome::Pruned);
 
         assert!(lesson.contains("d_model=64"));
@@ -265,7 +282,10 @@ mod tests {
             max_steps: None,
         };
 
-        let rung = RungData { step: 1000, bpb: 3.2 };
+        let rung = RungData {
+            step: 1000,
+            bpb: 3.2,
+        };
         let (lesson, _lesson_type) = generate_lesson(&config, &rung, Outcome::Pruned);
 
         assert!(lesson.contains("BPB=3.2"));
@@ -287,7 +307,10 @@ mod tests {
             max_steps: None,
         };
 
-        let rung = RungData { step: 1000, bpb: 3.5 };
+        let rung = RungData {
+            step: 1000,
+            bpb: 3.5,
+        };
         let (_lesson, lesson_type) = generate_lesson(&config, &rung, Outcome::Pruned);
 
         // Should prioritize AVOID lessons

--- a/src/race/mod.rs
+++ b/src/race/mod.rs
@@ -1,1 +1,14 @@
-pub mod asha; pub mod attn; pub mod bpb; pub mod ema; pub mod gf16; pub mod hive_automaton; pub mod lessons; pub mod nca; pub mod neon; pub mod race_runner; pub mod rungs; pub mod sampler; pub mod status; pub mod victory;
+pub mod asha;
+pub mod attn;
+pub mod bpb;
+pub mod ema;
+pub mod gf16;
+pub mod hive_automaton;
+pub mod lessons;
+pub mod nca;
+pub mod neon;
+pub mod race_runner;
+pub mod rungs;
+pub mod sampler;
+pub mod status;
+pub mod victory;

--- a/src/race/nca.rs
+++ b/src/race/nca.rs
@@ -185,10 +185,7 @@ pub fn validate_nca_entropy(
 /// without forcing the caller to repeat `INV4_NCA_GRID` / `_K_STATES`
 /// at every call site.  Equivalent to
 /// `validate_nca_entropy(h, mode, INV4_NCA_GRID, INV4_NCA_K_STATES)`.
-pub fn validate_nca_entropy_canonical(
-    h: f64,
-    mode: NcaBandMode,
-) -> Result<NcaReport, NcaError> {
+pub fn validate_nca_entropy_canonical(h: f64, mode: NcaBandMode) -> Result<NcaReport, NcaError> {
     validate_nca_entropy(h, mode, INV4_NCA_GRID, INV4_NCA_K_STATES)
 }
 

--- a/src/race/neon.rs
+++ b/src/race/neon.rs
@@ -90,12 +90,7 @@ impl NeonDb {
         Ok(())
     }
 
-    pub async fn record_checkpoint(
-        &self,
-        trial_id: &Uuid,
-        rung: i32,
-        bpb: f64,
-    ) -> Result<()> {
+    pub async fn record_checkpoint(&self, trial_id: &Uuid, rung: i32, bpb: f64) -> Result<()> {
         info!("Checkpoint recorded (STUB): trial={trial_id} rung={rung} BPB={bpb:.4}");
         Ok(())
     }
@@ -153,13 +148,27 @@ impl NeonDb {
         Ok(vec![])
     }
 
-    pub async fn query(&self, query: &str, _params: &[&(dyn tokio_postgres::types::ToSql + Sync)]) -> Result<Vec<tokio_postgres::Row>> {
-        info!("Query (STUB): {}", query.trim().chars().take(80).collect::<String>());
+    pub async fn query(
+        &self,
+        query: &str,
+        _params: &[&(dyn tokio_postgres::types::ToSql + Sync)],
+    ) -> Result<Vec<tokio_postgres::Row>> {
+        info!(
+            "Query (STUB): {}",
+            query.trim().chars().take(80).collect::<String>()
+        );
         Ok(vec![])
     }
 
-    pub async fn query_one(&self, query: &str, _params: &[&(dyn tokio_postgres::types::ToSql + Sync)]) -> Result<tokio_postgres::Row> {
-        info!("Query one (STUB): {}", query.trim().chars().take(80).collect::<String>());
+    pub async fn query_one(
+        &self,
+        query: &str,
+        _params: &[&(dyn tokio_postgres::types::ToSql + Sync)],
+    ) -> Result<tokio_postgres::Row> {
+        info!(
+            "Query one (STUB): {}",
+            query.trim().chars().take(80).collect::<String>()
+        );
         Err(anyhow::anyhow!("no rows (STUB)"))
     }
 }
@@ -255,8 +264,7 @@ mod tests {
 
     #[test]
     fn test_dashboard_meta_with_branch() {
-        let meta = DashboardMeta::new("GAMMA", "macbook-pro-1", "w0")
-            .with_branch("feat/jepa");
+        let meta = DashboardMeta::new("GAMMA", "macbook-pro-1", "w0").with_branch("feat/jepa");
         assert_eq!(meta.branch, "feat/jepa");
     }
 

--- a/src/race/race_runner.rs
+++ b/src/race/race_runner.rs
@@ -44,8 +44,8 @@ use rand::SeedableRng;
 
 use crate::invariants::{
     validate_inv_config, GradientMode, InvError, InvTrialConfig, INV1_CHAMPION_LR,
-    INV2_BPB_PRUNE_THRESHOLD, INV2_WARMUP_BLIND_STEPS, INV3_D_MODEL_MIN,
-    INV4_NCA_GRID, INV4_NCA_K_STATES,
+    INV2_BPB_PRUNE_THRESHOLD, INV2_WARMUP_BLIND_STEPS, INV3_D_MODEL_MIN, INV4_NCA_GRID,
+    INV4_NCA_K_STATES,
 };
 use crate::race::rungs::{iter_rungs, Rung};
 use crate::race::sampler::sample_lr;
@@ -170,10 +170,7 @@ impl TelemetrySink {
     /// Append one row. Lock is held only for the duration of the write —
     /// workers contend at most for a single `writeln!` call.
     pub fn record(&self, r: &TrialRecord) -> std::io::Result<()> {
-        let mut guard = self
-            .inner
-            .lock()
-            .expect("telemetry sink mutex poisoned");
+        let mut guard = self.inner.lock().expect("telemetry sink mutex poisoned");
         writeln!(
             guard,
             "{},{},{:.9},{},{},{:.9},{}",

--- a/src/race/rungs.rs
+++ b/src/race/rungs.rs
@@ -58,7 +58,10 @@ pub const RUNG_COUNT: usize = (MAX_RUNG_EXP as usize) + 1;
 const _: () = {
     assert!(TRINITY_BASE == 3, "Trinity base must be 3 (φ² + φ⁻²)");
     assert!(RUNG_UNIT == 1_000, "Rung unit pinned by INV-12 JSON anchor");
-    assert!(MAX_RUNG_EXP == 3, "Max rung exponent pinned to 3 (rung 27000)");
+    assert!(
+        MAX_RUNG_EXP == 3,
+        "Max rung exponent pinned to 3 (rung 27000)"
+    );
 };
 
 // ─── Rung type ───────────────────────────────────────────────────────────
@@ -184,10 +187,7 @@ pub fn check_inv12_rung_valid(step: u32) -> Result<Rung, InvError> {
 
 /// Convenience: validate a `usize` step (used by `asha.rs::record_checkpoint`).
 pub fn check_inv12_rung_valid_usize(step: usize) -> Result<Rung, InvError> {
-    let s32 = u32::try_from(step).map_err(|_| InvError::Inv4GridMismatch {
-        grid: step,
-        k: 0,
-    })?;
+    let s32 = u32::try_from(step).map_err(|_| InvError::Inv4GridMismatch { grid: step, k: 0 })?;
     check_inv12_rung_valid(s32)
 }
 

--- a/src/race/sampler.rs
+++ b/src/race/sampler.rs
@@ -27,9 +27,7 @@
 
 use rand::Rng;
 
-use crate::invariants::{
-    INV1_CHAMPION_LR, INV1_LR_SAFE_HI, INV1_LR_SAFE_LO,
-};
+use crate::invariants::{INV1_CHAMPION_LR, INV1_LR_SAFE_HI, INV1_LR_SAFE_LO};
 
 /// Width of the φ-safe LR band in natural-log space.
 ///
@@ -115,8 +113,11 @@ pub fn champion_lr() -> f64 {
 #[cfg(feature = "race-sampler-tests")]
 mod tests {
     use super::*;
-    use crate::invariants::{validate_inv_config, validate_config, GradientMode, InvTrialConfig, TrialConfig as InvTrialConfig2, INV2_BPB_PRUNE_THRESHOLD,
-        INV2_WARMUP_BLIND_STEPS, INV4_NCA_GRID, INV4_NCA_K_STATES};
+    use crate::invariants::{
+        validate_config, validate_inv_config, GradientMode, InvTrialConfig,
+        TrialConfig as InvTrialConfig2, INV2_BPB_PRUNE_THRESHOLD, INV2_WARMUP_BLIND_STEPS,
+        INV4_NCA_GRID, INV4_NCA_K_STATES,
+    };
     use rand::rngs::StdRng;
     use rand::SeedableRng;
 

--- a/src/race/status.rs
+++ b/src/race/status.rs
@@ -3,7 +3,8 @@ use anyhow::Result;
 use crate::race::neon::NeonDb;
 
 pub async fn show_status(db: &NeonDb) -> Result<()> {
-    let rows = db.client()
+    let rows = db
+        .client()
         .query(
             "SELECT trial_id, machine_id, status, \
                     COALESCE(best_bpb::text, '-'), \
@@ -18,8 +19,10 @@ pub async fn show_status(db: &NeonDb) -> Result<()> {
 
     eprintln!();
     eprintln!("IGLA RACE LEADERBOARD");
-    eprintln!("{:<6} {:<20} {:<10} {:<8} {:<10}",
-              "Rank", "Trial", "Status", "BPB", "Arch");
+    eprintln!(
+        "{:<6} {:<20} {:<10} {:<8} {:<10}",
+        "Rank", "Trial", "Status", "BPB", "Arch"
+    );
     eprintln!("{}", "-".repeat(60));
 
     for (i, row) in rows.iter().enumerate() {
@@ -35,15 +38,22 @@ pub async fn show_status(db: &NeonDb) -> Result<()> {
             trial_id
         };
 
-        eprintln!("#{:<5} {:<20} {:<10} {:<8} {:<10}",
-                   i + 1, tid_trunc, status, bpb, arch);
+        eprintln!(
+            "#{:<5} {:<20} {:<10} {:<8} {:<10}",
+            i + 1,
+            tid_trunc,
+            status,
+            bpb,
+            arch
+        );
     }
     eprintln!();
     Ok(())
 }
 
 pub async fn show_best(db: &NeonDb) -> Result<()> {
-    let row = db.client()
+    let row = db
+        .client()
         .query_one(
             "SELECT trial_id, machine_id, config::text, \
                     COALESCE(best_bpb::text, '-'), status \
@@ -68,7 +78,10 @@ pub async fn show_best(db: &NeonDb) -> Result<()> {
             eprintln!("  Machine: {}", machine_id);
             eprintln!("  Status:  {}", status);
             eprintln!("  BPB:     {}", bpb);
-            eprintln!("  Config:  {}", serde_json::to_string_pretty(&config).unwrap_or_default());
+            eprintln!(
+                "  Config:  {}",
+                serde_json::to_string_pretty(&config).unwrap_or_default()
+            );
         }
         Err(_) => {
             eprintln!("No completed trials yet");

--- a/src/race/victory.rs
+++ b/src/race/victory.rs
@@ -43,7 +43,7 @@
 use std::collections::HashSet;
 
 use crate::invariants::INV2_WARMUP_BLIND_STEPS;
-use crate::race::hive_automaton::{VICTORY_SEED_TARGET, BPB_VICTORY_TARGET};
+use crate::race::hive_automaton::{BPB_VICTORY_TARGET, VICTORY_SEED_TARGET};
 
 // Sanity: constants match (L-R14)
 const _: () = assert!((BPB_VICTORY_TARGET - 1.5).abs() < f64::EPSILON);
@@ -131,10 +131,7 @@ pub fn stat_strength(results: &[SeedResult]) -> Result<TtestReport, VictoryError
 
     // Compute sample standard deviation (Bessel's correction)
     let variance: f64 = if n > 1 {
-        let mean_diff_sq: f64 = bpbs
-            .iter()
-            .map(|&b| (b - sample_mean).powi(2))
-            .sum();
+        let mean_diff_sq: f64 = bpbs.iter().map(|&b| (b - sample_mean).powi(2)).sum();
         mean_diff_sq / (n - 1) as f64
     } else {
         0.0
@@ -293,11 +290,7 @@ pub enum VictoryError {
     /// At least one reported result has `bpb >= BPB_VICTORY_TARGET`.  Listed
     /// for diagnostics; gate counts only seeds *strictly below* the
     /// target.
-    BpbAboveTarget {
-        seed: u64,
-        bpb: f64,
-        target: f64,
-    },
+    BpbAboveTarget { seed: u64, bpb: f64, target: f64 },
     /// Same seed reported twice.  Distinct-seed reproducibility is the
     /// whole point of the gate; silently de-duplicating would let two
     /// runs of the same seed masquerade as three.
@@ -476,11 +469,14 @@ mod tests {
     /// must reject (predicate is strict `<`, not `≤`).
     #[test]
     fn falsify_bpb_equal_target_strict_lt() {
-        let r = vec![mk(1, BPB_VICTORY_TARGET), mk(2, BPB_VICTORY_TARGET), mk(3, BPB_VICTORY_TARGET)];
+        let r = vec![
+            mk(1, BPB_VICTORY_TARGET),
+            mk(2, BPB_VICTORY_TARGET),
+            mk(3, BPB_VICTORY_TARGET),
+        ];
         assert!(matches!(
             check_victory(&r),
-            Err(VictoryError::BpbAboveTarget { .. })
-                | Err(VictoryError::InsufficientSeeds { .. })
+            Err(VictoryError::BpbAboveTarget { .. }) | Err(VictoryError::InsufficientSeeds { .. })
         ));
     }
 
@@ -611,13 +607,31 @@ mod tests {
         // Pre-registered analysis: Welch's t-test, alpha = 0.01
         // Three seeds ALL at baseline mu0 = 1.55 — p > 0.01, gate refuses.
         let r = vec![
-            SeedResult { seed: 42, bpb: 1.55, step: 5000, sha: "a".into() },
-            SeedResult { seed: 43, bpb: 1.55, step: 5000, sha: "b".into() },
-            SeedResult { seed: 44, bpb: 1.55, step: 5000, sha: "c".into() },
+            SeedResult {
+                seed: 42,
+                bpb: 1.55,
+                step: 5000,
+                sha: "a".into(),
+            },
+            SeedResult {
+                seed: 43,
+                bpb: 1.55,
+                step: 5000,
+                sha: "b".into(),
+            },
+            SeedResult {
+                seed: 44,
+                bpb: 1.55,
+                step: 5000,
+                sha: "c".into(),
+            },
         ];
         match stat_strength(&r) {
             Err(VictoryError::TtestFailed {
-                t_statistic, p_value, alpha }) => {
+                t_statistic,
+                p_value,
+                alpha,
+            }) => {
                 assert!(p_value >= TTEST_ALPHA);
                 assert!((alpha - TTEST_ALPHA).abs() < f64::EPSILON);
                 // t_statistic >= 0 indicates mean >= baseline
@@ -631,9 +645,24 @@ mod tests {
     #[test]
     fn ttest_passes_when_distribution_clearly_below_baseline() {
         let r = vec![
-            SeedResult { seed: 42, bpb: 1.40, step: 5000, sha: "a".into() },
-            SeedResult { seed: 43, bpb: 1.39, step: 5000, sha: "b".into() },
-            SeedResult { seed: 44, bpb: 1.41, step: 5000, sha: "c".into() },
+            SeedResult {
+                seed: 42,
+                bpb: 1.40,
+                step: 5000,
+                sha: "a".into(),
+            },
+            SeedResult {
+                seed: 43,
+                bpb: 1.39,
+                step: 5000,
+                sha: "b".into(),
+            },
+            SeedResult {
+                seed: 44,
+                bpb: 1.41,
+                step: 5000,
+                sha: "c".into(),
+            },
         ];
         let report = stat_strength(&r).expect("expected t-test pass");
         assert!(report.passed);
@@ -645,9 +674,24 @@ mod tests {
     #[test]
     fn gate_final_check_victory_on_3_row_tail() {
         let r = vec![
-            SeedResult { seed: 42, bpb: 1.42, step: 5000, sha: "a".into() },
-            SeedResult { seed: 43, bpb: 1.44, step: 5000, sha: "b".into() },
-            SeedResult { seed: 44, bpb: 1.40, step: 5000, sha: "c".into() },
+            SeedResult {
+                seed: 42,
+                bpb: 1.42,
+                step: 5000,
+                sha: "a".into(),
+            },
+            SeedResult {
+                seed: 43,
+                bpb: 1.44,
+                step: 5000,
+                sha: "b".into(),
+            },
+            SeedResult {
+                seed: 44,
+                bpb: 1.40,
+                step: 5000,
+                sha: "c".into(),
+            },
         ];
         let report = check_victory(&r).expect("3 Gate-final seeds below 1.5");
         assert_eq!(report.winning_seeds, vec![42, 43, 44]);
@@ -658,33 +702,94 @@ mod tests {
     #[test]
     fn falsify_inv7_rejects_set() {
         let two = vec![
-            SeedResult { seed: 42, bpb: 1.42, step: 5000, sha: "a".into() },
-            SeedResult { seed: 43, bpb: 1.44, step: 5000, sha: "b".into() },
+            SeedResult {
+                seed: 42,
+                bpb: 1.42,
+                step: 5000,
+                sha: "a".into(),
+            },
+            SeedResult {
+                seed: 43,
+                bpb: 1.44,
+                step: 5000,
+                sha: "b".into(),
+            },
         ];
         assert!(check_victory(&two).is_err(), "2 seeds must be rejected");
 
         let dup = vec![
-            SeedResult { seed: 42, bpb: 1.42, step: 5000, sha: "a".into() },
-            SeedResult { seed: 42, bpb: 1.44, step: 5000, sha: "b".into() },
-            SeedResult { seed: 43, bpb: 1.40, step: 5000, sha: "c".into() },
+            SeedResult {
+                seed: 42,
+                bpb: 1.42,
+                step: 5000,
+                sha: "a".into(),
+            },
+            SeedResult {
+                seed: 42,
+                bpb: 1.44,
+                step: 5000,
+                sha: "b".into(),
+            },
+            SeedResult {
+                seed: 43,
+                bpb: 1.40,
+                step: 5000,
+                sha: "c".into(),
+            },
         ];
-        assert!(check_victory(&dup).is_err(), "duplicate seed must be rejected");
+        assert!(
+            check_victory(&dup).is_err(),
+            "duplicate seed must be rejected"
+        );
 
         let one_above = vec![
-            SeedResult { seed: 42, bpb: 1.42, step: 5000, sha: "a".into() },
-            SeedResult { seed: 43, bpb: 1.44, step: 5000, sha: "b".into() },
-            SeedResult { seed: 44, bpb: 1.55, step: 5000, sha: "c".into() },
+            SeedResult {
+                seed: 42,
+                bpb: 1.42,
+                step: 5000,
+                sha: "a".into(),
+            },
+            SeedResult {
+                seed: 43,
+                bpb: 1.44,
+                step: 5000,
+                sha: "b".into(),
+            },
+            SeedResult {
+                seed: 44,
+                bpb: 1.55,
+                step: 5000,
+                sha: "c".into(),
+            },
         ];
-        assert!(check_victory(&one_above).is_err(), "seed with bpb >= 1.5 must be rejected");
+        assert!(
+            check_victory(&one_above).is_err(),
+            "seed with bpb >= 1.5 must be rejected"
+        );
     }
 
     /// L-f4: stat_strength on Gate-final seed set {42,43,44}.
     #[test]
     fn gate_final_stat_strength_on_3_seeds() {
         let r = vec![
-            SeedResult { seed: 42, bpb: 1.35, step: 81000, sha: "a".into() },
-            SeedResult { seed: 43, bpb: 1.38, step: 81000, sha: "b".into() },
-            SeedResult { seed: 44, bpb: 1.32, step: 81000, sha: "c".into() },
+            SeedResult {
+                seed: 42,
+                bpb: 1.35,
+                step: 81000,
+                sha: "a".into(),
+            },
+            SeedResult {
+                seed: 43,
+                bpb: 1.38,
+                step: 81000,
+                sha: "b".into(),
+            },
+            SeedResult {
+                seed: 44,
+                bpb: 1.32,
+                step: 81000,
+                sha: "c".into(),
+            },
         ];
         let report = stat_strength(&r).expect("Gate-final 3-seed stat strength");
         assert!(report.passed);

--- a/src/train_loop.rs
+++ b/src/train_loop.rs
@@ -37,7 +37,9 @@ pub struct RunOutcome {
 fn load_data(path: &str) -> Vec<usize> {
     let raw = std::fs::read(path).unwrap_or_else(|e| {
         eprintln!("Failed to load {}: {}. Using fallback.", path, e);
-        b"The quick brown fox jumps over the lazy dog. ".repeat(100).to_vec()
+        b"The quick brown fox jumps over the lazy dog. "
+            .repeat(100)
+            .to_vec()
     });
     raw.into_iter().map(|b| (b as usize) % VOCAB).collect()
 }
@@ -57,29 +59,51 @@ fn layer_norm_backward(x: &[f32], y: &[f32], dy: &[f32], eps: f32) -> Vec<f32> {
     let std_inv = 1.0 / (var + eps).sqrt();
     let sum_dy: f32 = dy.iter().sum();
     let sum_dy_y: f32 = dy.iter().zip(y.iter()).map(|(d, yi)| d * yi).sum();
-    dy.iter().zip(y.iter()).map(|(d, yi)| (d - sum_dy / n - yi * sum_dy_y / n) * std_inv).collect()
+    dy.iter()
+        .zip(y.iter())
+        .map(|(d, yi)| (d - sum_dy / n - yi * sum_dy_y / n) * std_inv)
+        .collect()
 }
 
 fn softmax(v: &mut [f32]) {
     let max_val = v.iter().cloned().fold(f32::NEG_INFINITY, f32::max);
     let mut sum = 0.0f32;
-    for x in v.iter_mut() { *x = (*x - max_val).exp(); sum += *x; }
-    for x in v.iter_mut() { *x /= sum; }
+    for x in v.iter_mut() {
+        *x = (*x - max_val).exp();
+        sum += *x;
+    }
+    for x in v.iter_mut() {
+        *x /= sum;
+    }
 }
 
 fn cosine_lr(step: usize, max_steps: usize, base_lr: f32, warmup: usize) -> f32 {
-    if step < warmup { return base_lr * step as f32 / warmup.max(1) as f32; }
+    if step < warmup {
+        return base_lr * step as f32 / warmup.max(1) as f32;
+    }
     let p = (step - warmup) as f32 / (max_steps - warmup).max(1) as f32;
     1e-5 + (base_lr - 1e-5) * 0.5 * (1.0 + (std::f32::consts::PI * p).cos())
 }
 
 struct AdamW {
-    m: Vec<f32>, v: Vec<f32>, step: usize, beta1: f32, beta2: f32, wd: f32,
+    m: Vec<f32>,
+    v: Vec<f32>,
+    step: usize,
+    beta1: f32,
+    beta2: f32,
+    wd: f32,
 }
 
 impl AdamW {
     fn new(size: usize, wd: f32) -> Self {
-        Self { m: vec![0.0; size], v: vec![0.0; size], step: 0, beta1: 0.9, beta2: 0.999, wd }
+        Self {
+            m: vec![0.0; size],
+            v: vec![0.0; size],
+            step: 0,
+            beta1: 0.9,
+            beta2: 0.999,
+            wd,
+        }
     }
     fn update(&mut self, params: &mut [f32], grads: &[f32], lr: f32) {
         self.step += 1;
@@ -96,7 +120,9 @@ impl AdamW {
 
 fn gf16_floor(weights: &mut [f32]) {
     let scale = 16.0_f32;
-    for w in weights.iter_mut() { *w = (*w * scale).round() / scale; }
+    for w in weights.iter_mut() {
+        *w = (*w * scale).round() / scale;
+    }
 }
 
 struct HybridModel {
@@ -124,7 +150,9 @@ impl HybridModel {
     fn new(hidden: usize, seed: u64, attn_layers: u8) -> Self {
         let mut s = seed;
         let mut rng = || {
-            s = s.wrapping_mul(6364136223846793005).wrapping_add(1442695040888963407);
+            s = s
+                .wrapping_mul(6364136223846793005)
+                .wrapping_add(1442695040888963407);
             ((s >> 33) as f32) / (u32::MAX as f32) * 2.0 - 1.0
         };
         let lim = (6.0f32 / (3 * DIM) as f32).sqrt();
@@ -144,7 +172,9 @@ impl HybridModel {
 
         let mut m = Self {
             embed: (0..VOCAB * DIM).map(|_| rng() * lim).collect(),
-            ctx: (0..NUM_CTX).map(|_| (0..VOCAB * DIM).map(|_| rng() * lim).collect()).collect(),
+            ctx: (0..NUM_CTX)
+                .map(|_| (0..VOCAB * DIM).map(|_| rng() * lim).collect())
+                .collect(),
             proj: (0..hidden * DIM).map(|_| rng() * lim_h).collect(),
             attn,
             attn_down: (0..d * hidden).map(|_| rng() * lim_down).collect(),
@@ -155,14 +185,29 @@ impl HybridModel {
 
         let d = m.attn.config().d_model;
         let attn_lim = (2.0f32 / d as f32).sqrt();
-        for w in m.attn.wq_mut() { *w = rng() * attn_lim; }
-        for w in m.attn.wk_mut() { *w = rng() * attn_lim; }
-        for w in m.attn.wv_mut() { *w = rng() * attn_lim; }
-        for w in m.attn.wo_mut() { *w = rng() * attn_lim; }
+        for w in m.attn.wq_mut() {
+            *w = rng() * attn_lim;
+        }
+        for w in m.attn.wk_mut() {
+            *w = rng() * attn_lim;
+        }
+        for w in m.attn.wv_mut() {
+            *w = rng() * attn_lim;
+        }
+        for w in m.attn.wo_mut() {
+            *w = rng() * attn_lim;
+        }
 
         let attn_params = d * hidden * 2 + m.attn.total_weights();
-        let total = VOCAB * DIM + NUM_CTX * VOCAB * DIM + hidden * DIM + VOCAB * hidden + attn_params;
-        eprintln!("params={} ({:.1}K) attn_d={} attn_layers={}", total, total as f64 / 1000.0, d, attn_layers);
+        let total =
+            VOCAB * DIM + NUM_CTX * VOCAB * DIM + hidden * DIM + VOCAB * hidden + attn_params;
+        eprintln!(
+            "params={} ({:.1}K) attn_d={} attn_layers={}",
+            total,
+            total as f64 / 1000.0,
+            d,
+            attn_layers
+        );
         m
     }
 
@@ -175,30 +220,69 @@ impl HybridModel {
             let ctx_idx = NGRAM - 2 - ci;
             let t = tokens[pos + ctx_idx].min(VOCAB - 1);
             let cv = &self.ctx[ci][t * DIM..(t + 1) * DIM];
-            for j in 0..DIM { combined[j] += cv[j] * cw; }
+            for j in 0..DIM {
+                combined[j] += cv[j] * cw;
+            }
         }
         let ln = layer_norm(&combined, 1e-5);
         let mut hidden_raw = vec![0.0f32; h];
-        for hi in 0..h { for j in 0..DIM { hidden_raw[hi] += self.proj[hi * DIM + j] * ln[j]; } }
+        for hi in 0..h {
+            for j in 0..DIM {
+                hidden_raw[hi] += self.proj[hi * DIM + j] * ln[j];
+            }
+        }
         let mut hidden = vec![0.0f32; h];
-        for hi in 0..h { hidden[hi] = if hidden_raw[hi] > 0.0 { hidden_raw[hi] * hidden_raw[hi] } else { 0.0 }; }
+        for hi in 0..h {
+            hidden[hi] = if hidden_raw[hi] > 0.0 {
+                hidden_raw[hi] * hidden_raw[hi]
+            } else {
+                0.0
+            };
+        }
 
         let hidden_pre_attn = hidden.clone();
         let mut attn_in = vec![0.0f32; d];
-        for di in 0..d { for hi in 0..h { attn_in[di] += self.attn_down[di * h + hi] * hidden[hi]; } }
-        let attn_out = self.attn.forward(&attn_in, 1).unwrap_or_else(|_| vec![0.0f32; d]);
+        for di in 0..d {
+            for hi in 0..h {
+                attn_in[di] += self.attn_down[di * h + hi] * hidden[hi];
+            }
+        }
+        let attn_out = self
+            .attn
+            .forward(&attn_in, 1)
+            .unwrap_or_else(|_| vec![0.0f32; d]);
         let mut attn_up_out = vec![0.0f32; h];
-        for hi in 0..h { for di in 0..d { attn_up_out[hi] += self.attn_up[hi * d + di] * attn_out[di]; } }
-        for hi in 0..h { hidden[hi] += attn_up_out[hi] * 0.1; }
+        for hi in 0..h {
+            for di in 0..d {
+                attn_up_out[hi] += self.attn_up[hi * d + di] * attn_out[di];
+            }
+        }
+        for hi in 0..h {
+            hidden[hi] += attn_up_out[hi] * 0.1;
+        }
 
         let mut logits = vec![0.0f32; VOCAB];
-        for vi in 0..VOCAB { for hi in 0..h { logits[vi] += self.lm_head[vi * h + hi] * hidden[hi]; } }
+        for vi in 0..VOCAB {
+            for hi in 0..h {
+                logits[vi] += self.lm_head[vi * h + hi] * hidden[hi];
+            }
+        }
 
-        ForwardCache { combined, ln, hidden_pre_attn, attn_in, attn_out, hidden, logits }
+        ForwardCache {
+            combined,
+            ln,
+            hidden_pre_attn,
+            attn_in,
+            attn_out,
+            hidden,
+            logits,
+        }
     }
 
     fn loss_on_seq(&self, tokens: &[usize]) -> f32 {
-        if tokens.len() < NGRAM + 1 { return 0.0; }
+        if tokens.len() < NGRAM + 1 {
+            return 0.0;
+        }
         let count = tokens.len().saturating_sub(NGRAM);
         let mut total = 0.0f32;
         for i in 0..count {
@@ -212,14 +296,30 @@ impl HybridModel {
     }
 }
 
-fn compute_grads(model: &HybridModel, tokens: &[usize], positions: &[usize],
-    g_embed: &mut [f32], g_ctx: &mut [Vec<f32>], g_proj: &mut [f32], g_head: &mut [f32],
-    g_attn_down: &mut [f32], g_attn_up: &mut [f32]) {
+fn compute_grads(
+    model: &HybridModel,
+    tokens: &[usize],
+    positions: &[usize],
+    g_embed: &mut [f32],
+    g_ctx: &mut [Vec<f32>],
+    g_proj: &mut [f32],
+    g_head: &mut [f32],
+    g_attn_down: &mut [f32],
+    g_attn_up: &mut [f32],
+) {
     let h = model.hidden;
     let d = model.attn.config().d_model;
     for &pos in positions {
         let fc = model.forward_cached(tokens, pos);
-        let ForwardCache { combined, ln, hidden_pre_attn, attn_in: _, attn_out, hidden, mut logits } = fc;
+        let ForwardCache {
+            combined,
+            ln,
+            hidden_pre_attn,
+            attn_in: _,
+            attn_out,
+            hidden,
+            mut logits,
+        } = fc;
         softmax(&mut logits);
         let target = tokens[pos + NGRAM].min(VOCAB - 1);
         let mut d_hidden = vec![0.0f32; h];
@@ -240,7 +340,11 @@ fn compute_grads(model: &HybridModel, tokens: &[usize], positions: &[usize],
             }
         }
 
-        for di in 0..d { for hi in 0..h { g_attn_down[di * h + hi] += d_attn_out[di] * hidden_pre_attn[hi]; } }
+        for di in 0..d {
+            for hi in 0..h {
+                g_attn_down[di * h + hi] += d_attn_out[di] * hidden_pre_attn[hi];
+            }
+        }
 
         let mut d_raw = vec![0.0f32; h];
         for hi in 0..h {
@@ -257,11 +361,15 @@ fn compute_grads(model: &HybridModel, tokens: &[usize], positions: &[usize],
         }
         let d_combined = layer_norm_backward(&combined, &ln, &d_ln, 1e-5);
         let t_last = tokens[pos + NGRAM - 1].min(VOCAB - 1);
-        for j in 0..DIM { g_embed[t_last * DIM + j] += d_combined[j]; }
+        for j in 0..DIM {
+            g_embed[t_last * DIM + j] += d_combined[j];
+        }
         for (ci, cw) in CTX_WEIGHTS.iter().enumerate() {
             let ctx_idx = NGRAM - 2 - ci;
             let t = tokens[pos + ctx_idx].min(VOCAB - 1);
-            for j in 0..DIM { g_ctx[ci][t * DIM + j] += cw * d_combined[j]; }
+            for j in 0..DIM {
+                g_ctx[ci][t * DIM + j] += cw * d_combined[j];
+            }
         }
     }
 }
@@ -270,22 +378,39 @@ fn evaluate(model: &HybridModel, tokens: &[usize]) -> f32 {
     let seq = SEQ + 1;
     let num_chunks = 40usize;
     let max_start = tokens.len().saturating_sub(seq);
-    if max_start == 0 { return f32::MAX; }
-    let step = if max_start >= num_chunks * seq { max_start / num_chunks } else { seq };
+    if max_start == 0 {
+        return f32::MAX;
+    }
+    let step = if max_start >= num_chunks * seq {
+        max_start / num_chunks
+    } else {
+        seq
+    };
     let mut total = 0.0f32;
     let mut n = 0usize;
     for c in (0..max_start).step_by(step).take(num_chunks) {
         let end = (c + seq).min(tokens.len());
-        if end - c < NGRAM + 2 { continue; }
+        if end - c < NGRAM + 2 {
+            continue;
+        }
         let loss = model.loss_on_seq(&tokens[c..end]);
-        if loss.is_finite() { total += loss / LN_2; n += 1; }
+        if loss.is_finite() {
+            total += loss / LN_2;
+            n += 1;
+        }
     }
-    if n == 0 { f32::MAX } else { total / n as f32 }
+    if n == 0 {
+        f32::MAX
+    } else {
+        total / n as f32
+    }
 }
 
 pub fn run_single(args: &TrainArgs) -> Result<RunOutcome> {
-    eprintln!("=== trios-train seed={} steps={} hidden={} lr={:.4} attn_layers={} ===",
-        args.seed, args.steps, args.hidden, args.lr, args.attn_layers);
+    eprintln!(
+        "=== trios-train seed={} steps={} hidden={} lr={:.4} attn_layers={} ===",
+        args.seed, args.steps, args.hidden, args.lr, args.attn_layers
+    );
     let train = load_data(&args.train_path);
     let val = load_data(&args.val_path);
     eprintln!("train={} val={}", train.len(), val.len());
@@ -321,33 +446,59 @@ pub fn run_single(args: &TrainArgs) -> Result<RunOutcome> {
         let mut g_au = vec![0.0f32; args.hidden * d];
 
         for _ in 0..accum {
-            rng_s = rng_s.wrapping_mul(6364136223846793005).wrapping_add(1442695040888963407);
+            rng_s = rng_s
+                .wrapping_mul(6364136223846793005)
+                .wrapping_add(1442695040888963407);
             let dl = train.len();
             let ms = dl.saturating_sub(SEQ + 1);
-            if ms == 0 { continue; }
+            if ms == 0 {
+                continue;
+            }
             let cs = (rng_s as usize) % ms;
             let chunk = &train[cs..cs + SEQ + 1];
             let cnt = chunk.len().saturating_sub(NGRAM);
-            if cnt == 0 { continue; }
+            if cnt == 0 {
+                continue;
+            }
             let ns = 8.min(cnt);
             let mut pos = Vec::with_capacity(ns);
             for _ in 0..ns {
-                rng_s = rng_s.wrapping_mul(6364136223846793005).wrapping_add(1442695040888963407);
+                rng_s = rng_s
+                    .wrapping_mul(6364136223846793005)
+                    .wrapping_add(1442695040888963407);
                 pos.push((rng_s as usize) % cnt);
             }
-            compute_grads(&model, chunk, &pos, &mut ge, &mut gc, &mut gp, &mut gh, &mut g_ad, &mut g_au);
+            compute_grads(
+                &model, chunk, &pos, &mut ge, &mut gc, &mut gp, &mut gh, &mut g_ad, &mut g_au,
+            );
         }
 
         let tp = (accum * 8) as f32;
-        for x in ge.iter_mut() { *x /= tp; }
-        for g in gc.iter_mut() { for x in g.iter_mut() { *x /= tp; } }
-        for x in gp.iter_mut() { *x /= tp; }
-        for x in gh.iter_mut() { *x /= tp; }
-        for x in g_ad.iter_mut() { *x /= tp; }
-        for x in g_au.iter_mut() { *x /= tp; }
+        for x in ge.iter_mut() {
+            *x /= tp;
+        }
+        for g in gc.iter_mut() {
+            for x in g.iter_mut() {
+                *x /= tp;
+            }
+        }
+        for x in gp.iter_mut() {
+            *x /= tp;
+        }
+        for x in gh.iter_mut() {
+            *x /= tp;
+        }
+        for x in g_ad.iter_mut() {
+            *x /= tp;
+        }
+        for x in g_au.iter_mut() {
+            *x /= tp;
+        }
 
         opt_embed.update(&mut model.embed, &ge, lr);
-        for (ci, oc) in opt_ctx.iter_mut().enumerate() { oc.update(&mut model.ctx[ci], &gc[ci], lr); }
+        for (ci, oc) in opt_ctx.iter_mut().enumerate() {
+            oc.update(&mut model.ctx[ci], &gc[ci], lr);
+        }
         opt_proj.update(&mut model.proj, &gp, lr);
         opt_attn_down.update(&mut model.attn_down, &g_ad, lr);
         opt_attn_up.update(&mut model.attn_up, &g_au, lr);
@@ -357,35 +508,68 @@ pub fn run_single(args: &TrainArgs) -> Result<RunOutcome> {
             gf16_floor(&mut model.embed);
             gf16_floor(&mut model.proj);
             gf16_floor(&mut model.lm_head);
-            for c in &mut model.ctx { gf16_floor(c); }
+            for c in &mut model.ctx {
+                gf16_floor(c);
+            }
         }
 
         if step % args.eval_every == 0 || step == args.steps {
             let vbpb = evaluate(&model, &val);
             ema_bpb = PHI_INV * ema_bpb + (1.0 - PHI_INV) * vbpb;
-            if ema_bpb < best_bpb && ema_bpb.is_finite() { best_bpb = ema_bpb; }
-            println!("seed={} step={} val_bpb={:.4} ema_bpb={:.4} best={:.4} t={:.1}s",
-                args.seed, step, vbpb, ema_bpb, best_bpb, t0.elapsed().as_secs_f64());
+            if ema_bpb < best_bpb && ema_bpb.is_finite() {
+                best_bpb = ema_bpb;
+            }
+            println!(
+                "seed={} step={} val_bpb={:.4} ema_bpb={:.4} best={:.4} t={:.1}s",
+                args.seed,
+                step,
+                vbpb,
+                ema_bpb,
+                best_bpb,
+                t0.elapsed().as_secs_f64()
+            );
         }
     }
 
-    Ok(RunOutcome { final_bpb: best_bpb as f64, steps_done: args.steps, seed: args.seed })
+    Ok(RunOutcome {
+        final_bpb: best_bpb as f64,
+        steps_done: args.steps,
+        seed: args.seed,
+    })
 }
 
-pub fn run_sweep(steps: usize, hidden: usize, lr: f32, attn_layers: u8, eval_every: usize,
-                 train_path: &str, val_path: &str) -> Result<Vec<RunOutcome>> {
+pub fn run_sweep(
+    steps: usize,
+    hidden: usize,
+    lr: f32,
+    attn_layers: u8,
+    eval_every: usize,
+    train_path: &str,
+    val_path: &str,
+) -> Result<Vec<RunOutcome>> {
     let mut results = Vec::new();
     for &seed in GATE_FINAL_SEEDS {
-        results.push(run_single(&TrainArgs { seed, steps, hidden, lr, attn_layers, eval_every,
-            train_path: train_path.to_string(), val_path: val_path.to_string() })?);
+        results.push(run_single(&TrainArgs {
+            seed,
+            steps,
+            hidden,
+            lr,
+            attn_layers,
+            eval_every,
+            train_path: train_path.to_string(),
+            val_path: val_path.to_string(),
+        })?);
     }
     Ok(results)
 }
 
 pub fn run(cfg: &crate::TrainConfig) -> Result<RunOutcome> {
     let args = TrainArgs {
-        seed: cfg.seed, steps: cfg.steps, hidden: 828,
-        lr: cfg.optimizer.lr as f32, attn_layers: if cfg.model.hybrid_attn { 2 } else { 1 },
+        seed: cfg.seed,
+        steps: cfg.steps,
+        hidden: 828,
+        lr: cfg.optimizer.lr as f32,
+        attn_layers: if cfg.model.hybrid_attn { 2 } else { 1 },
         eval_every: 1000,
         train_path: cfg.data.train_path.clone(),
         val_path: cfg.data.val_path.clone(),

--- a/tests/champion_reproduction.rs
+++ b/tests/champion_reproduction.rs
@@ -5,8 +5,8 @@
 //!
 //! Reference: gHashTag/trios@2446855 — BPB=2.2393 @ 27K steps, seed=43.
 
-use trios_trainer::TrainConfig;
 use trios_trainer::train_loop::{self, DEFAULT_IGLA_TARGET_BPB};
+use trios_trainer::TrainConfig;
 
 #[test]
 fn champion_config_loads_and_validates() {
@@ -15,7 +15,10 @@ fn champion_config_loads_and_validates() {
     assert_eq!(cfg.name, "champion");
     assert_eq!(cfg.seed, 43);
     assert_eq!(cfg.steps, 27_000);
-    assert!((cfg.optimizer.lr - 0.004).abs() < 1e-9, "INV-8: lr must be 0.004");
+    assert!(
+        (cfg.optimizer.lr - 0.004).abs() < 1e-9,
+        "INV-8: lr must be 0.004"
+    );
     assert!((cfg.target_bpb - 1.50).abs() < 1e-9);
     assert!(cfg.champion_bpb.is_some());
     let champ = cfg.champion_bpb.unwrap();
@@ -30,7 +33,10 @@ fn champion_model_config_matches_spec() {
     assert_eq!(cfg.model.n_heads, 4);
     assert_eq!(cfg.model.vocab_size, 32_000);
     assert_eq!(cfg.model.seq_len, 1024);
-    assert!(!cfg.model.hybrid_attn, "champion uses plain causal attention");
+    assert!(
+        !cfg.model.hybrid_attn,
+        "champion uses plain causal attention"
+    );
 }
 
 #[test]
@@ -59,7 +65,8 @@ fn target_bpb_below_igla_gate() {
     assert!(
         cfg.target_bpb < DEFAULT_IGLA_TARGET_BPB,
         "target_bpb ({}) must be below IGLA gate ({})",
-        cfg.target_bpb, DEFAULT_IGLA_TARGET_BPB
+        cfg.target_bpb,
+        DEFAULT_IGLA_TARGET_BPB
     );
 }
 
@@ -77,11 +84,9 @@ fn champion_inv8_lr_in_phi_band() {
 #[test]
 #[ignore]
 fn champion_bpb_reproduction_full_run() {
-    let cfg = TrainConfig::from_toml("configs/champion.toml")
-        .expect("champion.toml must load");
+    let cfg = TrainConfig::from_toml("configs/champion.toml").expect("champion.toml must load");
 
-    let outcome = train_loop::run(&cfg)
-        .expect("champion training must complete without error");
+    let outcome = train_loop::run(&cfg).expect("champion training must complete without error");
 
     assert!(
         outcome.final_bpb >= 2.229 && outcome.final_bpb <= 2.249,
@@ -91,8 +96,5 @@ fn champion_bpb_reproduction_full_run() {
     );
 
     assert_eq!(outcome.steps_done, cfg.steps, "must run full step count");
-    assert!(
-        outcome.final_bpb.is_finite(),
-        "BPB must be finite"
-    );
+    assert!(outcome.final_bpb.is_finite(), "BPB must be finite");
 }

--- a/tests/embargo_block.rs
+++ b/tests/embargo_block.rs
@@ -16,19 +16,31 @@ fn make_test_config(embargo_path: &str) -> TrainConfig {
         target_bpb: 1.50,
         champion_bpb: Some(2.2393),
         model: ModelConfig {
-            d_model: 256, n_layers: 2, n_heads: 4,
-            vocab_size: 1000, seq_len: 64, hybrid_attn: false,
+            d_model: 256,
+            n_layers: 2,
+            n_heads: 4,
+            vocab_size: 1000,
+            seq_len: 64,
+            hybrid_attn: false,
         },
         optimizer: OptimizerConfig {
-            kind: "adamw".into(), lr: 0.004, beta1: 0.9,
-            beta2: 0.95, weight_decay: 0.04,
-            schedule: "phi".into(), warmup_steps: 500,
+            kind: "adamw".into(),
+            lr: 0.004,
+            beta1: 0.9,
+            beta2: 0.95,
+            weight_decay: 0.04,
+            schedule: "phi".into(),
+            warmup_steps: 500,
         },
         data: DataConfig {
-            corpus: "test".into(), batch_size: 1, batch_tokens: 1024,
+            corpus: "test".into(),
+            batch_size: 1,
+            batch_tokens: 1024,
         },
         objective: ObjectiveConfig {
-            w_ce: 1.0, w_jepa: 0.0, w_nca: 0.0,
+            w_ce: 1.0,
+            w_jepa: 0.0,
+            w_nca: 0.0,
         },
         ledger: LedgerConfig {
             jsonl_path: "/tmp/trios_test_embargo_results.jsonl".into(),
@@ -50,9 +62,18 @@ fn embargo_rejects_known_sha() {
     // the embargo file is parsed correctly by checking non-embargo case
     // and verifying the file content is read.
     let content = std::fs::read_to_string(&embargo_path).unwrap();
-    assert!(content.contains("477e3377"), "embargo must contain test SHA");
-    assert!(content.contains("b3ee6a36"), "embargo must contain test SHA");
-    assert!(content.contains("deadbeef"), "embargo must contain test SHA");
+    assert!(
+        content.contains("477e3377"),
+        "embargo must contain test SHA"
+    );
+    assert!(
+        content.contains("b3ee6a36"),
+        "embargo must contain test SHA"
+    );
+    assert!(
+        content.contains("deadbeef"),
+        "embargo must contain test SHA"
+    );
 }
 
 #[test]
@@ -159,7 +180,10 @@ fn triplet_format_in_row() {
     cfg.ledger.jsonl_path = jsonl.to_str().unwrap().into();
 
     if let Ok(row) = ledger::emit_row(&cfg, 2.0, 5000) {
-        assert!(row.agent.contains("trios-trainer-"), "agent must be trios-trainer-*");
+        assert!(
+            row.agent.contains("trios-trainer-"),
+            "agent must be trios-trainer-*"
+        );
         assert!(!row.sha.is_empty(), "SHA must be populated");
         assert!(!row.ts.is_empty(), "timestamp must be populated");
         assert_eq!(row.seed, 43);
@@ -172,10 +196,15 @@ fn triplet_format_in_row() {
 fn embargo_list_with_comments_and_blanks() {
     let dir = tempfile::tempdir().unwrap();
     let embargo_path = dir.path().join(".embargo");
-    std::fs::write(&embargo_path, "# comment\n\n477e3377\n  \n# another\nb3ee6a36\n").unwrap();
+    std::fs::write(
+        &embargo_path,
+        "# comment\n\n477e3377\n  \n# another\nb3ee6a36\n",
+    )
+    .unwrap();
 
     let content = std::fs::read_to_string(&embargo_path).unwrap();
-    let shas: Vec<&str> = content.lines()
+    let shas: Vec<&str> = content
+        .lines()
         .map(|l| l.trim())
         .filter(|l| !l.is_empty() && !l.starts_with('#'))
         .collect();

--- a/tests/invariants_match.rs
+++ b/tests/invariants_match.rs
@@ -32,9 +32,18 @@ fn phi_constants_computed_match_stored() {
     let phi: f64 = (1.0 + 5.0_f64.sqrt()) / 2.0;
     assert!((inv::PHI - phi).abs() < 1e-12, "PHI mismatch");
     assert!((inv::PHI_SQ - (phi * phi)).abs() < 1e-12, "PHI_SQ mismatch");
-    assert!((inv::PHI_CUBE - (phi * phi * phi)).abs() < 1e-12, "PHI_CUBE mismatch");
-    assert!((inv::PHI_INV6 - phi.powi(-6)).abs() < 1e-8, "PHI_INV6 mismatch");
-    assert!((inv::ALPHA_PHI - phi.powi(-3) / 2.0).abs() < 1e-10, "ALPHA_PHI mismatch");
+    assert!(
+        (inv::PHI_CUBE - (phi * phi * phi)).abs() < 1e-12,
+        "PHI_CUBE mismatch"
+    );
+    assert!(
+        (inv::PHI_INV6 - phi.powi(-6)).abs() < 1e-8,
+        "PHI_INV6 mismatch"
+    );
+    assert!(
+        (inv::ALPHA_PHI - phi.powi(-3) / 2.0).abs() < 1e-10,
+        "ALPHA_PHI mismatch"
+    );
 }
 
 #[test]
@@ -46,7 +55,9 @@ fn lr_champion_is_alpha_phi_over_phi_cube() {
     assert!(
         inv::LR_CHAMPION >= inv::LR_SAFE_MIN && inv::LR_CHAMPION <= inv::LR_SAFE_MAX,
         "LR_CHAMPION {} not in safe range [{}, {}]",
-        inv::LR_CHAMPION, inv::LR_SAFE_MIN, inv::LR_SAFE_MAX
+        inv::LR_CHAMPION,
+        inv::LR_SAFE_MIN,
+        inv::LR_SAFE_MAX
     );
     // alpha_phi ≈ 0.118 matches strong coupling constant to 4 decimal places
     assert!(
@@ -90,7 +101,8 @@ fn asha_champion_survives_pruning() {
     assert!(
         inv::BPB_CHAMPION < inv::ASHA_PRUNE_THRESHOLD,
         "BPB_CHAMPION {} must be below ASHA_PRUNE_THRESHOLD {}",
-        inv::BPB_CHAMPION, inv::ASHA_PRUNE_THRESHOLD
+        inv::BPB_CHAMPION,
+        inv::ASHA_PRUNE_THRESHOLD
     );
 }
 

--- a/tests/preregistration_seed_lock.rs
+++ b/tests/preregistration_seed_lock.rs
@@ -72,16 +72,10 @@ fn falsify_no_extra_seeds_during_gate_2() {
             None => continue,
         };
         // skip whitespace + ':' + whitespace
-        let after = after
-            .trim_start_matches(|c: char| c.is_whitespace() || c == ':');
-        let digits: String = after
-            .chars()
-            .take_while(|c| c.is_ascii_digit())
-            .collect();
+        let after = after.trim_start_matches(|c: char| c.is_whitespace() || c == ':');
+        let digits: String = after.chars().take_while(|c| c.is_ascii_digit()).collect();
         if digits.is_empty() {
-            panic!(
-                "ledger row {line_no} has malformed `seed` field: {trimmed}",
-            );
+            panic!("ledger row {line_no} has malformed `seed` field: {trimmed}",);
         }
         let seed: u64 = digits.parse().unwrap();
         assert_eq!(


### PR DESCRIPTION
Fixes `cargo fmt --check` failure in CI.

- Sorted imports
- Expanded one-line if-else expressions to multiline  
- Split struct fields onto separate lines

This unblocks docs PR #25 which is blocked on fmt debt in `arch_explorer.rs`.