### PR TITLE
fix(corpus): bake fineweb corpus into image, hard-fail if missing (closes #13)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@ RUN cargo build --release --bin trios-train -p trios-trainer
 FROM debian:bookworm-slim AS runtime
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
-        ca-certificates curl \
+        ca-certificates \
     && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /work
@@ -23,9 +23,15 @@ COPY --from=builder /build/target/release/trios-train /usr/local/bin/trios-train
 COPY scripts/entrypoint.sh /usr/local/bin/entrypoint.sh
 RUN chmod +x /usr/local/bin/entrypoint.sh
 
-RUN mkdir -p /work/data && \
-    curl -sL https://raw.githubusercontent.com/karpathy/char-rnn/master/data/tinyshakespeare/input.txt > /work/data/tiny_shakespeare.txt && \
-    head -c 100000 /work/data/tiny_shakespeare.txt > /work/data/tiny_shakespeare_val.txt
+# Bake corpus into image at build time (issue #13).
+# No runtime curl — eliminates silent tinyshakespeare fallback (R5 + R8).
+RUN mkdir -p /work/data
+COPY data/fineweb_train.bin /work/data/fineweb_train.bin
+COPY data/fineweb_val.bin   /work/data/fineweb_val.bin
+
+# Guard: fail the build if corpus is missing or empty.
+RUN test -s /work/data/fineweb_train.bin || (echo "ERROR: fineweb_train.bin missing or empty" && exit 1)
+RUN test -s /work/data/fineweb_val.bin   || (echo "ERROR: fineweb_val.bin missing or empty"   && exit 1)
 
 ENV RUST_LOG=info
 ENV TRIOS_SEED=43
@@ -33,5 +39,7 @@ ENV TRIOS_STEPS=81000
 ENV TRIOS_LR=0.003
 ENV TRIOS_HIDDEN=384
 ENV TRIOS_OPTIMIZER=adamw
+# R8: forbid synthetic fallback — trainer must abort if corpus unavailable
+ENV L_R8_SYNTHETIC_FALLBACK=FORBID
 
 ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]

--- a/scripts/entrypoint.sh
+++ b/scripts/entrypoint.sh
@@ -6,8 +6,32 @@ STEPS="${TRIOS_STEPS:-27000}"
 LR="${TRIOS_LR:-0.003}"
 HIDDEN="${TRIOS_HIDDEN:-384}"
 OPT="${TRIOS_OPTIMIZER:-adamw}"
+FALLBACK="${L_R8_SYNTHETIC_FALLBACK:-ALLOW}"
+
+TRAIN_DATA="/work/data/fineweb_train.bin"
+VAL_DATA="/work/data/fineweb_val.bin"
+
+# R8 guard: hard-fail if corpus missing
+if [ ! -s "$TRAIN_DATA" ]; then
+    echo "[entrypoint] FATAL: train corpus missing: $TRAIN_DATA"
+    echo "[entrypoint] R5/R8 VIOLATION: cannot produce honest BPB without corpus"
+    exit 1
+fi
+if [ ! -s "$VAL_DATA" ]; then
+    echo "[entrypoint] FATAL: val corpus missing: $VAL_DATA"
+    exit 1
+fi
+
+# R8 guard: if FORBID mode, abort on any synthetic/stale data path
+if [ "$FALLBACK" = "FORBID" ]; then
+    if echo "$TRAIN_DATA" | grep -q "tiny_shakespeare"; then
+        echo "[entrypoint] FATAL: L_R8_SYNTHETIC_FALLBACK=FORBID but tinyshakespeare path detected"
+        exit 1
+    fi
+fi
 
 echo "[entrypoint] trios-train seed=$SEED steps=$STEPS lr=$LR hidden=$HIDDEN opt=$OPT"
+echo "[entrypoint] train=$TRAIN_DATA val=$VAL_DATA fallback=$FALLBACK"
 
 exec /usr/local/bin/trios-train \
     --seed="$SEED" \
@@ -15,5 +39,5 @@ exec /usr/local/bin/trios-train \
     --lr="$LR" \
     --hidden="$HIDDEN" \
     --optimizer="$OPT" \
-    --train-data=data/tiny_shakespeare.txt \
-    --val-data=data/tiny_shakespeare_val.txt
+    --train-data="$TRAIN_DATA" \
+    --val-data="$VAL_DATA"


### PR DESCRIPTION
## Problem (issue [#13](https://github.com/gHashTag/trios-railway/issues/13))

Current Dockerfile fetches `tinyshakespeare` via `curl` at build time and wires it via entrypoint. If the fetch silently fails or the path is wrong, the trainer falls back to synthetic data → **BPB=0.0 rows in Neon ledger** → R5 violation → Gate-2 ledger corrupted.

All 6 live containers (Acc1 seed-100/101/102 + Acc2 seed-100/101/102) are exposed to this risk.

## Changes

### `Dockerfile`
- ❌ Remove `curl` + `apt-get install curl` from runtime stage
- ✅ `COPY data/fineweb_train.bin /work/data/fineweb_train.bin`
- ✅ `COPY data/fineweb_val.bin /work/data/fineweb_val.bin`
- ✅ Build-time `RUN test -s` guard — image fails to build if corpus is missing/empty
- ✅ `ENV L_R8_SYNTHETIC_FALLBACK=FORBID` baked in

### `scripts/entrypoint.sh`
- ✅ Hard-fail `exit 1` if `fineweb_train.bin` or `fineweb_val.bin` missing/empty
- ✅ R8 guard: abort if `L_R8_SYNTHETIC_FALLBACK=FORBID` and stale tinyshakespeare path detected
- ✅ Switch `--train-data` / `--val-data` to `/work/data/fineweb_{train,val}.bin`
- ✅ Logs `fallback=$FALLBACK` at startup for audit trail

## Why `fineweb_train.bin`

Already committed in `data/` (61 KB train + 160 B val). No new binary blobs added.

## Acceptance Criteria

- [ ] `docker build .` succeeds
- [ ] Container starts → logs show `train=/work/data/fineweb_train.bin fallback=FORBID`
- [ ] Container with empty corpus → exits 1 (R5 honest exit code)
- [ ] No `tinyshakespeare` path in runtime image
- [ ] CI green

## Risk

Low. `fineweb_train.bin` already exists in repo. `fineweb_val.bin` is 160 bytes. Image size increase: ~61 KB.

---

**φ² + φ⁻² = 3 | R5 + R8 compliance | Closes trios-railway#13**