### PR TITLE
fix(scarab): pass uuid::Uuid via with-uuid-1 feature — closes #84 (round 2)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1417,6 +1417,7 @@ dependencies = [
  "bytes",
  "fallible-iterator",
  "postgres-protocol",
+ "uuid",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -205,7 +205,7 @@ tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 sha1               = "0.10"
 uuid               = { version = "1", features = ["v4"] }
 tokio              = { version = "1", features = ["full"] }
-tokio-postgres       = "0.7"
+tokio-postgres       = { version = "0.7", features = ["with-uuid-1"] }
 tokio-postgres-rustls = "0.12"
 rustls               = "0.23"
 webpki-roots         = "0.26"

--- a/src/bin/scarab.rs
+++ b/src/bin/scarab.rs
@@ -79,12 +79,14 @@ struct Strategy {
 /// Any free scarab takes any pending task.
 /// `FOR UPDATE SKIP LOCKED` ensures two scarabs never race on the same row.
 ///
-/// `worker_id` is a uuid column (FK to `scarabs.id`); pass the scarab's PK
-/// uuid string with explicit `::uuid` cast so tokio-postgres serialises it
-/// without a type mismatch (#84 root cause).
+/// `worker_id` is a uuid column (FK to `scarabs.id`); we pass `uuid::Uuid`
+/// directly via the `with-uuid-1` feature on tokio-postgres so the wire-format
+/// encoder uses the binary uuid OID instead of trying to serialize a String
+/// into a uuid column (#84 root cause — `$1::uuid` SQL cast was insufficient,
+/// the type mismatch is at the wire-protocol layer, before SQL execution).
 async fn claim_any_pending(
     client: &tokio_postgres::Client,
-    scarab_uuid: &str,
+    scarab_uuid: uuid::Uuid,
 ) -> anyhow::Result<Option<Strategy>> {
     let row = client
         .query_opt(
@@ -92,7 +94,7 @@ async fn claim_any_pending(
             UPDATE strategy_queue
             SET status     = 'running',
                 started_at = NOW(),
-                worker_id  = $1::uuid
+                worker_id  = $1
             WHERE id = (
                 SELECT id FROM strategy_queue
                 WHERE status = 'pending'
@@ -258,34 +260,38 @@ async fn register_scarab(
     svc_id: &str,
     svc_name: &str,
     host: &str,
-) -> String {
+) -> uuid::Uuid {
     // `scarabs.id` is `uuid NOT NULL` with no DB-side default, so we must
     // generate it client-side. v4 random is fine — the column is the PK and
-    // collisions are statistically impossible. Pass as text and cast in SQL.
-    let id = uuid::Uuid::new_v4().to_string();
-    client
-        .query_one(
+    // collisions are statistically impossible. Pass `uuid::Uuid` directly
+    // (with-uuid-1 feature on tokio-postgres encodes it natively).
+    let id = uuid::Uuid::new_v4();
+    let res = client
+        .execute(
             "INSERT INTO scarabs (id, railway_acc, railway_svc_id, railway_svc_name, host, last_heartbeat, registered_at) \
-             VALUES ($1::uuid, $2, $3, $4, $5, NOW(), NOW()) RETURNING id::text",
+             VALUES ($1, $2, $3, $4, $5, NOW(), NOW())",
             &[&id, &acc, &svc_id, &svc_name, &host],
         )
-        .await
-        .map(|r| r.get::<_, String>(0))
-        .unwrap_or_else(|e| {
-            eprintln!("[scarab] register failed (check scarabs schema): {e}");
-            // Return the locally-generated uuid even on DB failure so claim_any_pending
-            // still has a valid uuid to bind into worker_id (otherwise every claim
-            // fails with `error serializing parameter 0`, #84).
-            id
-        })
+        .await;
+    if let Err(e) = res {
+        eprintln!("[scarab] register failed (check scarabs schema): {e}");
+        // Return the locally-generated uuid even on DB failure so claim_any_pending
+        // still has a valid uuid to bind into worker_id (otherwise every claim
+        // fails with `error serializing parameter 0`, #84).
+    }
+    id
 }
 
-async fn heartbeat(client: &tokio_postgres::Client, scarab_id: &str, current_id: Option<i64>) {
+async fn heartbeat(
+    client: &tokio_postgres::Client,
+    scarab_id: uuid::Uuid,
+    current_id: Option<i64>,
+) {
     let _ = client
         .execute(
             "UPDATE scarabs \
              SET last_heartbeat = NOW(), current_exp_id = $1 \
-             WHERE id = $2::uuid",
+             WHERE id = $2",
             &[&current_id, &scarab_id],
         )
         .await;
@@ -409,14 +415,14 @@ async fn main() -> anyhow::Result<()> {
         // Drain all pending strategies before sleeping.
         // Pass scarab_id (uuid) — NOT host (text) — so worker_id binds cleanly. (#84)
         loop {
-            match claim_any_pending(&client, &scarab_id).await {
+            match claim_any_pending(&client, scarab_id).await {
                 Ok(Some(strat)) => {
                     let sid = strat.id;
-                    heartbeat(&client, &scarab_id, Some(sid)).await;
+                    heartbeat(&client, scarab_id, Some(sid)).await;
                     run_strategy(&client, strat, &acc)
                         .await
                         .unwrap_or_else(|e| eprintln!("[{acc}] run error: {e}"));
-                    heartbeat(&client, &scarab_id, None).await;
+                    heartbeat(&client, scarab_id, None).await;
                 }
                 Ok(None) => break, // queue empty
                 Err(e) => {
@@ -427,7 +433,7 @@ async fn main() -> anyhow::Result<()> {
         }
 
         // Sleep until next NOTIFY or 30-second fallback.
-        heartbeat(&client, &scarab_id, None).await;
+        heartbeat(&client, scarab_id, None).await;
         tokio::select! {
             _ = notify_rx.recv() => {},
             _ = sleep(Duration::from_secs(30)) => {},


### PR DESCRIPTION
## P0 hotfix on top of [#85](https://github.com/gHashTag/trios-trainer-igla/pull/85)

**Anchor:** `phi^2 + phi^-2 = 3` · closes [#84](https://github.com/gHashTag/trios-trainer-igla/issues/84) (the previous PR did not fully fix it)

## What PR #85 missed

PR #85 added `$1::uuid` SQL casts and bound `&str` parameters into uuid columns. That works for psycopg2 (Python) but **NOT for tokio-postgres**: type coercion happens at the **wire-protocol layer** BEFORE the SQL parser sees the cast. tokio-postgres looks up the OID for each parameter via its `ToSql` impl; for `String` it sends OID = TEXT (25), and the server rejects when it discovers the column is UUID (2950) — `error serializing parameter 0`.

## Live evidence (deployment `a119bdad` @ 18:18:32 UTC, PR-#85 image)

```
[entrypoint] scarab seed=43 steps=81000 lr=0.003 hidden=384 opt=adamw
[scarab] register failed (check scarabs schema): error serializing parameter 0
[scarab][acc0_new] ready | id=2de7fe3e-b55d-4520-b83a-4449ee0956d8 host=e700c8c8d7bd
[acc0_new] claim error: error serializing parameter 0
[acc0_new] claim error: error serializing parameter 0
... (forever)
```

The new behavior shows PR #85 partially landed — `scarab_id` is now a real uuid (`2de7fe3e-...`), so the local-fallback path works. But the INSERT itself still fails, and `claim_any_pending` keeps failing with the same wire-format error.

## Real fix

```toml
# Cargo.toml
tokio-postgres = { version = "0.7", features = ["with-uuid-1"] }
```

The `with-uuid-1` feature adds `ToSql`/`FromSql` impls for `uuid::Uuid` that announce the correct PostgreSQL UUID OID on the wire.

```rust
// scarab.rs — pass uuid::Uuid directly, no String, no ::uuid cast
async fn claim_any_pending(client: &Client, scarab_uuid: uuid::Uuid) -> ...
async fn register_scarab(...) -> uuid::Uuid
async fn heartbeat(client: &Client, scarab_id: uuid::Uuid, current_id: Option<i64>)
```

## Verification

- `cargo build --release --bin scarab` green.
- `cargo tree -p tokio-postgres -e features` shows the uuid feature enabled.

## Smoke plan after merge

Same as PR #85: GHCR rebuild → redeploy scarab-pool → SMOKE row 2071 (`SMOKE-PR82-FULLCYCLE-rng34`, hidden=64, steps=200) should be claimed within 30s, run for ~2 min, write step=200 to bpb_samples, transition to `done` with `final_bpb` populated.

🌻 `phi^2 + phi^-2 = 3 · TRINITY · NEVER STOP`