### PR TITLE
docs(readme): Railway deployment status 2026-04-27 — fleet 100/101/102 + P0 corpus blocker (gHashTag/trios#143)

### DIFF
--- a/README.md
+++ b/README.md
@@ -424,6 +424,41 @@ Filled only by future PRs as each phase closes -- no row may be claimed `done` w
 | P4 | objective+EMA <= -0.03 | _pending_ | _pending_ | _pending_ |
 | P5 | 3 seeds < 1.85 | _pending_ | _pending_ | _pending_ |
 
+## Railway Deployment Status (2026-04-27)
+
+3-seed cloud fleet **deployed and live** in Railway project `IGLA`
+([`e4fe33bb-3b09-4842-9782-7d2dea1abc9b`](https://railway.com/project/e4fe33bb-3b09-4842-9782-7d2dea1abc9b)),
+env `production` (`54e293b9-00a9-4102-814d-db151636d96e`):
+
+| Service | serviceId | Image | Deploy |
+|---|---|---|---|
+| `trios-train-seed-100` | `0f0a948f-c457-4f4c-b5c7-a5ef96fcf9e9` | `ghcr.io/ghashtag/trios-trainer-igla:latest` | SUCCESS |
+| `trios-train-seed-101` | `8e1c7858-5c38-43bc-8015-23c46aaa1ee2` | `ghcr.io/ghashtag/trios-trainer-igla:latest` | SUCCESS |
+| `trios-train-seed-102` | `20b0fcef-b6da-4853-94b7-b1cc27cbd406` | `ghcr.io/ghashtag/trios-trainer-igla:latest` | SUCCESS |
+
+E2E test of `tri` + `trios-igla` against [`ee7771f`](https://github.com/gHashTag/trios-trainer-igla/commit/ee7771f7) is recorded in [gHashTag/trios#143](https://github.com/gHashTag/trios/issues/143#issuecomment-4324652513).
+
+### R5 honesty — Gate-2 status: **NOT DONE**
+
+Containers **start and train**, but the training corpus is missing from `ghcr.io/ghashtag/trios-trainer-igla:latest`:
+
+```
+Failed to load data/tiny_shakespeare.txt: No such file or directory (os error 2). Using fallback.
+step=4000 ntp=0.0001 ... val_bpb=0.0001
+step=7000 ntp=0.0000 ... val_bpb=0.0000
+```
+
+`val_bpb=0.0000` is degenerate output of the synthetic fallback in `train_loop.rs:57`, **not** a Gate-2 win. No valid R7 ledger row will be emitted from these services until the corpus is baked into the image (or a Railway volume is mounted). Same root cause on legacy seed-43/44/45 (`val_bpb=3.4e38` = `f32::MAX` overflow).
+
+### Open follow-up issues
+
+- **P0 — bake corpus into Docker image**: add `COPY data/tinyshakespeare.txt /app/data/` (or `ADD <url>`) to the `Dockerfile`; flip `train_loop.rs` from silent fallback to `bail!` on missing data file.
+- **P1 — `tri.rs` infra mismatch**:
+  - `RAILWAY_PROJECT_ID = "abdf752c-..."` -> `e4fe33bb-3b09-4842-9782-7d2dea1abc9b` (live IGLA project)
+  - `service_name(seed) = "trainer-seed-{}"` -> `"trios-train-seed-{}"` (live convention)
+  - `GATE_SEEDS = &[42, 43, 44]` -> `&[100, 101, 102]` (or env-driven)
+- **P2 — clean stale fleet**: legacy `trios-train-seed-43/44/45` show `f32::MAX` overflow; remove or diagnose.
+
 ## License
 
 MIT — see [`LICENSE`](LICENSE).


### PR DESCRIPTION
## Update README — Railway deployment status (2026-04-27)

Refs: [gHashTag/trios#143](https://github.com/gHashTag/trios/issues/143) · companion comment: [issuecomment-4324652513](https://github.com/gHashTag/trios/issues/143#issuecomment-4324652513)

### What

Adds a new top-level section `## Railway Deployment Status (2026-04-27)` immediately above `## License`. The section documents:

- Live 3-seed cloud fleet `trios-train-seed-100/101/102` deployed to Railway project `IGLA` (`e4fe33bb-3b09-4842-9782-7d2dea1abc9b`), env `production`, all `SUCCESS`.
- The R5-honest Gate-2 verdict: **NOT DONE** because the training corpus (`data/tinyshakespeare.txt`) is missing from `ghcr.io/ghashtag/trios-trainer-igla:latest` and containers fall through to a synthetic fallback yielding `val_bpb=0.0000` (degenerate, not a valid R7 ledger row).
- Three pre-registered follow-up issues (P0 corpus blocker, P1 `tri.rs` infra mismatch, P2 stale fleet cleanup).

### Why

- Anchors the public state of the cloud fleet for [trios#143](https://github.com/gHashTag/trios/issues/143) to the `main@ee7771f7` E2E test.
- Surfaces the P0 blocker so it can't be silently merged-around: `train_loop.rs` currently does silent fallback on missing corpus, which violates **R5 honesty**. The README now states this so the next PR (P0 fix) has clear context.

### R5 / R7 / R9 status

- R5 honesty: README explicitly states 0/3 valid Gate-2 rows on this fleet, no DONE-claim.
- R7 triplet: not affected — emit logic is unchanged in this PR (docs-only).
- R9 embargo: not affected.

### Falsification

- If the corpus is later baked into the image (P0 fix), this section can be amended (or kept as historical `2026-04-27` snapshot) by a follow-up PR.

### Diff

- **README.md**: +35 lines (1 new section), no other lines touched. Docs-only PR.

### Acceptance

- [x] No code changes — docs only, CI safe.
- [x] References issue #143 (NO-COMMIT-WITHOUT-ISSUE).
- [x] R5 honest: explicitly says Gate-2 NOT DONE.
- [x] Mentions follow-up issue priorities.
