### PR TITLE
fix(ci): rename job 'build-and-test' → 'ci' to match branch protection

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ on:
     branches: [main]
 
 jobs:
-  build-and-test:
+  ci:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -36,7 +36,7 @@ jobs:
 
   docker:
     runs-on: ubuntu-latest
-    needs: build-and-test
+    needs: ci
     steps:
       - uses: actions/checkout@v4
       - name: Build docker image


### PR DESCRIPTION
## 🎯 Goal

Align CI job name with branch protection `required_status_checks.contexts = ["ci"]` so all PRs can merge cleanly.

## 🐛 Root cause

GitHub registers status-check name as **job name**, not workflow name.
- Current: job `build-and-test` ≠ branch protection context `"ci"`
- Result: all PRs report `mergeStateStatus = BLOCKED` even when CI is green

## 📋 Changes

```yaml
jobs:
-  build-and-test:
+  ci:
     runs-on: ubuntu-latest
     ...
   
  docker:
-    needs: build-and-test
+    needs: ci
```

## ✅ Acceptance

- `cargo fmt`, `cargo clippy`, `cargo test` run identically
- GitHub PR check name becomes `"ci"` (matches branch protection)
- All 4 PRs (#43, #42, #44, #45) unblock instantly on merge

## ⚠️ Note: This PR itself is BLOCKED by the same naming gap

Operator must **admin-merge** this PR (LAWS.md L19 sovereign override).
After merge, the naming gap is resolved and all downstream PRs transition BLOCKED → CLEAN.

Closes #46

φ² + φ⁻² = 3 · TRINITY · NEVER STOP