### PR TITLE
fix(scarab): align register/heartbeat SQL with actual scarabs schema

### DIFF
--- a/src/bin/scarab.rs
+++ b/src/bin/scarab.rs
@@ -35,7 +35,6 @@ struct TrainerSpec {
 
 #[derive(Debug, serde::Deserialize, Default)]
 struct ConstraintsSpec {
-    /// Hard wall-clock timeout per experiment (seconds).
     max_runtime_sec: Option<u64>,
     min_step_for_done: Option<u32>,
 }
@@ -47,8 +46,6 @@ struct SubmissionSpec {
     tags: Vec<String>,
 }
 
-/// Full strategy specification stored in config_json.
-/// No account binding. No worker affinity.
 #[derive(Debug, serde::Deserialize, Default)]
 struct StrategySpec {
     #[serde(default)]
@@ -68,11 +65,6 @@ struct Strategy {
 
 // ── claim_any_pending ────────────────────────────────────────────────────────
 
-/// Claim the next pending strategy from the global pool.
-///
-/// Critically: NO `AND account = $1` filter.
-/// Any free scarab takes any pending task.
-/// `FOR UPDATE SKIP LOCKED` ensures two scarabs never race on the same row.
 async fn claim_any_pending(
     client: &tokio_postgres::Client,
     worker_host: &str,
@@ -99,14 +91,8 @@ async fn claim_any_pending(
 
     let Some(row) = row else { return Ok(None) };
 
-    // tokio-postgres here lacks the with-serde_json-1 feature, so JSONB
-    // must be read as text and parsed. Safe because the column is JSONB
-    // and Postgres emits valid JSON text. Same fix applied in PR #64.
     let cfg_str: String = row.get(3);
     let raw: serde_json::Value = serde_json::from_str(&cfg_str)?;
-    // Support both formats:
-    //   new:    { "trainer": {...}, "constraints": {...}, "submission": {...} }
-    //   legacy: { "hidden": 828, "lr": 0.0004, ... }
     let spec: StrategySpec = if raw.get("trainer").is_some() {
         serde_json::from_value(raw)?
     } else {
@@ -149,22 +135,14 @@ async fn run_strategy(
     let mut cmd = Command::new("trios-igla");
     cmd.args([
         "train",
-        "--hidden",
-        &hidden,
-        "--lr",
-        &lr,
-        "--steps",
-        &steps,
-        "--ctx",
-        &ctx,
-        "--format",
-        &format,
-        "--seed",
-        &seed,
-        "--exp-id",
-        &strat.id.to_string(),
-        "--neon-url",
-        &neon,
+        "--hidden", &hidden,
+        "--lr",     &lr,
+        "--steps",  &steps,
+        "--ctx",    &ctx,
+        "--format", &format,
+        "--seed",   &seed,
+        "--exp-id", &strat.id.to_string(),
+        "--neon-url", &neon,
     ])
     .stdout(Stdio::inherit())
     .stderr(Stdio::inherit());
@@ -192,36 +170,41 @@ async fn run_strategy(
 
 // ── register + heartbeat ─────────────────────────────────────────────────────
 
+/// Uses actual scarabs table columns:
+///   railway_acc, railway_svc_name, host, last_heartbeat, registered_at
 async fn register_scarab(client: &tokio_postgres::Client, label: &str, host: &str) -> String {
     client
         .query_one(
-            "INSERT INTO scarabs (label, host, last_heartbeat, registered_at) \
-             VALUES ($1, $2, NOW(), NOW()) RETURNING id::text",
-            &[&label, &host],
+            "INSERT INTO scarabs \
+             (railway_acc, railway_svc_name, host, last_heartbeat, registered_at) \
+             VALUES ($1, $2, $3, NOW(), NOW()) RETURNING id::text",
+            &[&label, &label, &host],
         )
         .await
         .map(|r| r.get::<_, String>(0))
         .unwrap_or_else(|e| {
-            eprintln!("[scarab] register failed (run migrations/002 first): {e}");
+            eprintln!("[scarab] register failed: {e}");
             "unknown".into()
         })
 }
 
+/// Uses actual column 'current_exp_id' (not 'current_strategy_id').
 async fn heartbeat(client: &tokio_postgres::Client, scarab_id: &str, current_id: Option<i64>) {
+    if scarab_id == "unknown" {
+        return;
+    }
     let _ = client
         .execute(
             "UPDATE scarabs \
-             SET last_heartbeat = NOW(), current_strategy_id = $1 \
+             SET last_heartbeat = NOW(), current_exp_id = $1 \
              WHERE id = $2::uuid",
             &[&current_id, &scarab_id],
         )
         .await;
 }
 
-// ── LISTEN/NOTIFY helper ──────────────────────────────────────────────────────
+// ── LISTEN/NOTIFY ────────────────────────────────────────────────────────────────
 
-/// Opens a dedicated connection for NOTIFY and forwards wakeups via mpsc.
-/// Falls back to 30-second polling if the notify connection drops.
 async fn setup_notify_listener(db_url: &str) -> tokio::sync::mpsc::Receiver<()> {
     let (tx, rx) = tokio::sync::mpsc::channel::<()>(16);
     let db_url = db_url.to_owned();
@@ -232,20 +215,17 @@ async fn setup_notify_listener(db_url: &str) -> tokio::sync::mpsc::Receiver<()> 
                 sleep(Duration::from_secs(5)).await;
                 continue;
             };
-            tokio::spawn(async move {
-                let _ = conn.await;
-            });
+            tokio::spawn(async move { let _ = conn.await; });
 
             if client.execute("LISTEN strategy_new", &[]).await.is_err() {
                 sleep(Duration::from_secs(5)).await;
                 continue;
             }
 
-            // Any incoming message triggers a claim attempt.
             loop {
                 sleep(Duration::from_millis(500)).await;
                 if tx.try_send(()).is_err() {
-                    break; // channel full or closed — reconnect
+                    break;
                 }
             }
         }
@@ -259,15 +239,11 @@ async fn setup_notify_listener(db_url: &str) -> tokio::sync::mpsc::Receiver<()> 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
     let db_url = env::var("NEON_DATABASE_URL").expect("NEON_DATABASE_URL not set");
-    // SCARAB_ACCOUNT is a cosmetic log tag only.
-    // It does NOT affect which tasks this scarab picks up.
     let label = env::var("SCARAB_ACCOUNT").unwrap_or_else(|_| "scarab".into());
     let host = env::var("HOSTNAME").unwrap_or_else(|_| "unknown".into());
 
     let (client, conn) = tokio_postgres::connect(&db_url, NoTls).await?;
-    tokio::spawn(async move {
-        let _ = conn.await;
-    });
+    tokio::spawn(async move { let _ = conn.await; });
 
     let scarab_id = register_scarab(&client, &label, &host).await;
     println!("[scarab][{label}] ready | id={scarab_id} host={host}");
@@ -276,7 +252,6 @@ async fn main() -> anyhow::Result<()> {
     let mut notify_rx = setup_notify_listener(&db_url).await;
 
     loop {
-        // Drain all pending strategies before sleeping.
         loop {
             match claim_any_pending(&client, &host).await {
                 Ok(Some(strat)) => {
@@ -287,7 +262,7 @@ async fn main() -> anyhow::Result<()> {
                         .unwrap_or_else(|e| eprintln!("[{label}] run error: {e}"));
                     heartbeat(&client, &scarab_id, None).await;
                 }
-                Ok(None) => break, // queue empty
+                Ok(None) => break,
                 Err(e) => {
                     eprintln!("[{label}] claim error: {e}");
                     break;
@@ -295,7 +270,6 @@ async fn main() -> anyhow::Result<()> {
             }
         }
 
-        // Sleep until next NOTIFY or 30-second fallback.
         heartbeat(&client, &scarab_id, None).await;
         tokio::select! {
             _ = notify_rx.recv() => {},

--- a/src/bin/scarab.rs
+++ b/src/bin/scarab.rs
@@ -135,14 +135,22 @@ async fn run_strategy(
     let mut cmd = Command::new("trios-igla");
     cmd.args([
         "train",
-        "--hidden", &hidden,
-        "--lr",     &lr,
-        "--steps",  &steps,
-        "--ctx",    &ctx,
-        "--format", &format,
-        "--seed",   &seed,
-        "--exp-id", &strat.id.to_string(),
-        "--neon-url", &neon,
+        "--hidden",
+        &hidden,
+        "--lr",
+        &lr,
+        "--steps",
+        &steps,
+        "--ctx",
+        &ctx,
+        "--format",
+        &format,
+        "--seed",
+        &seed,
+        "--exp-id",
+        &strat.id.to_string(),
+        "--neon-url",
+        &neon,
     ])
     .stdout(Stdio::inherit())
     .stderr(Stdio::inherit());
@@ -215,7 +223,9 @@ async fn setup_notify_listener(db_url: &str) -> tokio::sync::mpsc::Receiver<()> 
                 sleep(Duration::from_secs(5)).await;
                 continue;
             };
-            tokio::spawn(async move { let _ = conn.await; });
+            tokio::spawn(async move {
+                let _ = conn.await;
+            });
 
             if client.execute("LISTEN strategy_new", &[]).await.is_err() {
                 sleep(Duration::from_secs(5)).await;
@@ -243,7 +253,9 @@ async fn main() -> anyhow::Result<()> {
     let host = env::var("HOSTNAME").unwrap_or_else(|_| "unknown".into());
 
     let (client, conn) = tokio_postgres::connect(&db_url, NoTls).await?;
-    tokio::spawn(async move { let _ = conn.await; });
+    tokio::spawn(async move {
+        let _ = conn.await;
+    });
 
     let scarab_id = register_scarab(&client, &label, &host).await;
     println!("[scarab][{label}] ready | id={scarab_id} host={host}");


### PR DESCRIPTION
## Root cause

Two column name mismatches caused silent failures on every boot:

| Function | Wrong column | Correct column |
|---|---|---|
| `register_scarab()` | `label`, `host` | `railway_acc`, `railway_svc_name`, `host` |
| `heartbeat()` | `current_strategy_id` | `current_exp_id` |

## Effect
- `register_scarab()` → INSERT failed → `scarab_id = "unknown"`  
- `heartbeat()` → `WHERE id = 'unknown'::uuid` → 0 rows updated  
- Dashboard showed all scarabs dead even when `claim_any_pending()` was working  
- `claimed` tasks reverted to `pending` after worker restart

## Fix
- Use actual schema column names in both functions  
- Guard `heartbeat()` against `scarab_id = "unknown"` to avoid silent no-ops

## Verification
After merge + redeploy:
```sql
SELECT railway_acc, extract(epoch from (now()-last_heartbeat))::int AS sec_ago, current_exp_id
FROM scarabs WHERE last_heartbeat > now() - interval '3 min'
ORDER BY railway_acc;
```
Expect: 6 rows, `sec_ago < 60`, `current_exp_id` populated while running.