### PR TITLE
fix(P0): install rustls CryptoProvider in scarab.rs (own TLS path) — closes #80 crash-loop

### DIFF
--- a/src/bin/scarab.rs
+++ b/src/bin/scarab.rs
@@ -282,9 +282,33 @@ async fn heartbeat(client: &tokio_postgres::Client, scarab_id: &str, current_id:
 
 // ── LISTEN/NOTIFY helper ──────────────────────────────────────────────────────
 
+/// Install the rustls 0.23 process-level CryptoProvider exactly once.
+///
+/// rustls 0.23 stopped auto-selecting between `ring` and `aws-lc-rs` when both
+/// are present in the dependency graph (which they are here, via transitive
+/// deps of `tokio-postgres-rustls` + `webpki-roots`). Without an explicit
+/// install, `ClientConfig::builder()` panics on first use:
+///
+/// > panicked at rustls/src/crypto/mod.rs:249:14:
+/// > Could not automatically determine the process-level CryptoProvider
+///
+/// `neon_writer.rs` already installs `ring`, but scarab spawns its own TLS
+/// path BEFORE the trainer subprocess imports `neon_writer`, so this binary
+/// has to install the provider in its own `main`. The OnceLock guarantees
+/// idempotent re-entry across the multiple call sites in this file
+/// (`connect_with_retry` + `setup_notify_listener`).
+fn ensure_crypto_provider() {
+    use std::sync::OnceLock;
+    static INSTALLED: OnceLock<()> = OnceLock::new();
+    INSTALLED.get_or_init(|| {
+        let _ = rustls::crypto::ring::default_provider().install_default();
+    });
+}
+
 /// Opens a dedicated connection for NOTIFY and forwards wakeups via mpsc.
 /// Falls back to 30-second polling if the notify connection drops.
 fn make_tls_config() -> rustls::ClientConfig {
+    ensure_crypto_provider();
     let mut roots = rustls::RootCertStore::empty();
     roots.extend(webpki_roots::TLS_SERVER_ROOTS.iter().cloned());
     rustls::ClientConfig::builder()


### PR DESCRIPTION
## 🩺 P0 — scarab.rs has its own rustls TLS path; PR #79 only covered neon_writer

**EPIC:** [trios#446](https://github.com/gHashTag/trios/issues/446)
**Companion to:** [#79](https://github.com/gHashTag/trios-trainer-igla/pull/79) (which fixed `neon_writer.rs`)
**Closes** the live crash-loop on acc0_new (project `f29aa9dd-…`, services `33c986f7` + `760cf3dc`)
**Anchor:** `phi^2 + phi^-2 = 3 · TRINITY · O(1) FOREVER`

### Live evidence (Railway log capture 2026-05-02 ~17:00 UTC)

```
Starting Container
[entrypoint] scarab seed=43 steps=81000 lr=0.003 hidden=384 opt=adamw
thread 'main' (1) panicked at rustls-0.23.39/src/crypto/mod.rs:249:14:
Could not automatically determine the process-level CryptoProvider from Rustls
crate features. Call CryptoProvider::install_default() before this point ...
[entrypoint] scarab seed=43 ...   ← container restart
thread 'main' (1) panicked ...     ← repeat ad infinitum
```

`Restart policy = always` + entrypoint exec = infinite crash loop. Container never reaches `claim_one()`, so the NEON queue does not drain. But Railway also doesn't stop, so this burns credits with zero telemetry rows.

### Why PR #79 was not enough

PR #79 added `rustls::crypto::ring::default_provider().install_default()` inside `src/neon_writer.rs::make_tls_config()`. That covers every code path that imports `neon_writer` (igla_train, ngram_train_gf16, train_loop, trios-train, smoke_train).

But **`src/bin/scarab.rs` has its own duplicate `make_tls_config()`** (line 287, predates the neon_writer extraction). When `TRIOS_TRAINER_BIN=scarab`, the scarab binary opens TLS in `connect_with_retry` and `setup_notify_listener` — both call scarab's local `make_tls_config()`, **not** neon_writer's. The CryptoProvider is never installed for that code path → rustls panics on the first `ClientConfig::builder()` call → exit before `register_scarab` and `claim_any_pending`.

Phase 0 of WAVE-GF-001 only PASSED because `trainer-seed-{42,43,44}` services use the `trios-train` binary (which goes through `neon_writer`'s fixed path). The scarab worker pool was a different code path, untested by the champion-repro lane.

### Fix

`src/bin/scarab.rs`:

```rust
fn ensure_crypto_provider() {
    use std::sync::OnceLock;
    static INSTALLED: OnceLock<()> = OnceLock::new();
    INSTALLED.get_or_init(|| {
        let _ = rustls::crypto::ring::default_provider().install_default();
    });
}

fn make_tls_config() -> rustls::ClientConfig {
    ensure_crypto_provider();   // ← every TLS path goes through this gate
    let mut roots = rustls::RootCertStore::empty();
    roots.extend(webpki_roots::TLS_SERVER_ROOTS.iter().cloned());
    rustls::ClientConfig::builder()
        .with_root_certificates(roots)
        .with_no_client_auth()
}
```

`OnceLock` makes it idempotent across the two call sites (`connect_with_retry` + `setup_notify_listener`). Picked `ring` deterministically — same as PR #79, no cmake / `aws-lc-sys` cmake dependency on `debian:bookworm-slim`.

### Verification

```
cargo check  -p trios-trainer                              green
cargo clippy -p trios-trainer --bin scarab -- -D warnings  green
cargo fmt    -p trios-trainer -- --check                   green
```

### Acceptance after merge + GHCR rebuild + Railway redeploy

After the next redeploy of `scarab-pool` (`760cf3dc-…`) and `trainer-seed-43` (`33c986f7-…`) on acc0_new, container logs MUST show:

```
[scarab][acc0_new] ready | id=<uuid> host=<host> svc=<service-name>
[scarab][acc0_new] fungible pool — no account filter
[neon_writer] connecting to Neon (TLS) …
[neon_writer] connected
```

And NO `panicked at rustls-0.23.39/src/crypto/mod.rs:249`.

```sql
-- post-redeploy verification
SELECT canon_name, seed, max(step), min(bpb), count(*)
FROM public.bpb_samples
WHERE ts > now() - interval '5 minutes'
GROUP BY 1,2 ORDER BY count(*) DESC;
```

→ ≥ 1 row with numeric `bpb` from a `GF-LR-*` canon (Phase 1 phi-LR ladder will resume autonomously — `scarab` loop drains the queue, no manual intervention).

### R5 invariant added (skill `scarabaeus` v3)

> Every binary in this crate that opens a rustls TLS connection MUST install the CryptoProvider in its own `main` path. Code review MUST grep for `ClientConfig::builder()` across `bin/*.rs` and verify each call site is preceded by `ensure_crypto_provider()`.

This closes the entire class of init-order regressions for any future binary added to the crate.

### Refs

- [#80](https://github.com/gHashTag/trios-trainer-igla/issues/80) — live crash-loop incident
- [#79](https://github.com/gHashTag/trios-trainer-igla/pull/79) — sibling rustls fix in `neon_writer.rs`
- [#78](https://github.com/gHashTag/trios-trainer-igla/pull/78) — `TRIOS_CANON_NAME → CANON_NAME → fallback`
- [#76](https://github.com/gHashTag/trios-trainer-igla/pull/76) — `bpb_sample` wiring across binaries
- [trios#446](https://github.com/gHashTag/trios/issues/446) — EPIC E2E TTT pipeline (WAVE-GF-001 unblocking)

🌻 `phi^2 + phi^-2 = 3 · TRINITY · LEAD R5-honest`
