### PR TITLE
fix(matrix-ledger): bypass .gitignore via hash-object diff (trios#380 G3)

### DIFF
--- a/.github/workflows/format-algo-matrix.yml
+++ b/.github/workflows/format-algo-matrix.yml
@@ -337,11 +337,19 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          # Use `git status --porcelain` so an untracked ledger file (file
-          # absent on main) still triggers the PR. `git diff --quiet` would
-          # exit 0 on untracked paths and skip the PR — see trios#380.
-          if [[ -z "$(git status --porcelain assertions/matrix_samples.jsonl)" ]]; then
-            echo "[matrix_ledger] no changes vs main — skipping PR"
+          # The ledger file lives under /assertions/ which is .gitignored,
+          # so `git status --porcelain` returns empty even when the file
+          # is freshly written. We detect changes by hashing the new file
+          # and comparing against the blob hash on HEAD. Empty file or
+          # unchanged content -> skip; everything else -> open PR.
+          if [[ ! -s assertions/matrix_samples.jsonl ]]; then
+            echo "[matrix_ledger] empty ledger file — skipping PR"
+            exit 0
+          fi
+          NEW_HASH=$(git hash-object assertions/matrix_samples.jsonl)
+          OLD_HASH=$(git rev-parse "HEAD:assertions/matrix_samples.jsonl" 2>/dev/null || echo "")
+          if [[ -n "$OLD_HASH" && "$NEW_HASH" == "$OLD_HASH" ]]; then
+            echo "[matrix_ledger] content identical to main — skipping PR"
             exit 0
           fi
           BRANCH="auto/matrix-ledger-${GITHUB_RUN_ID}"


### PR DESCRIPTION
## Why · L-MATRIX-LEDGER G3 fix #2 (trios#380)

PR [#107](https://github.com/gHashTag/trios-trainer-igla/pull/107) switched the predicate to `git status --porcelain` to handle untracked paths, but the next dispatch run [25538865148](https://github.com/gHashTag/trios-trainer-igla/actions/runs/25538865148) still skipped:

```
[matrix_ledger] no changes vs main — skipping PR
```

Root cause is one level deeper: the `/assertions/` directory is **gitignored** (line 12 of `.gitignore`). For ignored paths `git status --porcelain` returns empty by default, so the predicate evaluates as "no changes" and the step short-circuits.

## What · 1 file · +13 / −5 LOC

- `.github/workflows/format-algo-matrix.yml`: replace the status-based predicate with a content-hash diff:
  ```bash
  if [[ ! -s assertions/matrix_samples.jsonl ]]; then skip; fi
  NEW_HASH=$(git hash-object assertions/matrix_samples.jsonl)
  OLD_HASH=$(git rev-parse "HEAD:assertions/matrix_samples.jsonl" 2>/dev/null || echo "")
  if [[ -n "$OLD_HASH" && "$NEW_HASH" == "$OLD_HASH" ]]; then skip; fi
  ```
  This is the canonical pattern for staging gitignored CI artefacts: `hash-object` is gitignore-blind, and `rev-parse HEAD:<path>` yields empty when the path is not on main yet (handled). The existing `git add -f` already bypasses gitignore at staging time.

## Verified

- `python3 -c "import yaml; yaml.safe_load(...)"` ✅
- `.gitignore` line 12 confirms `/assertions/` is ignored.
- Locally: `git hash-object new.jsonl` and `git rev-parse HEAD:assertions/matrix_samples.jsonl 2>/dev/null` both behave as expected (the latter exits 128 with stderr suppressed → empty string from `||`).

## Compliance

- **R1** ✅ shell-only inside an existing CI step (no new Python).
- **R3** ✅ PR-only.
- **R5** ✅ honest — bug reproduced verbatim from CI logs of two consecutive runs.
- **R10** ✅ atomic single-file commit, single hunk.

## Anchor

`φ² + φ⁻² = 3` · DOI [10.5281/zenodo.19227877](https://doi.org/10.5281/zenodo.19227877)

Refs: trios#380 G3, trios-trainer-igla#106 #107, runs 25538417068 + 25538865148.
