### PR TITLE
L-C5: allow parallel workflow_dispatch sweeps (per-run-id concurrency group)

### DIFF
--- a/.github/workflows/format-algo-matrix.yml
+++ b/.github/workflows/format-algo-matrix.yml
@@ -53,7 +53,11 @@ on:
       - ".github/workflows/format-algo-matrix.yml"
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  # Parallel workflow_dispatch sweeps must NOT cancel each other (we fan out
+  # 312 cells over multiple waves to stay under the per-account GHA queue
+  # quota). Per-run-id grouping lets each manual dispatch keep its slot.
+  # Schedule + pull_request still serialize on workflow+ref.
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event_name == 'workflow_dispatch' && github.run_id || 'shared' }}
   cancel-in-progress: false
 
 jobs:


### PR DESCRIPTION
Closes part of #7 · refs gHashTag/trios#536 L-C5.

The previous concurrency group `${{ github.workflow }}-${{ github.ref }}` forced all `workflow_dispatch` runs onto a single slot and auto-cancelled wave 2 of the 20+32+52 fan-out. This PR scopes the group to the individual `run_id` for manual dispatches, allowing parallel sweeps. Schedule + pull_request still serialize on workflow+ref.

Run log from this morning's fan-out confirms the bug:
```
25482255593  workflow_dispatch  completed  success     (40 cells, wave 1)
25482259726  workflow_dispatch  completed  cancelled   (32 cells, wave 2 — cancelled by concurrency)
25482263821  workflow_dispatch  completed  success     (52 cells, wave 3)
```

Anchor: `φ² + φ⁻² = 3`.