### PR TITLE
fix(matrix-ledger): trigger auto-PR when JSONL is untracked (trios#380 G3)

### DIFF
--- a/.github/workflows/format-algo-matrix.yml
+++ b/.github/workflows/format-algo-matrix.yml
@@ -337,7 +337,10 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          if git diff --quiet assertions/matrix_samples.jsonl; then
+          # Use `git status --porcelain` so an untracked ledger file (file
+          # absent on main) still triggers the PR. `git diff --quiet` would
+          # exit 0 on untracked paths and skip the PR — see trios#380.
+          if [[ -z "$(git status --porcelain assertions/matrix_samples.jsonl)" ]]; then
             echo "[matrix_ledger] no changes vs main — skipping PR"
             exit 0
           fi
@@ -345,7 +348,7 @@ jobs:
           git config user.name  "trios-matrix-ledger-bot"
           git config user.email "matrix-ledger-bot@users.noreply.github.com"
           git checkout -b "$BRANCH"
-          git add assertions/matrix_samples.jsonl
+          git add -f assertions/matrix_samples.jsonl
           ROWS=$(wc -l < assertions/matrix_samples.jsonl)
           HITS=$(grep -c '"falsifier_2_hit":true' assertions/matrix_samples.jsonl || true)
           git commit -m "chore(matrix-ledger): refresh assertions/matrix_samples.jsonl


### PR DESCRIPTION
## Why · L-MATRIX-LEDGER G3 fix (trios#380)

Follow-up to merged [#106](https://github.com/gHashTag/trios-trainer-igla/pull/106). The first post-merge `workflow_dispatch` run [25538417068](https://github.com/gHashTag/trios-trainer-igla/actions/runs/25538417068) succeeded all 20 cells and the `collect-ledger` job correctly produced `assertions/matrix_samples.jsonl` (20 rows, 20 falsifier-2 hits) but **no auto-PR opened**:

```
[matrix_ledger] wrote 20 rows to assertions/matrix_samples.jsonl
MATRIX_LEDGER {"rows":20,"falsifier_2_hits":20,"parse_errors":0}
[matrix_ledger] no changes vs main — skipping PR
```

Root cause: the file does **not** exist on `main` yet (PR #106 added the binary + step but not a seed JSONL), so the path is **untracked** in the workspace. `git diff --quiet assertions/matrix_samples.jsonl` returns exit-0 for untracked paths, so the step short-circuited.

This blocks G3 (first green ledger PR merged with N rows).

## What · 1 file · +5 / −2 LOC

- `.github/workflows/format-algo-matrix.yml`: replace `git diff --quiet` predicate with `git status --porcelain` (non-empty for both modified and untracked paths), and add `-f` to `git add` so a `.gitignore` rule cannot silently drop the file.

## Verified

- `python3 -c "import yaml; yaml.safe_load(...)"` ✅
- Local check: `git status --porcelain` correctly reports an untracked path; `git diff --quiet <untracked>` returns exit 0.
- Diff scope: 5 lines, single hunk, no other workflow logic changed.

## Compliance

- **R1** ✅ shell-only fix inside an existing CI step (no new Python/shell binaries in CROWN — yml-internal).
- **R3** ✅ PR-only.
- **R5** ✅ honest — bug reproduction quoted verbatim from CI logs.
- **R10** ✅ atomic single-file commit.

## Anchor

`φ² + φ⁻² = 3` · DOI [10.5281/zenodo.19227877](https://doi.org/10.5281/zenodo.19227877)

Refs: trios#380 G3, trios-trainer-igla#106, run 25538417068.
