### PR TITLE
fix(P0): scarab JSONB deserialization — enable with-serde_json-1 — round 5

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1417,6 +1417,8 @@ dependencies = [
  "bytes",
  "fallible-iterator",
  "postgres-protocol",
+ "serde_core",
+ "serde_json",
  "uuid",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -205,7 +205,7 @@ tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 sha1               = "0.10"
 uuid               = { version = "1", features = ["v4"] }
 tokio              = { version = "1", features = ["full"] }
-tokio-postgres       = { version = "0.7", features = ["with-uuid-1"] }
+tokio-postgres       = { version = "0.7", features = ["with-uuid-1", "with-serde_json-1"] }
 tokio-postgres-rustls = "0.12"
 rustls               = "0.23"
 webpki-roots         = "0.26"

--- a/src/bin/scarab.rs
+++ b/src/bin/scarab.rs
@@ -110,11 +110,13 @@ async fn claim_any_pending(
 
     let Some(row) = row else { return Ok(None) };
 
-    // tokio-postgres here lacks the with-serde_json-1 feature, so JSONB
-    // must be read as text and parsed. Safe because the column is JSONB
-    // and Postgres emits valid JSON text. Same fix applied in PR #64.
-    let cfg_str: String = row.get(3);
-    let raw: serde_json::Value = serde_json::from_str(&cfg_str)?;
+    // After PR #88 follow-up: tokio-postgres now has the `with-serde_json-1`
+    // feature, so we read JSONB columns natively as `serde_json::Value` instead
+    // of going through `String` (which has no FromSql impl for the JSONB OID
+    // and panics with `error deserializing column 3`). The legacy String-based
+    // path was only a workaround for an environment where the feature was off;
+    // with it on, this is both faster and panic-safe.
+    let raw: serde_json::Value = row.get(3);
     // Support both formats:
     //   new:    { "trainer": {...}, "constraints": {...}, "submission": {...} }
     //   legacy: { "hidden": 828, "lr": 0.0004, ... }


### PR DESCRIPTION
## Round 5 — scarab panics on every claim with 'error deserializing column 3'

**Anchor:** `phi^2 + phi^-2 = 3` · follows [#82](https://github.com/gHashTag/trios-trainer-igla/pull/82) · [#85](https://github.com/gHashTag/trios-trainer-igla/pull/85) · [#86](https://github.com/gHashTag/trios-trainer-igla/pull/86) · [#87](https://github.com/gHashTag/trios-trainer-igla/pull/87) · [#88](https://github.com/gHashTag/trios-trainer-igla/pull/88)

## Live evidence (scarab-pool replicas, 2026-05-02 19:35–19:55 UTC)

All four scarab-pool replicas enter panic-restart-claim-panic loops within ~40 seconds of boot:

```
[scarab][acc6] ready | id=01263911-...
[scarab] stripped channel_binding from DSN (rustls limitation)
Starting Container
... ~40s later ...
thread 'main' (1) panicked at src/bin/scarab.rs:116:31:
error retrieving column 3: error deserializing column 3
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

## Root cause

Line 116 of scarab.rs:
```rust
let cfg_str: String = row.get(3);
```

Column 3 of the `RETURNING` clause is `config_json` (JSONB). tokio-postgres has **no FromSql<JSONB> for String** when the `with-serde_json-1` feature is off. The in-source comment `tokio-postgres here lacks the with-serde_json-1 feature, so JSONB must be read as text` is wrong: without the feature there is no FromSql impl for the JSONB OID at all, so `row.get` panics on the very first claim of any pending row.

Why legacy acc0/3/4/5 scarabs still worked: they're built from an older `Cargo.lock` where the feature was enabled. After PR #86 added `with-uuid-1`, the new feature set resolved without `with-serde_json-1`.

## Fix

### Cargo.toml

```toml
tokio-postgres = { version = "0.7", features = ["with-uuid-1", "with-serde_json-1"] }
```

### scarab.rs

```rust
// Read JSONB natively; no double-parse via String.
let raw: serde_json::Value = row.get(3);
```

## Verification

- `cargo build --release --bin scarab --bin trios-train` — green
- After redeploy: `scarab-pool*` must run continuously (no panic-restart), phi-LR rows 2062..2070 finish with non-NULL `final_bpb`

## Complete regression chain (rounds 1–5)

| Round | Layer | PR | Status |
|---|---|---|---|
| 1 | rustls 0.23 CryptoProvider install | [#82](https://github.com/gHashTag/trios-trainer-igla/pull/82) | merged |
| 2 | `scarabs.id` UUID PK + `worker_id` bind via with-uuid-1 | [#85](https://github.com/gHashTag/trios-trainer-igla/pull/85) · [#86](https://github.com/gHashTag/trios-trainer-igla/pull/86) | merged |
| 3 | strip `channel_binding=` from DSN + full_error_chain | [#87](https://github.com/gHashTag/trios-trainer-igla/pull/87) | merged |
| 4 | `ON CONFLICT DO NOTHING` on bpb_samples | [#88](https://github.com/gHashTag/trios-trainer-igla/pull/88) | merged |
| 5 | `with-serde_json-1` for JSONB deser | **this PR** | pending |

🌻 `phi^2 + phi^-2 = 3 · TRINITY · NEVER STOP`