### PR TITLE
fix(P0): wire bpb_sample into igla_train + ngram_train_gf16 — closes #75

### DIFF
--- a/src/bin/igla_train.rs
+++ b/src/bin/igla_train.rs
@@ -2,6 +2,12 @@ use std::fs;
 use std::io::Write;
 use std::time::Instant;
 
+mod neon_writer {
+    include!(concat!(env!("CARGO_MANIFEST_DIR"), "/src/neon_writer.rs"));
+}
+
+use crate::neon_writer as nw;
+
 const VOCAB: usize = 128;
 const DIM: usize = 64;
 const SEQ: usize = 32;
@@ -138,21 +144,38 @@ fn main() {
     let seed = std::env::args()
         .find(|a| a.starts_with("--seed="))
         .map(|a| a[7..].parse::<u64>().unwrap_or(42))
-        .unwrap_or(42);
+        .unwrap_or_else(|| {
+            std::env::var("SEED")
+                .ok()
+                .and_then(|s| s.parse().ok())
+                .unwrap_or(42)
+        });
     let steps = std::env::args()
         .find(|a| a.starts_with("--steps="))
         .map(|a| a[8..].parse::<usize>().unwrap_or(5000))
-        .unwrap_or(5000);
+        .unwrap_or_else(|| {
+            std::env::var("STEPS")
+                .ok()
+                .and_then(|s| s.parse().ok())
+                .unwrap_or(5000)
+        });
     let lr = std::env::args()
         .find(|a| a.starts_with("--lr="))
         .map(|a| a[5..].parse::<f32>().unwrap_or(0.1))
         .unwrap_or(0.1);
 
+    let checkpoint_interval = nw::checkpoint_interval();
+
+    // canon_name: prefer env var, fall back to deterministic name
+    let canon_name = std::env::var("CANON_NAME")
+        .unwrap_or_else(|_| format!("IGLA-TRAIN-igla_train-rng{}", seed));
+
     println!("=== IGLA-STACK-502 Embedding Training ===");
     println!(
-        "vocab={} dim={} seq={} steps={} seed={} lr={}",
-        VOCAB, DIM, SEQ, steps, seed, lr
+        "vocab={} dim={} seq={} steps={} seed={} lr={} checkpoint_interval={}",
+        VOCAB, DIM, SEQ, steps, seed, lr, checkpoint_interval
     );
+    println!("canon_name={}", canon_name);
     println!();
 
     let tokens = load_data("data/tinyshakespeare.txt");
@@ -162,6 +185,11 @@ fn main() {
 
     let (init_loss, init_bpb) = evaluate(&model, &tokens, SEQ);
     println!("Initial: loss={:.4} bpb={:.4}", init_loss, init_bpb);
+
+    // Write step=0 ping so queue knows trainer started
+    nw::bpb_sample(&canon_name, seed as i32, 0, init_bpb);
+    eprintln!("[neon] wrote step=0 bpb={:.4}", init_bpb);
+
     println!();
     println!(
         "{:>6} | {:>10} | {:>10} | {:>10} | {:>8}",
@@ -179,7 +207,7 @@ fn main() {
         let seq = &tokens[offset..offset + SEQ + 1];
         model.train_step(seq, lr);
 
-        if step % 500 == 0 || step == steps {
+        if step % checkpoint_interval == 0 || step == steps {
             let ms = t0.elapsed().as_millis();
             let (eval_loss, eval_bpb) = evaluate(&model, &tokens, SEQ);
             if eval_bpb < best_bpb && eval_bpb.is_finite() {
@@ -190,6 +218,12 @@ fn main() {
                 step, eval_loss, eval_bpb, best_bpb, ms
             );
             results.push((step, eval_loss, eval_bpb));
+
+            // P0 fix: wire bpb_sample to Neon every checkpoint_interval steps
+            if eval_bpb.is_finite() {
+                nw::bpb_sample(&canon_name, seed as i32, step as i32, eval_bpb);
+                eprintln!("[neon] wrote step={} bpb={:.4}", step, eval_bpb);
+            }
         }
     }
 

--- a/src/bin/igla_train.rs
+++ b/src/bin/igla_train.rs
@@ -2,11 +2,7 @@ use std::fs;
 use std::io::Write;
 use std::time::Instant;
 
-mod neon_writer {
-    include!(concat!(env!("CARGO_MANIFEST_DIR"), "/src/neon_writer.rs"));
-}
-
-use crate::neon_writer as nw;
+use trios_trainer::neon_writer as nw;
 
 const VOCAB: usize = 128;
 const DIM: usize = 64;

--- a/src/bin/ngram_train_gf16.rs
+++ b/src/bin/ngram_train_gf16.rs
@@ -12,6 +12,7 @@ use std::io::Write;
 use std::time::Instant;
 
 use trios_trainer::gf16::{QuantizationMetrics, GF16};
+use trios_trainer::neon_writer as nw;
 
 const VOCAB: usize = 128;
 const SEQ: usize = 64;
@@ -635,11 +636,21 @@ fn main() {
     let seed = std::env::args()
         .find(|a| a.starts_with("--seed="))
         .map(|a| a[7..].parse::<u64>().unwrap_or(42))
-        .unwrap_or(42);
+        .unwrap_or_else(|| {
+            std::env::var("SEED")
+                .ok()
+                .and_then(|s| s.parse().ok())
+                .unwrap_or(42)
+        });
     let steps = std::env::args()
         .find(|a| a.starts_with("--steps="))
         .map(|a| a[8..].parse::<usize>().unwrap_or(10000))
-        .unwrap_or(10000);
+        .unwrap_or_else(|| {
+            std::env::var("STEPS")
+                .ok()
+                .and_then(|s| s.parse().ok())
+                .unwrap_or(10000)
+        });
     let base_lr = std::env::args()
         .find(|a| a.starts_with("--lr="))
         .map(|a| a[5..].parse::<f32>().unwrap_or(0.004))
@@ -680,6 +691,8 @@ fn main() {
         .map(|a| a[11..].parse::<usize>().unwrap_or(500))
         .unwrap_or(500);
 
+    let checkpoint_interval = nw::checkpoint_interval();
+
     let ngram = if use_ctx5 {
         "7-Gram"
     } else if use_ctx4 {
@@ -691,10 +704,15 @@ fn main() {
     };
     let activation_name = if activation == "gelu" { "GELU" } else { "ReLU" };
 
+    // canon_name: prefer env var, fall back to deterministic name
+    let canon_name = std::env::var("CANON_NAME")
+        .unwrap_or_else(|_| format!("IGLA-GF16-{}-rng{}", ngram, seed));
+
     println!("=== GF16 {} Context Model + {} ===", ngram, activation_name);
-    println!("vocab={} dim={} hidden={} seq={} steps={} seed={} lr={} activation={} wd={} warmup={} dropout={}",
-        VOCAB, dim, hidden, SEQ, steps, seed, base_lr, activation, wd, warmup, dropout);
+    println!("vocab={} dim={} hidden={} seq={} steps={} seed={} lr={} activation={} wd={} warmup={} dropout={} checkpoint_interval={}",
+        VOCAB, dim, hidden, SEQ, steps, seed, base_lr, activation, wd, warmup, dropout, checkpoint_interval);
     println!("GF16 φ-distance: {:.6}", GF16::phi_distance());
+    println!("canon_name={}", canon_name);
 
     let tokens = load_data("data/tinyshakespeare.txt");
     println!("Dataset: {} tokens", tokens.len());
@@ -730,6 +748,11 @@ fn main() {
 
     let (init_loss, init_bpb) = evaluate(&model, val, SEQ);
     println!("Initial val: loss={:.4} bpb={:.4}", init_loss, init_bpb);
+
+    // Write step=0 ping so queue knows trainer started
+    nw::bpb_sample(&canon_name, seed as i32, 0, init_bpb);
+    eprintln!("[neon] wrote step=0 bpb={:.4}", init_bpb);
+
     println!();
     println!(
         "{:>6} | {:>10} | {:>10} | {:>10} | {:>12}",
@@ -750,7 +773,7 @@ fn main() {
         let off = (step * 97 + seed as usize) % (dl.saturating_sub(SEQ + 1));
         model.train_step(&train[off..off + SEQ + 1], lr, &mut opts);
 
-        if step % 500 == 0 || step == steps {
+        if step % checkpoint_interval == 0 || step == steps {
             let ms = t0.elapsed().as_millis();
             let (vl, vb) = evaluate(&model, val, SEQ);
             let improved = vb < best_bpb && vb.is_finite();
@@ -759,7 +782,7 @@ fn main() {
                 best_step = step;
                 steps_without_improvement = 0;
             } else {
-                steps_without_improvement += 500;
+                steps_without_improvement += checkpoint_interval;
             }
 
             // Early stopping
@@ -768,6 +791,10 @@ fn main() {
                     "\n>>> Early stopping at step {} (patience={} exceeded)",
                     step, patience
                 );
+                // Write final sample before exit
+                if vb.is_finite() {
+                    nw::bpb_sample(&canon_name, seed as i32, step as i32, vb);
+                }
                 break;
             }
 
@@ -780,6 +807,12 @@ fn main() {
                 step, vl, vb, best_bpb, max_q_error
             );
             results.push((step, vl, vb));
+
+            // P0 fix: wire bpb_sample to Neon every checkpoint_interval steps
+            if vb.is_finite() {
+                nw::bpb_sample(&canon_name, seed as i32, step as i32, vb);
+                eprintln!("[neon] wrote step={} bpb={:.4}", step, vb);
+            }
         }
     }
 
@@ -859,4 +892,7 @@ fn main() {
             .as_bytes(),
         );
     println!("Experience: {}", ep);
+
+    // L-R8: stdout must end with BPB=X.XXXX for ASHA worker parsing
+    println!("BPB={:.4}", best_bpb);
 }

--- a/src/bin/ngram_train_gf16.rs
+++ b/src/bin/ngram_train_gf16.rs
@@ -705,8 +705,8 @@ fn main() {
     let activation_name = if activation == "gelu" { "GELU" } else { "ReLU" };
 
     // canon_name: prefer env var, fall back to deterministic name
-    let canon_name = std::env::var("CANON_NAME")
-        .unwrap_or_else(|_| format!("IGLA-GF16-{}-rng{}", ngram, seed));
+    let canon_name =
+        std::env::var("CANON_NAME").unwrap_or_else(|_| format!("IGLA-GF16-{}-rng{}", ngram, seed));
 
     println!("=== GF16 {} Context Model + {} ===", ngram, activation_name);
     println!("vocab={} dim={} hidden={} seq={} steps={} seed={} lr={} activation={} wd={} warmup={} dropout={} checkpoint_interval={}",


### PR DESCRIPTION
## Проблема (Issue #75)

Два тренера `igla_train` и `ngram_train_gf16` НЕ вызывали `neon_writer::bpb_sample()` — телеметрия BPB не поступала в таблицу `public.bpb_samples`. IGLA RACE Dashboard был слеп по этим двум экспериментам.

## Что изменено

### `src/bin/igla_train.rs`
- Добавлен `use trios_trainer::neon_writer as nw`
- Checkpoint loop изменён с `step % 500` → `step % checkpoint_interval` (читает `TRIOS_CHECKPOINT_INTERVAL`, дефолт 200)
- `nw::bpb_sample(&canon_name, seed as i32, step as i32, eval_bpb)` — вызов на каждом checkpoint
- `nw::bpb_sample(…, 0, init_bpb)` — step=0 ping при старте
- `canon_name` = `CANON_NAME` env var или `IGLA-TRAIN-igla_train-rng{seed}`
- `--seed` / `--steps` теперь также читаются из `SEED` / `STEPS` env vars (Railway-compatible)

### `src/bin/ngram_train_gf16.rs`
- Добавлен `use trios_trainer::neon_writer as nw`
- Checkpoint loop изменён с `step % 500` → `step % checkpoint_interval`
- `steps_without_improvement += checkpoint_interval` (было хардкод `+= 500`)
- `nw::bpb_sample(…)` — вызов на каждом checkpoint + при early stop
- step=0 ping при старте
- `canon_name` = `CANON_NAME` env var или `IGLA-GF16-{ngram}-rng{seed}`
- `--seed` / `--steps` читаются из env vars
- `BPB=X.XXXX` добавлен в конец stdout (L-R8 requirement)

## Поведение при отсутствии DSN

Когда `TRIOS_NEON_DSN` не задан — `neon_writer` работает как no-op (R5): пишет только `eprintln` лог, тренировка не падает.

## Проверка

```
cargo build --bin igla_train --bin ngram_train_gf16
# без DSN — должен работать, писать warn в stderr
CARGO_MANIFEST_DIR=. cargo run --bin igla_train -- --steps=200 --seed=1
```

---
Agent: LEAD · Anchor: φ² + φ⁻² = 3 · Closes #75