### PR TITLE
fix(P1): bpb_sample idempotent INSERT (ON CONFLICT DO NOTHING) — closes #84 round 4

### DIFF
--- a/src/neon_writer.rs
+++ b/src/neon_writer.rs
@@ -219,9 +219,17 @@ pub fn trial_complete(trial_id: &str, bpb: f32) {
 /// Schema (verified against NEON 2026-04-30):
 ///   id BIGSERIAL, canon_name TEXT, seed INT, step INT, bpb DOUBLE PRECISION, val_bpb_ema DOUBLE PRECISION, ts TIMESTAMPTZ
 pub fn bpb_sample(canon_name: &str, seed: i32, step: i32, bpb: f32) {
+    // Idempotent: `bpb_samples_canon_name_seed_step_key` is UNIQUE
+    // (canon_name, seed, step). A duplicate emit (scarab restart on the
+    // same row, smoke retry, NOTIFY redelivery, etc.) used to throw
+    // "duplicate key value violates unique constraint" three times before
+    // giving up; now we let Postgres silently skip. Training output is
+    // deterministic for fixed (canon_name, seed, step), so DO NOTHING
+    // preserves the first-write timestamp and avoids redundant churn.
     execute(
         "INSERT INTO public.bpb_samples (canon_name, seed, step, bpb, ts) \
-         VALUES ($1, $2, $3, $4, NOW())",
+         VALUES ($1, $2, $3, $4, NOW()) \
+         ON CONFLICT (canon_name, seed, step) DO NOTHING",
         &[&canon_name, &seed, &step, &(bpb as f64)],
     );
 }


### PR DESCRIPTION
## Final P1 — bpb_sample INSERT now idempotent

**Anchor:** `phi^2 + phi^-2 = 3` · closes [#84](https://github.com/gHashTag/trios-trainer-igla/issues/84) · follows [#82](https://github.com/gHashTag/trios-trainer-igla/pull/82) · [#85](https://github.com/gHashTag/trios-trainer-igla/pull/85) · [#86](https://github.com/gHashTag/trios-trainer-igla/pull/86) · [#87](https://github.com/gHashTag/trios-trainer-igla/pull/87)

## Root cause finally visible (thanks to PR #87's full error chain)

```
[neon_writer] stripped channel_binding from DSN (rustls limitation)
[neon_writer] connecting to Neon (TLS) ...
[neon_writer] connected OK
[neon_writer] attempt 1/3 failed for INSERT INTO public.bpb_samples ...: db error
  caused by: ERROR: duplicate key value violates unique constraint "bpb_samples_canon_name_seed_step_key"
  DETAIL: Key (canon_name, seed, step)=(DIRECT-SMOKE-PR86-rng34, 34, 50) already exists.
```

After PR #82/#85/#86/#87 the writer connects, the INSERT reaches the server, and the server returns a clean unique-constraint violation. The 4-PR regression chain discovered:

1. ❌ rustls CryptoProvider not installed → ✅ PR #82
2. ❌ uuid columns couldn't bind str → ✅ PR #85 / #86 (with-uuid-1 feature)
3. ❌ channel_binding=require + rustls = no PLUS auth → ✅ PR #87
4. ❌ Display impl hid `caused by` → ✅ PR #87 (full_error_chain)
5. ❌ INSERT not idempotent on retry → ✅ **this PR**

## Fix (3-line SQL change)

```rust
"INSERT INTO public.bpb_samples (canon_name, seed, step, bpb, ts) \\
 VALUES ($1, $2, $3, $4, NOW()) \\
 ON CONFLICT (canon_name, seed, step) DO NOTHING"
```

### Why DO NOTHING (not DO UPDATE)

- Training is deterministic for fixed `(canon_name, seed, step)` — the bpb value is identical on retry; updating changes only the timestamp.
- `DO NOTHING` preserves the first-write `ts` (true moment of first observation).
- Avoids unnecessary index churn on retry storms.

## Verification

- `cargo test --lib neon_writer` — 5/5 green.
- `cargo build --release --bin trios-train` — green.
- Acceptance after redeploy: re-running `DIRECT-SMOKE-PR86-rng34` (steps=200) completes with no `attempt N/3 failed` lines even though canon+seed+step rows already exist.

## Rollout plan

1. Merge → GHCR rebuild (~5 min)
2. Redeploy `scarab-pool` 760cf3dc + `trios-train-direct-smoke` 4c529bb7 via acc0_new MCP
3. Re-queue 9 phi-LR rows (id 2062..2070, set status='pending')
4. Watch `bpb_samples` for `GF-LR-k*-rng*` canon rows — expect them to land at step=1000 within 60s of claim
5. Close #84 once Phase-1 Quick-3 has at least one seed with 3+ checkpoints written

🌻 `phi^2 + phi^-2 = 3 · TRINITY · NEVER STOP`