### PR TITLE
fix(scarab): read DATABASE_URL first, NEON_DATABASE_URL becomes legacy alias

### DIFF
--- a/Dockerfile.scarab
+++ b/Dockerfile.scarab
@@ -1,7 +1,10 @@
 # Scarab Worker — one image, N replicas, zero account binding
 #
-# Required Railway variable:
+# Required Railway variable (preferred neutral name):
+#   DATABASE_URL=postgres://...
+# Legacy aliases (still honored, will be removed in a future release):
 #   NEON_DATABASE_URL=postgres://...
+#   TRIOS_DATABASE_URL=postgres://...
 #
 # Optional (cosmetic log label, does NOT affect scheduling):
 #   SCARAB_ACCOUNT=acc0  (or RAILWAY_ACC)

--- a/src/bin/scarab.rs
+++ b/src/bin/scarab.rs
@@ -423,7 +423,16 @@ fn strip_channel_binding(dsn: &str) -> String {
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
-    let raw_db_url = env::var("NEON_DATABASE_URL").expect("NEON_DATABASE_URL not set");
+    // Resolve Postgres DSN with neutral name first, then fall back to legacy aliases.
+    // Trinity moved off Neon onto Railway Postgres (2026-05). DATABASE_URL is the
+    // canonical neutral name; NEON_DATABASE_URL / TRIOS_DATABASE_URL kept as aliases
+    // for backward compatibility with operator-side scripts that still set them.
+    let raw_db_url = env::var("DATABASE_URL")
+        .or_else(|_| env::var("NEON_DATABASE_URL"))
+        .or_else(|_| env::var("TRIOS_DATABASE_URL"))
+        .map_err(|_| anyhow::anyhow!(
+            "no Postgres DSN found: set DATABASE_URL (preferred) or NEON_DATABASE_URL / TRIOS_DATABASE_URL"
+        ))?;
     let db_url = strip_channel_binding(&raw_db_url);
     if db_url != raw_db_url {
         eprintln!("[scarab] stripped channel_binding from DSN (rustls limitation)");


### PR DESCRIPTION
## Summary

Trinity migrated off Neon onto Railway Postgres in May 2026 (anchor `phi^2 + phi^-2 = 3`, DOI [10.5281/zenodo.19227877](https://zenodo.org/records/19227877)). The scarab worker, however, still hard-coded `env::var("NEON_DATABASE_URL").expect(...)` and panicked at boot when only the neutral `DATABASE_URL` was present — the very env var Railway Postgres exposes via reference variables.

This blocked **all 49 trainer / runner services** in the new SoT project `empathetic-kindness` (`f29aa9dd-ca0b-460f-ad24-c7680c6717fb`) and produced a "telemetry path broken" symptom on `trios#446`: `ssot.bpb_samples` stayed at 0 rows even after every service had `DATABASE_URL` set correctly.

## Change

`src/bin/scarab.rs` now resolves the DSN in this order:

1. **`DATABASE_URL`** — preferred neutral name, set automatically by Railway Postgres reference variables.
2. `NEON_DATABASE_URL` — legacy alias, kept for backward compat.
3. `TRIOS_DATABASE_URL` — legacy alias.

If none is set, scarab returns a clear `anyhow::Error` instead of panicking.

`Dockerfile.scarab` header comment updated to document the new resolution order.

## Why "DATABASE_URL" and not keep "NEON_*"

The operator has explicitly forbidden the substring **NEON** in env var names because the project no longer uses Neon. Keeping the legacy aliases as fallback means existing operator scripts continue to work during the transition, but the recommended path is `DATABASE_URL`.

## Verification

- [x] `cargo check --bin scarab` (compiles cleanly)
- [ ] CI green
- [ ] `Docker Publish (GHCR)` rebuilds `ghcr.io/ghashtag/trios-trainer-igla:latest` after merge
- [ ] Re-deployed runner with new image writes to `ssot.bpb_samples` within 60 s of boot

## Refs

- [trios#446](https://github.com/gHashTag/trios/issues/446) — matrix-completion epic
- empathetic-kindness Railway project SoT migration

Anchor: `phi^2 + phi^-2 = 3`
