### PR TITLE
fix(d2): real Neon INSERTs in tjepa_train (#36)

### DIFF
--- a/src/bin/tjepa_train.rs
+++ b/src/bin/tjepa_train.rs
@@ -456,13 +456,16 @@ fn load_data(path: &str) -> Vec<usize> {
     }
 
     let is_val = path.contains("val");
-    let url = "https://raw.githubusercontent.com/karpathy/char-rnn/master/data/tinyshakespeare/input.txt";
+    let url =
+        "https://raw.githubusercontent.com/karpathy/char-rnn/master/data/tinyshakespeare/input.txt";
     eprintln!("Downloading TinyShakespeare from {}...", url);
     match ureq::get(url).call() {
         Ok(resp) => {
             let mut bytes = Vec::new();
             use std::io::Read;
-            resp.into_reader().read_to_end(&mut bytes).unwrap_or_default();
+            resp.into_reader()
+                .read_to_end(&mut bytes)
+                .unwrap_or_default();
             if bytes.is_empty() {
                 panic!("Downloaded 0 bytes from {}", url);
             }
@@ -663,6 +666,8 @@ fn nca_training_step(nca: &NcaObjective, seed: u64, step: usize) -> f64 {
 // ── Neon heartbeat ──
 
 fn neon_trial_start(cfg: &Config) {
+    // Build config_json once and forward to neon_writer (real INSERT) plus
+    // an eprintln! breadcrumb for log-grep compatibility.
     let config_json = format!(
         "{{\"arch\":\"tjepa\",\"d_model\":{},\"lr\":{},\"seed\":{},\"optimizer\":\"{}\",\"ntp_w\":{},\"jepa_w\":{},\"nca_w\":{}}}",
         HIDDEN, cfg.encoder_lr, cfg.seed,
@@ -673,6 +678,7 @@ fn neon_trial_start(cfg: &Config) {
         "NEON_SQL: INSERT INTO igla_race_trials (trial_id, config, status, agent_id, branch) VALUES ('{}', '{}', 'running', '{}', 'main');",
         cfg.trial_id, config_json, cfg.agent_id,
     );
+    trios_trainer::neon_writer::trial_start(&cfg.trial_id, &config_json, &cfg.agent_id, "main");
 }
 
 fn neon_heartbeat(cfg: &Config, step: usize, bpb: f32, last: &mut Instant) {
@@ -682,6 +688,7 @@ fn neon_heartbeat(cfg: &Config, step: usize, bpb: f32, last: &mut Instant) {
             cfg.agent_id, cfg.trial_id,
         );
         eprintln!("NEON_SQL: UPDATE igla_race_trials SET bpb_latest={:.4}, steps_done={} WHERE trial_id='{}';", bpb, step, cfg.trial_id);
+        trios_trainer::neon_writer::heartbeat(&cfg.trial_id, &cfg.agent_id, bpb, step);
         *last = Instant::now();
     }
 }
@@ -691,6 +698,7 @@ fn neon_trial_complete(cfg: &Config, bpb: f32) {
         "NEON_SQL: UPDATE igla_race_trials SET bpb_final={:.4}, status='complete' WHERE trial_id='{}';",
         bpb, cfg.trial_id,
     );
+    trios_trainer::neon_writer::trial_complete(&cfg.trial_id, bpb);
 }
 
 // ── training state ──

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,6 +17,7 @@ pub mod ledger;
 pub mod model;
 pub mod model_hybrid_attn;
 pub mod mup;
+pub mod neon_writer;
 pub mod objective;
 pub mod optimizer;
 pub mod phi_numbers;

--- a/src/neon_writer.rs
+++ b/src/neon_writer.rs
@@ -1,0 +1,148 @@
+// Real Neon writer for tjepa_train.
+//
+// Replaces the previous `eprintln!("NEON_SQL: ...")` log-only emits with actual
+// INSERT/UPDATE statements over `tokio-postgres`. DSN is read from
+// `TRIOS_NEON_DSN`; if unset the writer is a no-op so existing developer
+// workflows that don't have Neon access keep working.
+//
+// Drift code: D2_NEON_NOT_WRITTEN (ref: trios-trainer-igla #36).
+//
+// Constitutional notes:
+//   R5 — never panic the trainer on Neon errors; log a warn and continue.
+//   R7 — emits forward step/seed/bpb verbatim (caller already builds the
+//        triplet for ledger::emit_row).
+//   R9 — writer never touches `ledger::emit_row`; embargo gate stays in trios.
+
+#![allow(dead_code)]
+
+use std::sync::OnceLock;
+use std::time::Duration;
+
+use tokio::runtime::Runtime;
+use tokio_postgres::{Client, NoTls};
+
+/// Lazy-initialised tokio runtime shared by all sync wrappers.
+fn rt() -> &'static Runtime {
+    static RT: OnceLock<Runtime> = OnceLock::new();
+    RT.get_or_init(|| {
+        tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .expect("build tokio runtime")
+    })
+}
+
+/// Lazy-initialised Neon client. `None` if `TRIOS_NEON_DSN` is unset or the
+/// connection failed. Cached across calls.
+fn client() -> Option<&'static Client> {
+    static CLIENT: OnceLock<Option<Client>> = OnceLock::new();
+    CLIENT
+        .get_or_init(|| {
+            let dsn = std::env::var("TRIOS_NEON_DSN").ok()?;
+            let connect = rt().block_on(async {
+                let connector = tokio_postgres::connect(&dsn, NoTls).await;
+                match connector {
+                    Ok((client, conn)) => {
+                        // Drive the connection task in the background.
+                        tokio::spawn(async move {
+                            if let Err(e) = conn.await {
+                                eprintln!("[neon_writer] connection task error: {e}");
+                            }
+                        });
+                        Some(client)
+                    }
+                    Err(e) => {
+                        eprintln!("[neon_writer] connect failed: {e}");
+                        None
+                    }
+                }
+            });
+            connect
+        })
+        .as_ref()
+}
+
+/// Run an SQL statement with up to `max_attempts` retries on transient errors.
+fn execute(stmt: &str, params: &[&(dyn tokio_postgres::types::ToSql + Sync)]) {
+    let Some(c) = client() else {
+        // No DSN or connect failed: log only, like the legacy eprintln path.
+        eprintln!(
+            "[neon_writer] DSN unset or unreachable; skipping: {}",
+            short(stmt)
+        );
+        return;
+    };
+    let max_attempts = 3u8;
+    for attempt in 1..=max_attempts {
+        let res = rt().block_on(c.execute(stmt, params));
+        match res {
+            Ok(rows) => {
+                eprintln!("[neon_writer] ok: {} ({} rows)", short(stmt), rows);
+                return;
+            }
+            Err(e) => {
+                eprintln!(
+                    "[neon_writer] attempt {attempt}/{max_attempts} failed for {} : {e}",
+                    short(stmt)
+                );
+                std::thread::sleep(Duration::from_millis(500 * attempt as u64));
+            }
+        }
+    }
+    eprintln!(
+        "[neon_writer] giving up after {max_attempts} attempts: {}",
+        short(stmt)
+    );
+}
+
+fn short(s: &str) -> &str {
+    let limit = 80usize.min(s.len());
+    &s[..limit]
+}
+
+/// Insert a fresh row into `igla_race_trials` (idempotent on `trial_id`).
+pub fn trial_start(trial_id: &str, config_json: &str, agent_id: &str, branch: &str) {
+    execute(
+        "INSERT INTO igla_race_trials (trial_id, config, status, agent_id, branch) \
+         VALUES ($1, $2::jsonb, 'running', $3, $4) \
+         ON CONFLICT (trial_id) DO UPDATE SET status='running', agent_id=EXCLUDED.agent_id, branch=EXCLUDED.branch",
+        &[&trial_id, &config_json, &agent_id, &branch],
+    );
+}
+
+/// Upsert agent heartbeat and update the latest BPB on the trial row.
+pub fn heartbeat(trial_id: &str, agent_id: &str, bpb: f32, step: usize) {
+    execute(
+        "INSERT INTO igla_agents_heartbeat (agent_id, machine_id, branch, task, status, last_heartbeat) \
+         VALUES ($1, 'railway', 'main', $2, 'active', NOW()) \
+         ON CONFLICT (agent_id) DO UPDATE SET status=EXCLUDED.status, last_heartbeat=EXCLUDED.last_heartbeat, task=EXCLUDED.task",
+        &[&agent_id, &trial_id],
+    );
+    execute(
+        "UPDATE igla_race_trials SET bpb_latest=$1, steps_done=$2 WHERE trial_id=$3",
+        &[&(bpb as f64), &(step as i64), &trial_id],
+    );
+}
+
+/// Mark a trial complete with the final BPB.
+pub fn trial_complete(trial_id: &str, bpb: f32) {
+    execute(
+        "UPDATE igla_race_trials SET bpb_final=$1, status='complete' WHERE trial_id=$2",
+        &[&(bpb as f64), &trial_id],
+    );
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// When DSN is unset, all writers must be silent no-ops (no panic).
+    #[test]
+    fn no_dsn_is_safe() {
+        // Make sure DSN is unset for this test.
+        std::env::remove_var("TRIOS_NEON_DSN");
+        trial_start("00000000-0000-0000-0000-000000000000", "{}", "TEST", "main");
+        heartbeat("00000000-0000-0000-0000-000000000000", "TEST", 2.5, 1);
+        trial_complete("00000000-0000-0000-0000-000000000000", 2.5);
+    }
+}


### PR DESCRIPTION
Closes #36 (D2_NEON_NOT_WRITTEN drift).

## Problem

`tjepa_train` only printed `NEON_SQL: ...` lines via `eprintln!` — Neon Hive tables (`igla_race_trials`, `igla_agents_heartbeat`) showed last writes from **2026-04-25** despite multiple successful Railway runs through **2026-04-27**.

## Fix

- New module `src/neon_writer.rs` with three sync wrappers:
  `trial_start`, `heartbeat`, `trial_complete`.
- Lazy tokio runtime + lazy `tokio_postgres` client cached in `OnceLock`.
- DSN read from `TRIOS_NEON_DSN` env var (Railway shared variable).
- `ON CONFLICT (trial_id) DO UPDATE` makes re-runs idempotent.
- Up to 3 retries on transient errors with exponential-ish backoff.
- **R5 honesty**: never panic the trainer on Neon errors — log a warn and continue.

## Wiring

`neon_trial_start`, `neon_heartbeat`, `neon_trial_complete` in `src/bin/tjepa_train.rs` now call the writer in addition to the existing `eprintln!` breadcrumbs (kept for log-grep compatibility).

## Tests

- `neon_writer::tests::no_dsn_is_safe` — verifies all three writers are silent no-ops when `TRIOS_NEON_DSN` is unset. **Passes.**
- `cargo fmt --check` — clean.
- `cargo clippy --all-targets -- -D warnings` — clean.
- `cargo check --bin tjepa_train --bin hybrid_train` — clean.

## Deploy plan

After merge, Railway services pick up the new image on next redeploy. Set `TRIOS_NEON_DSN` as a shared Railway variable; otherwise the writer stays silent (zero-impact rollout).

Anchor: phi^2 + phi^-2 = 3. Gate-2 deadline: 2026-04-30 23:59 UTC.