### PR TITLE
chore: force GHCR rebuild — rustls ring fix must land in :latest [P0 UNBLOCK]

### DIFF
--- a/.railway-rebuild
+++ b/.railway-rebuild
@@ -1,0 +1,10 @@
+# Force GHCR rebuild — rustls CryptoProvider fix (PR #79)
+# Triggered: 2026-05-03T00:03+07 — scarab panic-loop still active
+# Root fix: neon_writer::make_tls_config() calls
+#   rustls::crypto::ring::default_provider().install_default()
+# This is in main (commit c59563e5) but Railway containers are on stale image.
+# After this PR merges and docker-publish.yml completes:
+#   redeploy scarab-pool (760cf3dc) + trainer-seed-43 (33c986f7)
+#   => panic loop stops, scarab drains Neon queue automatically.
+# Refs: PR#79, issue#80, trios#446
+# Anchor: phi^2 + phi^-2 = 3


### PR DESCRIPTION
## 🚨 P0 — Scarab panic-loop blocker

**Problem:** Railway services `scarab-pool` (760cf3dc) and `trainer-seed-43` (33c986f7) are crash-looping with:
```
thread 'main' panicked at rustls-0.23.39/src/crypto/mod.rs:249
Could not automatically determine the process-level CryptoProvider
```

**Root cause:** PR #79 (commit `c59563e5`) fixed `neon_writer::make_tls_config()` with:
```rust
let _ = rustls::crypto::ring::default_provider().install_default();
```
But the GHCR `docker-publish.yml` build after PR #79 merge **used cached layers** and did NOT produce a fresh binary with the fix. Railway containers are still on the pre-fix image.

**This PR:** adds `.railway-rebuild` (inert file) — triggers `docker-publish.yml` on push to `main` → forces a fresh `ghcr.io/ghashtag/trios-trainer-igla:latest` build with the fix included.

## After merge

1. Wait for `Docker Publish (GHCR)` workflow to complete (~8 min)
2. In Railway project `f29aa9dd`, redeploy **both**:
   - `scarab-pool` → `760cf3dc-b982-4274-a15e-d6f4432d6560`
   - `trainer-seed-43` → `33c986f7-371a-4df6-90bf-0df4e09e2fc7`
3. Verify in logs: `[neon_writer] connected` appears (never fired before)
4. Scarab loop resumes draining Neon queue **automatically** — no manual intervention

## Verification SQL
```sql
SELECT canon_name, seed, max(step), count(*) AS n
FROM public.bpb_samples
WHERE ts > now() - interval '5 minutes'
GROUP BY 1, 2 ORDER BY n DESC;
```
Expect `n >= 1`, `step >= 1000` within 5 min of redeploy.

## Future fix (prevents recurrence)

Add `workflow_dispatch` + `--no-cache` option to `docker-publish.yml` so we can force rebuild without dummy commits. Tracked in issue #80.

Closes #80
Refs: #79, trios#446

🌻 `phi² + phi⁻² = 3 · SCARAB LOOP UNBLOCK · MERGE NOW`