### PR TITLE
fix(P0): trios-train.train_loop reads TRIOS_CANON_NAME → CANON_NAME → fallback (EPIC #446 silent-write fix)

### DIFF
--- a/src/train_loop.rs
+++ b/src/train_loop.rs
@@ -751,9 +751,13 @@ pub fn run_single(args: &TrainArgs) -> Result<RunOutcome> {
 
             // Bug A fix: write eval to Neon bpb_samples if TRIOS_CANON_NAME
             // is set (scarab sets this env var for the trainer subprocess).
-            if let Ok(canon) = std::env::var("TRIOS_CANON_NAME") {
-                crate::neon_writer::bpb_sample(&canon, args.seed as i32, step as i32, vbpb);
-            }
+            // EPIC-446 follow-up: same triple-source canon resolution as
+            // run_single (TRIOS_CANON_NAME → CANON_NAME → fallback by seed).
+            let canon = std::env::var("TRIOS_CANON_NAME")
+                .ok()
+                .or_else(|| std::env::var("CANON_NAME").ok())
+                .unwrap_or_else(|| format!("trios-train-rng{}", args.seed));
+            crate::neon_writer::bpb_sample(&canon, args.seed as i32, step as i32, vbpb);
         }
     }
 
@@ -978,9 +982,16 @@ pub fn run_single_muon(args: &TrainArgs, use_cwd: bool) -> Result<RunOutcome> {
 
             // Bug A fix: write eval to Neon bpb_samples if TRIOS_CANON_NAME
             // is set (scarab sets this env var for the trainer subprocess).
-            if let Ok(canon) = std::env::var("TRIOS_CANON_NAME") {
-                crate::neon_writer::bpb_sample(&canon, args.seed as i32, step as i32, vbpb);
-            }
+            // EPIC-446 follow-up: also accept the unprefixed CANON_NAME that
+            // the railway_template_deploy MCP tool injects, plus a deterministic
+            // fallback derived from seed so direct trios-train invocations
+            // still produce telemetry. R5: a missing canon_name must never
+            // cost us a 27 000-step training run silently again.
+            let canon = std::env::var("TRIOS_CANON_NAME")
+                .ok()
+                .or_else(|| std::env::var("CANON_NAME").ok())
+                .unwrap_or_else(|| format!("trios-train-rng{}", args.seed));
+            crate::neon_writer::bpb_sample(&canon, args.seed as i32, step as i32, vbpb);
         }
     }
 


### PR DESCRIPTION
## 🩺 P0 root-cause: 27K-step training silent-write — `TRIOS_CANON_NAME` vs `CANON_NAME`

**Anchor:** `phi² + phi⁻² = 3 · TRINITY · O(1) FOREVER`
**EPIC:** [trios#446](https://github.com/gHashTag/trios/issues/446)
**Refs:** #55, #75 (PR #76), #77 (split-DSN), [trios-railway#112](https://github.com/gHashTag/trios-railway/pull/112)

### Evidence

`trainer-seed-43` (acc0_new, project `f29aa9dd-ca0b-460f-ad24-c7680c6717fb`, service `f5db313d-7737-449b-8364-85d23aac195e`, image `ghcr.io/ghashtag/trios-trainer-igla:latest` post-PR-#76) trained for 19 minutes:

```
seed=43 step=1000  val_bpb=3.2301  ema_bpb=5.5602  best=5.5602  t=29.2s
…
seed=43 step=27000 val_bpb=2.8118  ema_bpb=2.8144  best=2.8144  t=1144.6s
DONE: seed=43 bpb=2.8144 steps=27000 opt=adamw
```

Resulting rows in `public.bpb_samples` (live Neon, DSN-A): **0**.

### Root cause

`train_loop::run_single()` and `run_single_muon()` only emit `neon_writer::bpb_sample` when env `TRIOS_CANON_NAME` is set:

```rust
if let Ok(canon) = std::env::var("TRIOS_CANON_NAME") {
    crate::neon_writer::bpb_sample(&canon, args.seed as i32, step as i32, vbpb);
}
```

The EPIC-446 fan-out path uses `CANON_NAME` (unprefixed) because `railway_template_deploy` ([trios-railway#112](https://github.com/gHashTag/trios-railway/pull/112)) treats `CANON_NAME` as a top-level identifier, matching `railway-template.json` `wave`/`doc_id` semantics. Manual canary redeploys also set `CANON_NAME`. The `if-let` then `Err`s, the writer never fires, 27K eval points vanish.

PR #76 already patched the same bug pattern in `igla_train` and `ngram_train_gf16` — but `trios-train` (the most common binary) was missed.

### Fix

Three-source resolution, identical in both `run_single` and `run_single_muon`:

```rust
let canon = std::env::var("TRIOS_CANON_NAME")
    .ok()
    .or_else(|| std::env::var("CANON_NAME").ok())
    .unwrap_or_else(|| format!("trios-train-rng{}", args.seed));
crate::neon_writer::bpb_sample(&canon, args.seed as i32, step as i32, vbpb);
```

- **Primary**: `TRIOS_CANON_NAME` (existing scarab worker contract).
- **Fallback 1**: `CANON_NAME` (railway_template_deploy + manual deploy contract).
- **Fallback 2**: `trios-train-rng<seed>` — deterministic, always produces telemetry. Direct `trios-train --seed 43` smoke runs no longer go silent.

The `if-let` is removed because PR #70's `neon_writer::bpb_sample` is already a no-op when the Neon client is unavailable (TLS failure or DSN missing). Unconditional emit is safe; silent-success training is not.

### Verification

```bash
cargo check  -p trios-trainer                              # green
cargo clippy -p trios-trainer --bin trios-train -- -D warnings  # green
cargo fmt    -p trios-trainer -- --check                   # green
```

### Acceptance after merge + GHCR rebuild

```sql
-- live Neon DSN-A
SELECT canon_name, seed, max(step) AS s, min(bpb), count(*), max(ts)
FROM public.bpb_samples
WHERE canon_name IN ('IGLA-CHAMPION-acc0new-rng42',
                     'IGLA-CHAMPION-acc0new-rng43',
                     'IGLA-CHAMPION-acc0new-rng44')
GROUP BY 1,2 ORDER BY 1;
```

→ ≥ 3 rows (one per seed), `step ≥ 100`, numeric bpb. Same for any future trios-train run on any DSN.

### R5 invariant added

> A missing `canon_name` env var must never cost us a 27 000-step run silently again.

Encoded in code (the seed-derived fallback) and in the verbatim 19-minute log proof above. This is the "two-PRs ago" lesson; closing the loop here.

🌻 `phi² + phi⁻² = 3 · TRINITY · LEAD R5-honest`
