### PR TITLE
feat(ledger): migrate writer to SeaORM + add migration crate (closes drift between Rust and Postgres types)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,6 +9,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
+name = "ahash"
+version = "0.7.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "891477e0c6a8957309ee5c45a6368af3ae14bb510732d2684ffa19af310920f9"
+dependencies = [
+ "getrandom 0.2.17",
+ "once_cell",
+ "version_check",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -16,6 +27,18 @@ checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
 dependencies = [
  "memchr",
 ]
+
+[[package]]
+name = "aliasable"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "250f629c0161ad8107cf89319e990051fae62832fd343083bea452d93e2205fd"
+
+[[package]]
+name = "allocator-api2"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
 name = "android_system_properties"
@@ -92,6 +115,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "arrayvec"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
+
+[[package]]
+name = "async-stream"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b5a71a6f37880a80d1d7f19efd781e4b5de42c88f0722cc13bcb6cc2cfe8476"
+dependencies = [
+ "async-stream-impl",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-stream-impl"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7c24de15d275a1ecfd47a380fb4d5ec9bfe0933f309ed5e705b775596a3574d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "async-trait"
 version = "0.1.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -99,7 +150,16 @@ checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "atoi"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f28d99ec8bfea296261ca1af174f24225171fea9664ba9003cbebee704810528"
+dependencies = [
+ "num-traits",
 ]
 
 [[package]]
@@ -153,6 +213,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "bigdecimal"
+version = "0.4.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d6867f1565b3aad85681f1015055b087fcfd840d6aeee6eee7f2da317603695"
+dependencies = [
+ "autocfg",
+ "libm",
+ "num-bigint",
+ "num-integer",
+ "num-traits",
+ "serde",
+]
+
+[[package]]
 name = "bindgen_cuda"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -174,6 +248,21 @@ name = "bitflags"
 version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
+name = "bitvec"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bc2832c24239b0141d5674bb9174f9d68a8b5b3f2753311927c172ca46f7e9c"
+dependencies = [
+ "funty",
+ "radium",
+ "tap",
+ "wyz",
+]
 
 [[package]]
 name = "block-buffer"
@@ -194,10 +283,56 @@ dependencies = [
 ]
 
 [[package]]
+name = "borsh"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfd1e3f8955a5d7de9fab72fc8373fade9fb8a703968cb200ae3dc6cf08e185a"
+dependencies = [
+ "borsh-derive",
+ "bytes",
+ "cfg_aliases",
+]
+
+[[package]]
+name = "borsh-derive"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfcfdc083699101d5a7965e49925975f2f55060f94f9a05e7187be95d530ca59"
+dependencies = [
+ "once_cell",
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
+
+[[package]]
+name = "bytecheck"
+version = "0.6.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23cdc57ce23ac53c931e88a43d06d070a6fd142f2617be5855eb75efc9beb1c2"
+dependencies = [
+ "bytecheck_derive",
+ "ptr_meta",
+ "simdutf8",
+]
+
+[[package]]
+name = "bytecheck_derive"
+version = "0.6.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3db406d29fbcd95542e92559bed4d8ad92636d1ca8b3b72ede10b4bcc010e659"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
 
 [[package]]
 name = "bytemuck"
@@ -216,7 +351,7 @@ checksum = "f9abbd1bc6865053c427f7198e6af43bfdedc55ab791faed4fbd361d789575ff"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -249,7 +384,7 @@ dependencies = [
  "rand_distr 0.4.3",
  "rayon",
  "safetensors",
- "thiserror",
+ "thiserror 1.0.69",
  "yoke 0.7.5",
  "zip",
 ]
@@ -275,7 +410,7 @@ dependencies = [
  "rayon",
  "safetensors",
  "serde",
- "thiserror",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -295,6 +430,12 @@ name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
+name = "cfg_aliases"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "chacha20"
@@ -349,10 +490,10 @@ version = "4.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "528131438037fd55894f62d6e9f068b8f45ac57ffa77517819645d10aed04f64"
 dependencies = [
- "heck",
+ "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -381,6 +522,15 @@ name = "colorchoice"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
+
+[[package]]
+name = "concurrent-queue"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973"
+dependencies = [
+ "crossbeam-utils",
+]
 
 [[package]]
 name = "const-oid"
@@ -419,6 +569,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "crc"
+version = "3.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5eb8a2a1cd12ab0d987a5d5e825195d372001a4094a0376319d5a0ad71c1ba0d"
+dependencies = [
+ "crc-catalog",
+]
+
+[[package]]
+name = "crc-catalog"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "217698eaf96b4a3f0bc4f3662aaa55bdf913cd54d7204591faa790070c6d0853"
+
+[[package]]
 name = "crc32fast"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -442,6 +607,15 @@ name = "crossbeam-epoch"
 version = "0.9.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-queue"
+version = "0.3.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f58bbc28f91df819d0aa2a2c00cd19754769c2fad90579b3592b1c9ba7a3115"
 dependencies = [
  "crossbeam-utils",
 ]
@@ -497,13 +671,58 @@ dependencies = [
 ]
 
 [[package]]
+name = "darling"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc7f46116c46ff9ab3eb1597a45688b6715c6e628b5c133e288e709a29bcb4ee"
+dependencies = [
+ "darling_core",
+ "darling_macro",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d00b9596d185e565c2207a0b01f8bd1a135483d02d9b7b0a54b11da8d53412e"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
+dependencies = [
+ "darling_core",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "der"
 version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
 dependencies = [
  "const-oid 0.9.6",
+ "pem-rfc7468",
  "zeroize",
+]
+
+[[package]]
+name = "deranged"
+version = "0.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
+dependencies = [
+ "powerfmt",
+ "serde_core",
 ]
 
 [[package]]
@@ -514,7 +733,29 @@ checksum = "1e567bd82dcff979e4b03460c307b3cdc9e96fde3d73bed1496d2bc75d9dd62a"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "derive_more"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d751e9e49156b02b44f9c1815bcb94b984cdcc4396ecc32521c739452808b134"
+dependencies = [
+ "derive_more-impl",
+]
+
+[[package]]
+name = "derive_more-impl"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "799a97264921d8623a957f6c3b9011f3b5492f557bbb7a5a19b7fa6d06ba8dcb"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "syn 2.0.117",
+ "unicode-xid",
 ]
 
 [[package]]
@@ -524,7 +765,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer 0.10.4",
+ "const-oid 0.9.6",
  "crypto-common 0.1.7",
+ "subtle",
 ]
 
 [[package]]
@@ -547,8 +790,14 @@ checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
+
+[[package]]
+name = "dotenvy"
+version = "0.15.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1aaf95b3e5c8f23aa320147307562d361db0ae0d51242340f558153b4eb2439b"
 
 [[package]]
 name = "dunce"
@@ -571,6 +820,9 @@ name = "either"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "enum-as-inner"
@@ -578,10 +830,10 @@ version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1e6a265c649f3f5979b601d26f1d05ada116434c87741c9493cb56218f76cbc"
 dependencies = [
- "heck",
+ "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -598,6 +850,28 @@ checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "etcetera"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "136d1b5283a1ab77bd9257427ffd09d8667ced0570b6f938942bc7568ed5b943"
+dependencies = [
+ "cfg-if",
+ "home",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "event-listener"
+version = "5.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e13b66accf52311f30a0db42147dadea9850cb48cd070028831ae5f5d4b856ab"
+dependencies = [
+ "concurrent-queue",
+ "parking",
+ "pin-project-lite",
 ]
 
 [[package]]
@@ -629,6 +903,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "flume"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da0e4dd2a88388a1f4ccc7c9ce104604dab68d9f408dc34cd45823d5a9069095"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+ "spin",
+]
+
+[[package]]
+name = "fnv"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
 name = "foldhash"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -650,6 +941,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
 
 [[package]]
+name = "funty"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
+
+[[package]]
+name = "futures"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b147ee9d1f6d097cef9ce628cd2ee62288d963e16fb287bd9286455b241382d"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
 name = "futures-channel"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -664,6 +975,34 @@ name = "futures-core"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
+
+[[package]]
+name = "futures-executor"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baf29c38818342a3b26b5b923639e7b1f4a61fc5e76102d4b1981c6dc7a7579d"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-intrusive"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d930c203dd0b6ff06e0201a4a2fe9149b43c684fd4420555b26d21b1a02956f"
+dependencies = [
+ "futures-core",
+ "lock_api",
+ "parking_lot",
+]
+
+[[package]]
+name = "futures-io"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
 
 [[package]]
 name = "futures-sink"
@@ -684,9 +1023,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
 dependencies = [
  "futures-core",
+ "futures-io",
  "futures-sink",
  "futures-task",
+ "memchr",
  "pin-project-lite",
+ "slab",
 ]
 
 [[package]]
@@ -877,10 +1219,21 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
+dependencies = [
+ "ahash",
+]
+
+[[package]]
+name = "hashbrown"
 version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 dependencies = [
+ "allocator-api2",
+ "equivalent",
  "foldhash",
 ]
 
@@ -889,6 +1242,21 @@ name = "hashbrown"
 version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
+
+[[package]]
+name = "hashlink"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7382cf6263419f2d8df38c55d7da83da5c18aef87fc7a7fc1fb1e344edfe14c1"
+dependencies = [
+ "hashbrown 0.15.5",
+]
+
+[[package]]
+name = "heck"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
 
 [[package]]
 name = "heck"
@@ -909,12 +1277,39 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
+name = "hkdf"
+version = "0.12.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b5f8eb2ad728638ea2c7d47a21db23b7b58a72ed6a38256b8a1849f15fbbdf7"
+dependencies = [
+ "hmac 0.12.1",
+]
+
+[[package]]
+name = "hmac"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
+dependencies = [
+ "digest 0.10.7",
+]
+
+[[package]]
 name = "hmac"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6303bc9732ae41b04cb554b844a762b4115a61bfaa81e3e83050991eeb56863f"
 dependencies = [
  "digest 0.11.2",
+]
+
+[[package]]
+name = "home"
+version = "0.5.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc627f471c528ff0c4a49e1d5e60450c8f6461dd6d10ba9dcd3a61d3dff7728d"
+dependencies = [
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1039,6 +1434,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
 
 [[package]]
+name = "ident_case"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
+
+[[package]]
 name = "idna"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1069,6 +1470,17 @@ dependencies = [
  "hashbrown 0.17.0",
  "serde",
  "serde_core",
+]
+
+[[package]]
+name = "inherent"
+version = "1.0.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c727f80bfa4a6c6e2508d2f05b6f4bfce242030bd88ed15ae5331c5b5d30fba7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1108,6 +1520,9 @@ name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+dependencies = [
+ "spin",
+]
 
 [[package]]
 name = "leb128fmt"
@@ -1143,7 +1558,20 @@ version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e02f3bb43d335493c96bf3fd3a321600bf6bd07ed34bc64118e9293bdffea46c"
 dependencies = [
+ "bitflags 2.11.1",
  "libc",
+ "plain",
+ "redox_syscall 0.7.5",
+]
+
+[[package]]
+name = "libsqlite3-sys"
+version = "0.30.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e99fb7a497b1e3339bc746195567ed8d3e24945ecd636e3619d20b9de9e9149"
+dependencies = [
+ "pkg-config",
+ "vcpkg",
 ]
 
 [[package]]
@@ -1174,12 +1602,33 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
+name = "mac_address"
+version = "1.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0aeb26bf5e836cc1c341c8106051b573f1766dfa05aa87f0b98be5e51b02303"
+dependencies = [
+ "nix",
+ "serde",
+ "winapi",
+]
+
+[[package]]
 name = "matchers"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d1525a2a28c7f4fa0fc98bb91ae755d1e2d1505079e05539e35bc876b5d65ae9"
 dependencies = [
  "regex-automata",
+]
+
+[[package]]
+name = "md-5"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d89e7ee0cfbedfc4da3340218492196241d89eefb6dab27de5df917a6d2e78cf"
+dependencies = [
+ "cfg-if",
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -1209,6 +1658,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "memoffset"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
+name = "migration"
+version = "0.1.0"
+dependencies = [
+ "sea-orm",
+ "sea-orm-migration",
+ "tokio",
+]
+
+[[package]]
 name = "miniz_oxide"
 version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1230,6 +1697,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "nix"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71e2746dc3a24dd78b3cfcb7be93368c6de9963d30f43a6a73998a9cf4b17b46"
+dependencies = [
+ "bitflags 2.11.1",
+ "cfg-if",
+ "cfg_aliases",
+ "libc",
+ "memoffset",
+]
+
+[[package]]
 name = "nu-ansi-term"
 version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1239,12 +1719,64 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-bigint"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
+dependencies = [
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-bigint-dig"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e661dda6640fad38e827a6d4a310ff4763082116fe217f279885c97f511bb0b7"
+dependencies = [
+ "lazy_static",
+ "libm",
+ "num-integer",
+ "num-iter",
+ "num-traits",
+ "rand 0.8.6",
+ "smallvec",
+ "zeroize",
+]
+
+[[package]]
 name = "num-complex"
 version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73f88a1307638156682bada9d7604135552957b7818057dcef22705b4d509495"
 dependencies = [
  "bytemuck",
+ "num-traits",
+]
+
+[[package]]
+name = "num-conv"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6673768db2d862beb9b39a78fdcb1a69439615d5794a1be50caa9bc92c81967"
+
+[[package]]
+name = "num-integer"
+version = "0.1.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "num-iter"
+version = "0.1.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1429034a0490724d0075ebb2bc9e875d6503c3cf69e235a8941aa757d83ef5bf"
+dependencies = [
+ "autocfg",
+ "num-integer",
  "num-traits",
 ]
 
@@ -1287,7 +1819,7 @@ dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1321,6 +1853,45 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
+name = "ordered-float"
+version = "4.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7bb71e1b3fa6ca1c61f383464aaf2bb0e2f8e772a1f01d486832464de363b951"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "ouroboros"
+version = "0.18.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e0f050db9c44b97a94723127e6be766ac5c340c48f2c4bb3ffa11713744be59"
+dependencies = [
+ "aliasable",
+ "ouroboros_macro",
+ "static_assertions",
+]
+
+[[package]]
+name = "ouroboros_macro"
+version = "0.18.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c7028bdd3d43083f6d8d4d5187680d0d3560d54df4cc9d752005268b41e64d0"
+dependencies = [
+ "heck 0.4.1",
+ "proc-macro2",
+ "proc-macro2-diagnostics",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "parking"
+version = "2.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f38d5652c16fde515bb1ecef450ab0f6a219d619a7274976324d5e377f7dceba"
+
+[[package]]
 name = "parking_lot"
 version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1338,7 +1909,7 @@ checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
 dependencies = [
  "cfg-if",
  "libc",
- "redox_syscall",
+ "redox_syscall 0.5.18",
  "smallvec",
  "windows-link",
 ]
@@ -1360,10 +1931,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "pem-rfc7468"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88b39c9bfcfc231068454382784bb460aae594343fb030d46e9f50a645418412"
+dependencies = [
+ "base64ct",
+]
+
+[[package]]
 name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
+
+[[package]]
+name = "pgvector"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc58e2d255979a31caa7cabfa7aac654af0354220719ab7a68520ae7a91e8c0b"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "phf"
@@ -1391,6 +1980,39 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
+name = "pkcs1"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8ffb9f10fa047879315e6625af03c164b16962a5368d724ed16323b68ace47f"
+dependencies = [
+ "der",
+ "pkcs8",
+ "spki",
+]
+
+[[package]]
+name = "pkcs8"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7"
+dependencies = [
+ "der",
+ "spki",
+]
+
+[[package]]
+name = "pkg-config"
+version = "0.3.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
+
+[[package]]
+name = "plain"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
+
+[[package]]
 name = "postgres-protocol"
 version = "0.6.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1400,11 +2022,11 @@ dependencies = [
  "byteorder",
  "bytes",
  "fallible-iterator",
- "hmac",
- "md-5",
+ "hmac 0.13.0",
+ "md-5 0.11.0",
  "memchr",
  "rand 0.10.1",
- "sha2",
+ "sha2 0.11.0",
  "stringprep",
 ]
 
@@ -1432,6 +2054,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "powerfmt"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
+
+[[package]]
 name = "ppv-lite86"
 version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1447,7 +2075,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
 dependencies = [
  "proc-macro2",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1460,12 +2088,67 @@ dependencies = [
 ]
 
 [[package]]
+name = "proc-macro-error-attr2"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96de42df36bb9bba5542fe9f1a054b8cc87e172759a1868aa05c1f3acc89dfc5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+]
+
+[[package]]
+name = "proc-macro-error2"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11ec05c52be0a07b08061f7dd003e7d7092e0472bc731b4af7bb1ef876109802"
+dependencies = [
+ "proc-macro-error-attr2",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "proc-macro2-diagnostics"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af066a9c399a26e020ada66a034357a868728e72cd426f3adcd35f80d88d88c8"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+ "version_check",
+ "yansi",
+]
+
+[[package]]
+name = "ptr_meta"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0738ccf7ea06b608c10564b31debd4f5bc5e197fc8bfe088f68ae5ce81e7a4f1"
+dependencies = [
+ "ptr_meta_derive",
+]
+
+[[package]]
+name = "ptr_meta_derive"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16b845dbfca988fa33db069c0e230574d15a3088f147a87b64c7589eb662c9ac"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -1500,6 +2183,12 @@ name = "r-efi"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
+name = "radium"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
 
 [[package]]
 name = "rand"
@@ -1642,6 +2331,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "redox_syscall"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4666a1a60d8412eab19d94f6d13dcc9cea0a5ef4fdf6a5db306537413c661b1b"
+dependencies = [
+ "bitflags 2.11.1",
+]
+
+[[package]]
+name = "regex"
+version = "1.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e10754a14b9137dd7b1e3e5b0493cc9171fdd105e0ab477f51b72e7f3ac0e276"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
 name = "regex-automata"
 version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1659,6 +2369,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
+name = "rend"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71fe3824f5629716b1589be05dacd749f6aa084c87e00e016714a8cdfccc997c"
+dependencies = [
+ "bytecheck",
+]
+
+[[package]]
 name = "ring"
 version = "0.17.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1670,6 +2389,81 @@ dependencies = [
  "libc",
  "untrusted",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "rkyv"
+version = "0.7.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2297bf9c81a3f0dc96bc9521370b88f054168c29826a75e89c55ff196e7ed6a1"
+dependencies = [
+ "bitvec",
+ "bytecheck",
+ "bytes",
+ "hashbrown 0.12.3",
+ "ptr_meta",
+ "rend",
+ "rkyv_derive",
+ "seahash",
+ "tinyvec",
+ "uuid",
+]
+
+[[package]]
+name = "rkyv_derive"
+version = "0.7.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "84d7b42d4b8d06048d3ac8db0eb31bcb942cbeb709f0b5f2b2ebde398d3038f5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "rsa"
+version = "0.9.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8573f03f5883dcaebdfcf4725caa1ecb9c15b2ef50c43a07b816e06799bb12d"
+dependencies = [
+ "const-oid 0.9.6",
+ "digest 0.10.7",
+ "num-bigint-dig",
+ "num-integer",
+ "num-traits",
+ "pkcs1",
+ "pkcs8",
+ "rand_core 0.6.4",
+ "signature",
+ "spki",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "rust_decimal"
+version = "1.42.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c5108e3d4d903e21aac27f12ba5377b6b34f9f44b325e4894c7924169d06995"
+dependencies = [
+ "arrayvec",
+ "borsh",
+ "bytes",
+ "num-traits",
+ "rand 0.8.6",
+ "rkyv",
+ "serde",
+ "serde_json",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "rustc_version"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
+dependencies = [
+ "semver",
 ]
 
 [[package]]
@@ -1729,6 +2523,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
+name = "ryu"
+version = "1.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
+
+[[package]]
 name = "safetensors"
 version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1752,6 +2552,177 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "sea-bae"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f694a6ab48f14bc063cfadff30ab551d3c7e46d8f81836c51989d548f44a2a25"
+dependencies = [
+ "heck 0.4.1",
+ "proc-macro-error2",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "sea-orm"
+version = "1.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2dc312fedd460a47ea563911761d254a84e7b51d8cc73ec92c929e78f33fa957"
+dependencies = [
+ "async-stream",
+ "async-trait",
+ "bigdecimal",
+ "chrono",
+ "derive_more",
+ "futures-util",
+ "log",
+ "mac_address",
+ "ouroboros",
+ "pgvector",
+ "rust_decimal",
+ "sea-orm-macros",
+ "sea-query",
+ "sea-query-binder",
+ "serde",
+ "serde_json",
+ "sqlx",
+ "strum",
+ "thiserror 2.0.18",
+ "time",
+ "tracing",
+ "url",
+ "uuid",
+]
+
+[[package]]
+name = "sea-orm-cli"
+version = "1.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da80ebcdb44571e86f03a2bdcb5532136a87397f366f38bbce64673fc5e6a450"
+dependencies = [
+ "chrono",
+ "clap",
+ "dotenvy",
+ "glob",
+ "regex",
+ "sea-schema",
+ "sqlx",
+ "tokio",
+ "tracing",
+ "tracing-subscriber",
+ "url",
+]
+
+[[package]]
+name = "sea-orm-macros"
+version = "1.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b9a3f90e336ec74803e8eb98c61bc98754c1adfba3b4f84d946237b752b1c88"
+dependencies = [
+ "heck 0.5.0",
+ "proc-macro2",
+ "quote",
+ "sea-bae",
+ "syn 2.0.117",
+ "unicode-ident",
+]
+
+[[package]]
+name = "sea-orm-migration"
+version = "1.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07c577f2959277e936c1d08109acd1e08fc36a95ef29ec028190ba82cad8f96e"
+dependencies = [
+ "async-trait",
+ "clap",
+ "dotenvy",
+ "sea-orm",
+ "sea-orm-cli",
+ "sea-schema",
+ "tracing",
+ "tracing-subscriber",
+]
+
+[[package]]
+name = "sea-query"
+version = "0.32.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a5d1c518eaf5eda38e5773f902b26ab6d5e9e9e2bb2349ca6c64cf96f80448c"
+dependencies = [
+ "bigdecimal",
+ "chrono",
+ "inherent",
+ "ordered-float",
+ "rust_decimal",
+ "sea-query-derive",
+ "serde_json",
+ "time",
+ "uuid",
+]
+
+[[package]]
+name = "sea-query-binder"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0019f47430f7995af63deda77e238c17323359af241233ec768aba1faea7608"
+dependencies = [
+ "bigdecimal",
+ "chrono",
+ "rust_decimal",
+ "sea-query",
+ "serde_json",
+ "sqlx",
+ "time",
+ "uuid",
+]
+
+[[package]]
+name = "sea-query-derive"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bae0cbad6ab996955664982739354128c58d16e126114fe88c2a493642502aab"
+dependencies = [
+ "darling",
+ "heck 0.4.1",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "sea-schema"
+version = "0.16.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2239ff574c04858ca77485f112afea1a15e53135d3097d0c86509cef1def1338"
+dependencies = [
+ "futures",
+ "sea-query",
+ "sea-query-binder",
+ "sea-schema-derive",
+ "sqlx",
+]
+
+[[package]]
+name = "sea-schema-derive"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "debdc8729c37fdbf88472f97fd470393089f997a909e535ff67c544d18cfccf0"
+dependencies = [
+ "heck 0.4.1",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "seahash"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c107b6f4780854c8b126e228ea8869f4d7b71260f962fefb57b996b8959ba6b"
 
 [[package]]
 name = "semver"
@@ -1792,7 +2763,7 @@ checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1818,10 +2789,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_urlencoded"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
+dependencies = [
+ "form_urlencoded",
+ "itoa",
+ "ryu",
+ "serde",
+]
+
+[[package]]
 name = "sha1"
 version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.2.17",
+ "digest 0.10.7",
+]
+
+[[package]]
+name = "sha2"
+version = "0.10.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
  "cpufeatures 0.2.17",
@@ -1870,6 +2864,7 @@ version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
 dependencies = [
+ "digest 0.10.7",
  "rand_core 0.6.4",
 ]
 
@@ -1880,16 +2875,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
 
 [[package]]
+name = "simdutf8"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
+
+[[package]]
 name = "siphasher"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b2aa850e253778c88a04c3d7323b043aeda9d3e30d5971937c1855769763678e"
 
 [[package]]
+name = "slab"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
+
+[[package]]
 name = "smallvec"
 version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "socket2"
@@ -1899,6 +2909,15 @@ checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "spin"
+version = "0.9.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
+dependencies = [
+ "lock_api",
 ]
 
 [[package]]
@@ -1912,10 +2931,225 @@ dependencies = [
 ]
 
 [[package]]
+name = "sqlx"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fefb893899429669dcdd979aff487bd78f4064e5e7907e4269081e0ef7d97dc"
+dependencies = [
+ "sqlx-core",
+ "sqlx-macros",
+ "sqlx-mysql",
+ "sqlx-postgres",
+ "sqlx-sqlite",
+]
+
+[[package]]
+name = "sqlx-core"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee6798b1838b6a0f69c007c133b8df5866302197e404e8b6ee8ed3e3a5e68dc6"
+dependencies = [
+ "base64",
+ "bigdecimal",
+ "bytes",
+ "chrono",
+ "crc",
+ "crossbeam-queue",
+ "either",
+ "event-listener",
+ "futures-core",
+ "futures-intrusive",
+ "futures-io",
+ "futures-util",
+ "hashbrown 0.15.5",
+ "hashlink",
+ "indexmap",
+ "log",
+ "memchr",
+ "once_cell",
+ "percent-encoding",
+ "rust_decimal",
+ "rustls",
+ "serde",
+ "serde_json",
+ "sha2 0.10.9",
+ "smallvec",
+ "thiserror 2.0.18",
+ "time",
+ "tokio",
+ "tokio-stream",
+ "tracing",
+ "url",
+ "uuid",
+ "webpki-roots 0.26.11",
+]
+
+[[package]]
+name = "sqlx-macros"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2d452988ccaacfbf5e0bdbc348fb91d7c8af5bee192173ac3636b5fb6e6715d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "sqlx-core",
+ "sqlx-macros-core",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "sqlx-macros-core"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19a9c1841124ac5a61741f96e1d9e2ec77424bf323962dd894bdb93f37d5219b"
+dependencies = [
+ "dotenvy",
+ "either",
+ "heck 0.5.0",
+ "hex",
+ "once_cell",
+ "proc-macro2",
+ "quote",
+ "serde",
+ "serde_json",
+ "sha2 0.10.9",
+ "sqlx-core",
+ "sqlx-mysql",
+ "sqlx-postgres",
+ "sqlx-sqlite",
+ "syn 2.0.117",
+ "tokio",
+ "url",
+]
+
+[[package]]
+name = "sqlx-mysql"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa003f0038df784eb8fecbbac13affe3da23b45194bd57dba231c8f48199c526"
+dependencies = [
+ "atoi",
+ "base64",
+ "bigdecimal",
+ "bitflags 2.11.1",
+ "byteorder",
+ "bytes",
+ "chrono",
+ "crc",
+ "digest 0.10.7",
+ "dotenvy",
+ "either",
+ "futures-channel",
+ "futures-core",
+ "futures-io",
+ "futures-util",
+ "generic-array",
+ "hex",
+ "hkdf",
+ "hmac 0.12.1",
+ "itoa",
+ "log",
+ "md-5 0.10.6",
+ "memchr",
+ "once_cell",
+ "percent-encoding",
+ "rand 0.8.6",
+ "rsa",
+ "rust_decimal",
+ "serde",
+ "sha1",
+ "sha2 0.10.9",
+ "smallvec",
+ "sqlx-core",
+ "stringprep",
+ "thiserror 2.0.18",
+ "time",
+ "tracing",
+ "uuid",
+ "whoami 1.6.1",
+]
+
+[[package]]
+name = "sqlx-postgres"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db58fcd5a53cf07c184b154801ff91347e4c30d17a3562a635ff028ad5deda46"
+dependencies = [
+ "atoi",
+ "base64",
+ "bigdecimal",
+ "bitflags 2.11.1",
+ "byteorder",
+ "chrono",
+ "crc",
+ "dotenvy",
+ "etcetera",
+ "futures-channel",
+ "futures-core",
+ "futures-util",
+ "hex",
+ "hkdf",
+ "hmac 0.12.1",
+ "home",
+ "itoa",
+ "log",
+ "md-5 0.10.6",
+ "memchr",
+ "num-bigint",
+ "once_cell",
+ "rand 0.8.6",
+ "rust_decimal",
+ "serde",
+ "serde_json",
+ "sha2 0.10.9",
+ "smallvec",
+ "sqlx-core",
+ "stringprep",
+ "thiserror 2.0.18",
+ "time",
+ "tracing",
+ "uuid",
+ "whoami 1.6.1",
+]
+
+[[package]]
+name = "sqlx-sqlite"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2d12fe70b2c1b4401038055f90f151b78208de1f9f89a7dbfd41587a10c3eea"
+dependencies = [
+ "atoi",
+ "chrono",
+ "flume",
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-intrusive",
+ "futures-util",
+ "libsqlite3-sys",
+ "log",
+ "percent-encoding",
+ "serde",
+ "serde_urlencoded",
+ "sqlx-core",
+ "thiserror 2.0.18",
+ "time",
+ "tracing",
+ "url",
+ "uuid",
+]
+
+[[package]]
 name = "stable_deref_trait"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
+
+[[package]]
+name = "static_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "stringprep"
@@ -1935,10 +3169,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
+name = "strum"
+version = "0.26.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fec0f0aef304996cf250b31b5a10dee7980c85da9d759361292b8bca5a18f06"
+
+[[package]]
 name = "subtle"
 version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
+
+[[package]]
+name = "syn"
+version = "1.0.109"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
 
 [[package]]
 name = "syn"
@@ -1959,7 +3210,7 @@ checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1972,9 +3223,15 @@ dependencies = [
  "byteorder",
  "enum-as-inner",
  "libc",
- "thiserror",
+ "thiserror 1.0.69",
  "walkdir",
 ]
+
+[[package]]
+name = "tap"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
 name = "tempfile"
@@ -1995,7 +3252,16 @@ version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
 dependencies = [
- "thiserror-impl",
+ "thiserror-impl 1.0.69",
+]
+
+[[package]]
+name = "thiserror"
+version = "2.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
+dependencies = [
+ "thiserror-impl 2.0.18",
 ]
 
 [[package]]
@@ -2006,7 +3272,18 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "2.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2016,6 +3293,37 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "time"
+version = "0.3.47"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
+dependencies = [
+ "deranged",
+ "itoa",
+ "num-conv",
+ "powerfmt",
+ "serde_core",
+ "time-core",
+ "time-macros",
+]
+
+[[package]]
+name = "time-core"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
+
+[[package]]
+name = "time-macros"
+version = "0.2.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e70e4c5a0e0a8a4823ad65dfe1a6930e4f4d756dcd9dd7939022b5e8c501215"
+dependencies = [
+ "num-conv",
+ "time-core",
 ]
 
 [[package]]
@@ -2068,7 +3376,7 @@ checksum = "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2094,7 +3402,7 @@ dependencies = [
  "socket2",
  "tokio",
  "tokio-util",
- "whoami",
+ "whoami 2.1.2",
 ]
 
 [[package]]
@@ -2118,6 +3426,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
 dependencies = [
  "rustls",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-stream"
+version = "0.1.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32da49809aab5c3bc678af03902d4ccddea2a87d028d86392a4b1560c6906c70"
+dependencies = [
+ "futures-core",
+ "pin-project-lite",
  "tokio",
 ]
 
@@ -2211,6 +3530,7 @@ version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
 dependencies = [
+ "log",
  "pin-project-lite",
  "tracing-attributes",
  "tracing-core",
@@ -2224,7 +3544,7 @@ checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2275,8 +3595,11 @@ dependencies = [
  "candle-nn",
  "chrono",
  "clap",
+ "migration",
  "rand 0.8.6",
  "rustls",
+ "sea-orm",
+ "sea-orm-migration",
  "serde",
  "serde_json",
  "sha1",
@@ -2385,6 +3708,7 @@ checksum = "ddd74a9687298c6858e9b88ec8935ec45d22e8fd5e6394fa1bd4e99a87789c76"
 dependencies = [
  "getrandom 0.4.2",
  "js-sys",
+ "serde_core",
  "wasm-bindgen",
 ]
 
@@ -2393,6 +3717,12 @@ name = "valuable"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
+
+[[package]]
+name = "vcpkg"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "version_check"
@@ -2445,6 +3775,12 @@ dependencies = [
 
 [[package]]
 name = "wasite"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8dad83b4f25e74f184f64c43b150b91efe7647395b42289f38e50566d82855b"
+
+[[package]]
+name = "wasite"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "66fe902b4a6b8028a753d5424909b764ccf79b7a209eac9bf97e59cda9f71a42"
@@ -2461,6 +3797,7 @@ dependencies = [
  "cfg-if",
  "once_cell",
  "rustversion",
+ "serde",
  "wasm-bindgen-macro",
  "wasm-bindgen-shared",
 ]
@@ -2484,7 +3821,7 @@ dependencies = [
  "bumpalo",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
  "wasm-bindgen-shared",
 ]
 
@@ -2561,6 +3898,16 @@ dependencies = [
 
 [[package]]
 name = "whoami"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d4a4db5077702ca3015d3d02d74974948aba2ad9e12ab7df718ee64ccd7e97d"
+dependencies = [
+ "libredox",
+ "wasite 0.1.0",
+]
+
+[[package]]
+name = "whoami"
 version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "998767ef88740d1f5b0682a9c53c24431453923962269c2db68ee43788c5a40d"
@@ -2568,9 +3915,25 @@ dependencies = [
  "libc",
  "libredox",
  "objc2-system-configuration",
- "wasite",
+ "wasite 1.0.2",
  "web-sys",
 ]
+
+[[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
 
 [[package]]
 name = "winapi-util"
@@ -2580,6 +3943,12 @@ checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
  "windows-sys 0.61.2",
 ]
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-core"
@@ -2602,7 +3971,7 @@ checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2613,7 +3982,7 @@ checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2642,11 +4011,20 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
+dependencies = [
+ "windows-targets 0.48.5",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -2660,19 +4038,40 @@ dependencies = [
 
 [[package]]
 name = "windows-targets"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
+dependencies = [
+ "windows_aarch64_gnullvm 0.48.5",
+ "windows_aarch64_msvc 0.48.5",
+ "windows_i686_gnu 0.48.5",
+ "windows_i686_msvc 0.48.5",
+ "windows_x86_64_gnu 0.48.5",
+ "windows_x86_64_gnullvm 0.48.5",
+ "windows_x86_64_msvc 0.48.5",
+]
+
+[[package]]
+name = "windows-targets"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
 dependencies = [
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
+ "windows_aarch64_gnullvm 0.52.6",
+ "windows_aarch64_msvc 0.52.6",
+ "windows_i686_gnu 0.52.6",
  "windows_i686_gnullvm",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
+ "windows_i686_msvc 0.52.6",
+ "windows_x86_64_gnu 0.52.6",
+ "windows_x86_64_gnullvm 0.52.6",
+ "windows_x86_64_msvc 0.52.6",
 ]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
@@ -2682,9 +4081,21 @@ checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
 name = "windows_aarch64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
+
+[[package]]
+name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -2700,9 +4111,21 @@ checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
 
 [[package]]
 name = "windows_i686_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
+
+[[package]]
+name = "windows_i686_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -2712,9 +4135,21 @@ checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -2762,7 +4197,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
 dependencies = [
  "anyhow",
- "heck",
+ "heck 0.5.0",
  "wit-parser",
 ]
 
@@ -2773,10 +4208,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
 dependencies = [
  "anyhow",
- "heck",
+ "heck 0.5.0",
  "indexmap",
  "prettyplease",
- "syn",
+ "syn 2.0.117",
  "wasm-metadata",
  "wit-bindgen-core",
  "wit-component",
@@ -2792,7 +4227,7 @@ dependencies = [
  "prettyplease",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
  "wit-bindgen-core",
  "wit-bindgen-rust",
 ]
@@ -2841,6 +4276,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
 
 [[package]]
+name = "wyz"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05f360fc0b24296329c78fda852a1e9ae82de9cf7b27dae4b7f62f118f77b9ed"
+dependencies = [
+ "tap",
+]
+
+[[package]]
 name = "x509-certificate"
 version = "0.23.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2855,9 +4299,15 @@ dependencies = [
  "ring",
  "signature",
  "spki",
- "thiserror",
+ "thiserror 1.0.69",
  "zeroize",
 ]
+
+[[package]]
+name = "yansi"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfe53a6657fd280eaa890a3bc59152892ffa3e30101319d168b781ed6529b049"
 
 [[package]]
 name = "yoke"
@@ -2890,7 +4340,7 @@ checksum = "2380878cad4ac9aac1e2435f3eb4020e8374b5f13c296cb75b4620ff8e229154"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
  "synstructure",
 ]
 
@@ -2902,7 +4352,7 @@ checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
  "synstructure",
 ]
 
@@ -2923,7 +4373,7 @@ checksum = "70e3cd084b1788766f53af483dd21f93881ff30d7320490ec3ef7526d203bad4"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2943,7 +4393,7 @@ checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
  "synstructure",
 ]
 
@@ -2964,7 +4414,7 @@ checksum = "85a5b4158499876c763cb03bc4e49185d3cccbabb15b33c627f7884f43db852e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2997,7 +4447,7 @@ checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3012,7 +4462,7 @@ dependencies = [
  "displaydoc",
  "indexmap",
  "num_enum",
- "thiserror",
+ "thiserror 1.0.69",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,7 @@
 [workspace]
-# Empty workspace to isolate from parent trios workspace
+# Workspace includes the migration subcrate (sea-orm-migration)
+members = [".", "migration"]
+# Empty resolver comment preserved for compatibility
 
 [package]
 name        = "trios-trainer"
@@ -210,6 +212,16 @@ tokio-postgres-rustls = "0.12"
 rustls               = "0.23"
 webpki-roots         = "0.26"
 ureq                  = "2.12"
+sea-orm = { version = "1.1", features = [
+    "sqlx-postgres",
+    "runtime-tokio-rustls",
+    "macros",
+    "with-uuid",
+    "with-chrono",
+    "with-json",
+] }
+sea-orm-migration = "1.1"
+migration = { path = "migration" }
 
 [dev-dependencies]
 tempfile = "3.10"

--- a/migration/Cargo.toml
+++ b/migration/Cargo.toml
@@ -1,0 +1,29 @@
+[package]
+name = "migration"
+version = "0.1.0"
+edition = "2021"
+authors = ["Dmitrii Vasilev <admin@t27.ai>"]
+description = "SeaORM migration crate for trios-trainer-igla ledger schema"
+
+[lib]
+name = "migration"
+path = "src/lib.rs"
+
+[[bin]]
+name = "migration"
+path = "src/main.rs"
+
+[dependencies]
+sea-orm-migration = { version = "1.1", features = ["runtime-tokio-rustls"] }
+tokio = { version = "1", features = ["full"] }
+
+[dev-dependencies]
+sea-orm = { version = "1.1", features = [
+    "sqlx-postgres",
+    "runtime-tokio-rustls",
+    "macros",
+    "with-uuid",
+    "with-chrono",
+    "with-json",
+] }
+tokio = { version = "1", features = ["full"] }

--- a/migration/src/lib.rs
+++ b/migration/src/lib.rs
@@ -1,0 +1,18 @@
+// migration/src/lib.rs
+//
+// SeaORM migration crate for trios-trainer-igla.
+//
+// Anchor: phi^2 + phi^-2 = 3 · DOI 10.5281/zenodo.19227877
+
+pub use sea_orm_migration::prelude::*;
+
+pub mod m20260509_000001_init_schema;
+
+pub struct Migrator;
+
+#[async_trait::async_trait]
+impl MigratorTrait for Migrator {
+    fn migrations() -> Vec<Box<dyn MigrationTrait>> {
+        vec![Box::new(m20260509_000001_init_schema::Migration)]
+    }
+}

--- a/migration/src/m20260509_000001_init_schema.rs
+++ b/migration/src/m20260509_000001_init_schema.rs
@@ -176,10 +176,8 @@ END;
 $$ LANGUAGE plpgsql",
         )
         .await?;
-        db.execute_unprepared(
-            "DROP TRIGGER IF EXISTS trg_strategy_new ON public.strategy_queue",
-        )
-        .await?;
+        db.execute_unprepared("DROP TRIGGER IF EXISTS trg_strategy_new ON public.strategy_queue")
+            .await?;
         db.execute_unprepared(
             "CREATE TRIGGER trg_strategy_new
                 AFTER INSERT OR UPDATE OF status ON public.strategy_queue
@@ -194,28 +192,21 @@ $$ LANGUAGE plpgsql",
     async fn down(&self, manager: &SchemaManager) -> Result<(), DbErr> {
         let db = manager.get_connection();
 
-        db.execute_unprepared(
-            "DROP TRIGGER IF EXISTS trg_strategy_new ON public.strategy_queue",
-        )
-        .await?;
-        db.execute_unprepared(
-            "DROP FUNCTION IF EXISTS public.notify_strategy_new()",
-        )
-        .await?;
+        db.execute_unprepared("DROP TRIGGER IF EXISTS trg_strategy_new ON public.strategy_queue")
+            .await?;
+        db.execute_unprepared("DROP FUNCTION IF EXISTS public.notify_strategy_new()")
+            .await?;
         db.execute_unprepared("DROP TABLE IF EXISTS public.strategy_queue")
             .await?;
         db.execute_unprepared("DROP TABLE IF EXISTS public.scarabs")
             .await?;
-        db.execute_unprepared(
-            "DROP TABLE IF EXISTS public.igla_agents_heartbeat",
-        )
-        .await?;
+        db.execute_unprepared("DROP TABLE IF EXISTS public.igla_agents_heartbeat")
+            .await?;
         db.execute_unprepared("DROP TABLE IF EXISTS public.igla_race_trials")
             .await?;
         db.execute_unprepared("DROP TABLE IF EXISTS ssot.bpb_samples")
             .await?;
-        db.execute_unprepared("DROP SCHEMA IF EXISTS ssot")
-            .await?;
+        db.execute_unprepared("DROP SCHEMA IF EXISTS ssot").await?;
         db.execute_unprepared("DROP TABLE IF EXISTS public.bpb_samples")
             .await?;
 

--- a/migration/src/m20260509_000001_init_schema.rs
+++ b/migration/src/m20260509_000001_init_schema.rs
@@ -1,0 +1,224 @@
+// Migration: m20260509_000001_init_schema
+//
+// Mirrors the canonical /tmp/full_ddl.sql 1-to-1.
+// All statements are idempotent (CREATE TABLE IF NOT EXISTS, etc.).
+//
+// Tables:
+//   - public.bpb_samples       (legacy ledger, used by neon_writer)
+//   - ssot.bpb_samples         (new SoT, per matrix_runner.rs)
+//   - public.igla_race_trials  (trial lifecycle tracking)
+//   - public.igla_agents_heartbeat (worker heartbeats)
+//   - public.scarabs           (fungible worker pool, migration 002)
+//   - public.strategy_queue    (job queue with NOTIFY trigger)
+//
+// Anchor: phi^2 + phi^-2 = 3 · DOI 10.5281/zenodo.19227877
+
+use sea_orm_migration::prelude::*;
+
+pub struct Migration;
+
+impl MigrationName for Migration {
+    fn name(&self) -> &str {
+        "m20260509_000001_init_schema"
+    }
+}
+
+#[async_trait::async_trait]
+impl MigrationTrait for Migration {
+    async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        let db = manager.get_connection();
+
+        // ── public.bpb_samples (legacy) ──────────────────────────────────
+        db.execute_unprepared(
+            "CREATE TABLE IF NOT EXISTS public.bpb_samples (
+                id            BIGSERIAL PRIMARY KEY,
+                canon_name    TEXT NOT NULL,
+                seed          BIGINT NOT NULL,
+                step          INT NOT NULL,
+                bpb           DOUBLE PRECISION NOT NULL,
+                ts            TIMESTAMPTZ NOT NULL DEFAULT now(),
+                UNIQUE (canon_name, seed, step)
+            )",
+        )
+        .await?;
+        db.execute_unprepared(
+            "CREATE INDEX IF NOT EXISTS bpb_samples_canon_idx ON public.bpb_samples (canon_name)",
+        )
+        .await?;
+        db.execute_unprepared(
+            "CREATE INDEX IF NOT EXISTS bpb_samples_ts_idx ON public.bpb_samples (ts DESC)",
+        )
+        .await?;
+
+        // ── ssot schema + ssot.bpb_samples ───────────────────────────────
+        db.execute_unprepared("CREATE SCHEMA IF NOT EXISTS ssot")
+            .await?;
+        db.execute_unprepared(
+            "CREATE TABLE IF NOT EXISTS ssot.bpb_samples (
+                id            BIGSERIAL PRIMARY KEY,
+                canon_name    TEXT NOT NULL,
+                format        TEXT NOT NULL,
+                algo          TEXT NOT NULL,
+                hidden        INT NOT NULL,
+                seed          BIGINT NOT NULL,
+                step          INT NOT NULL,
+                bpb           DOUBLE PRECISION NOT NULL,
+                sha           TEXT,
+                run_id        TEXT,
+                ts            TIMESTAMPTZ NOT NULL DEFAULT now()
+            )",
+        )
+        .await?;
+        db.execute_unprepared(
+            "CREATE INDEX IF NOT EXISTS ssot_bpb_format_algo_idx ON ssot.bpb_samples (format, algo)",
+        )
+        .await?;
+        db.execute_unprepared(
+            "CREATE INDEX IF NOT EXISTS ssot_bpb_canon_idx ON ssot.bpb_samples (canon_name)",
+        )
+        .await?;
+        db.execute_unprepared(
+            "CREATE INDEX IF NOT EXISTS ssot_bpb_ts_idx ON ssot.bpb_samples (ts DESC)",
+        )
+        .await?;
+
+        // ── public.igla_race_trials ───────────────────────────────────────
+        db.execute_unprepared(
+            "CREATE TABLE IF NOT EXISTS public.igla_race_trials (
+                trial_id      UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+                config        JSONB NOT NULL,
+                status        VARCHAR(32) NOT NULL DEFAULT 'pending',
+                agent_id      TEXT,
+                branch        TEXT,
+                final_bpb     DOUBLE PRECISION,
+                final_step    INT,
+                started_at    TIMESTAMPTZ,
+                completed_at  TIMESTAMPTZ,
+                created_at    TIMESTAMPTZ NOT NULL DEFAULT now(),
+                updated_at    TIMESTAMPTZ NOT NULL DEFAULT now()
+            )",
+        )
+        .await?;
+
+        // Ensure bpb_latest column exists (added by ensure_schema() hotfix).
+        db.execute_unprepared(
+            "ALTER TABLE public.igla_race_trials ADD COLUMN IF NOT EXISTS bpb_latest DOUBLE PRECISION",
+        )
+        .await?;
+        db.execute_unprepared(
+            "ALTER TABLE public.igla_race_trials ADD COLUMN IF NOT EXISTS steps_done BIGINT",
+        )
+        .await?;
+        db.execute_unprepared(
+            "ALTER TABLE public.igla_race_trials ADD COLUMN IF NOT EXISTS bpb_final DOUBLE PRECISION",
+        )
+        .await?;
+
+        // ── public.igla_agents_heartbeat ──────────────────────────────────
+        db.execute_unprepared(
+            "CREATE TABLE IF NOT EXISTS public.igla_agents_heartbeat (
+                agent_id        TEXT PRIMARY KEY,
+                machine_id      TEXT NOT NULL DEFAULT 'railway',
+                branch          TEXT NOT NULL DEFAULT 'main',
+                task            TEXT,
+                status          VARCHAR(32) NOT NULL DEFAULT 'active',
+                last_heartbeat  TIMESTAMPTZ NOT NULL DEFAULT now()
+            )",
+        )
+        .await?;
+
+        // ── public.scarabs ────────────────────────────────────────────────
+        db.execute_unprepared(
+            "CREATE TABLE IF NOT EXISTS public.scarabs (
+                scarab_id            UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+                label                TEXT,
+                host                 TEXT,
+                railway_service_id   TEXT,
+                railway_service_name TEXT,
+                current_strategy_id  BIGINT,
+                last_seen            TIMESTAMPTZ NOT NULL DEFAULT now(),
+                created_at           TIMESTAMPTZ NOT NULL DEFAULT now()
+            )",
+        )
+        .await?;
+
+        // ── public.strategy_queue ─────────────────────────────────────────
+        db.execute_unprepared(
+            "CREATE TABLE IF NOT EXISTS public.strategy_queue (
+                id           BIGSERIAL PRIMARY KEY,
+                canon_name   TEXT NOT NULL,
+                config       JSONB NOT NULL,
+                seed         BIGINT NOT NULL,
+                priority     INT NOT NULL DEFAULT 0,
+                status       VARCHAR(32) NOT NULL DEFAULT 'pending',
+                worker_id    TEXT,
+                error_msg    TEXT,
+                started_at   TIMESTAMPTZ,
+                completed_at TIMESTAMPTZ,
+                created_at   TIMESTAMPTZ NOT NULL DEFAULT now()
+            )",
+        )
+        .await?;
+        db.execute_unprepared(
+            "CREATE INDEX IF NOT EXISTS idx_strategy_pending
+                ON public.strategy_queue (priority DESC, id ASC)
+                WHERE status = 'pending'",
+        )
+        .await?;
+
+        // ── NOTIFY trigger for strategy_queue ─────────────────────────────
+        db.execute_unprepared(
+            "CREATE OR REPLACE FUNCTION public.notify_strategy_new() RETURNS trigger AS $$
+BEGIN
+    PERFORM pg_notify('strategy_new', NEW.id::text);
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql",
+        )
+        .await?;
+        db.execute_unprepared(
+            "DROP TRIGGER IF EXISTS trg_strategy_new ON public.strategy_queue",
+        )
+        .await?;
+        db.execute_unprepared(
+            "CREATE TRIGGER trg_strategy_new
+                AFTER INSERT OR UPDATE OF status ON public.strategy_queue
+                FOR EACH ROW WHEN (NEW.status = 'pending')
+                EXECUTE FUNCTION public.notify_strategy_new()",
+        )
+        .await?;
+
+        Ok(())
+    }
+
+    async fn down(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        let db = manager.get_connection();
+
+        db.execute_unprepared(
+            "DROP TRIGGER IF EXISTS trg_strategy_new ON public.strategy_queue",
+        )
+        .await?;
+        db.execute_unprepared(
+            "DROP FUNCTION IF EXISTS public.notify_strategy_new()",
+        )
+        .await?;
+        db.execute_unprepared("DROP TABLE IF EXISTS public.strategy_queue")
+            .await?;
+        db.execute_unprepared("DROP TABLE IF EXISTS public.scarabs")
+            .await?;
+        db.execute_unprepared(
+            "DROP TABLE IF EXISTS public.igla_agents_heartbeat",
+        )
+        .await?;
+        db.execute_unprepared("DROP TABLE IF EXISTS public.igla_race_trials")
+            .await?;
+        db.execute_unprepared("DROP TABLE IF EXISTS ssot.bpb_samples")
+            .await?;
+        db.execute_unprepared("DROP SCHEMA IF EXISTS ssot")
+            .await?;
+        db.execute_unprepared("DROP TABLE IF EXISTS public.bpb_samples")
+            .await?;
+
+        Ok(())
+    }
+}

--- a/migration/src/main.rs
+++ b/migration/src/main.rs
@@ -1,0 +1,11 @@
+// migration/src/main.rs
+//
+// CLI entry point for sea-orm-migration.
+// Run: `cargo run -p migration -- up`
+
+use sea_orm_migration::prelude::*;
+
+#[tokio::main]
+async fn main() {
+    cli::run_cli(migration::Migrator).await;
+}

--- a/migration/tests/idempotent.rs
+++ b/migration/tests/idempotent.rs
@@ -1,0 +1,64 @@
+// migration/tests/idempotent.rs
+//
+// Idempotency test: applying the migration twice must not produce an error.
+//
+// This test requires a live Postgres database reachable via DATABASE_URL.
+// It is skipped (passes trivially) if DATABASE_URL is not set, so CI runs
+// without a database do not fail.
+//
+// To run locally:
+//   DATABASE_URL=postgres://... cargo test -p migration -- --nocapture
+
+use migration::{Migrator, MigratorTrait};
+
+#[tokio::test]
+async fn migration_is_idempotent() {
+    let db_url = match std::env::var("DATABASE_URL")
+        .or_else(|_| std::env::var("NEON_DATABASE_URL"))
+        .or_else(|_| std::env::var("TRIOS_DATABASE_URL"))
+    {
+        Ok(u) => u,
+        Err(_) => {
+            eprintln!("[idempotent] DATABASE_URL not set — skipping live test");
+            return;
+        }
+    };
+
+    // Strip channel_binding to avoid SCRAM-SHA-256-PLUS failures with rustls.
+    let db_url = strip_channel_binding(&db_url);
+
+    let db = sea_orm::Database::connect(&db_url)
+        .await
+        .expect("connect to Postgres");
+
+    // First apply.
+    Migrator::up(&db, None)
+        .await
+        .expect("first migration::up must succeed");
+
+    // Second apply — must be idempotent (all CREATE IF NOT EXISTS).
+    Migrator::up(&db, None)
+        .await
+        .expect("second migration::up must also succeed (idempotency)");
+
+    db.close().await.expect("close connection");
+}
+
+/// Mirror of neon_writer::strip_channel_binding — duplicated here to keep
+/// the migration crate self-contained without a dep on trios_trainer.
+fn strip_channel_binding(dsn: &str) -> String {
+    let Some(qpos) = dsn.find('?') else {
+        return dsn.to_string();
+    };
+    let (head, query) = dsn.split_at(qpos + 1);
+    let kept: Vec<&str> = query
+        .split('&')
+        .filter(|kv| !kv.trim_start().starts_with("channel_binding="))
+        .collect();
+    let rebuilt = kept.join("&");
+    if rebuilt.is_empty() {
+        head.trim_end_matches('?').to_string()
+    } else {
+        format!("{head}{rebuilt}")
+    }
+}

--- a/src/bin/scarab.rs
+++ b/src/bin/scarab.rs
@@ -17,6 +17,7 @@ use std::process::Stdio;
 use std::sync::Arc;
 use std::time::Duration;
 
+use migration::MigratorTrait;
 use tokio::process::Command;
 use tokio::time::sleep;
 use tokio_postgres_rustls::MakeRustlsConnect;
@@ -443,6 +444,23 @@ async fn main() -> anyhow::Result<()> {
     let svc_id = env::var("RAILWAY_SERVICE_ID").unwrap_or_else(|_| "unknown".into());
     let svc_name = env::var("RAILWAY_SERVICE_NAME").unwrap_or_else(|_| "scarab".into());
     let host = env::var("HOSTNAME").unwrap_or_else(|_| "unknown".into());
+
+    // Run SeaORM migrations at startup (gated by TRINITY_AUTOMIGRATE != "0").
+    let automigrate = env::var("TRINITY_AUTOMIGRATE").unwrap_or_else(|_| "1".to_string());
+    if automigrate != "0" {
+        match sea_orm::Database::connect(&db_url).await {
+            Ok(sea_db) => {
+                match migration::Migrator::up(&sea_db, None).await {
+                    Ok(()) => eprintln!("[migrator] schema up-to-date"),
+                    Err(e) => eprintln!("[migrator] migration failed (non-fatal): {e}"),
+                }
+                let _ = sea_db.close().await;
+            }
+            Err(e) => eprintln!("[migrator] connect failed (non-fatal): {e}"),
+        }
+    } else {
+        eprintln!("[migrator] TRINITY_AUTOMIGRATE=0 — skipping");
+    }
 
     let client = connect_with_retry(&db_url).await?;
 

--- a/src/bin/trios-train.rs
+++ b/src/bin/trios-train.rs
@@ -14,8 +14,8 @@
 use anyhow::Result;
 use clap::Parser;
 use migration::MigratorTrait;
-use trios_trainer::train_loop::{self, TrainArgs, GATE_FINAL_SEEDS};
 use trios_trainer::neon_writer::strip_channel_binding;
+use trios_trainer::train_loop::{self, TrainArgs, GATE_FINAL_SEEDS};
 
 #[derive(Parser, Debug)]
 #[command(
@@ -132,8 +132,7 @@ fn install_panic_hook() {
 /// Gating: TRINITY_AUTOMIGRATE=0 disables for local CI; default is ON.
 /// Logs: "[migrator] schema up-to-date (N migrations applied)"
 fn run_automigrate() {
-    let automigrate = std::env::var("TRINITY_AUTOMIGRATE")
-        .unwrap_or_else(|_| "1".to_string());
+    let automigrate = std::env::var("TRINITY_AUTOMIGRATE").unwrap_or_else(|_| "1".to_string());
     if automigrate == "0" {
         eprintln!("[migrator] TRINITY_AUTOMIGRATE=0 — skipping");
         return;

--- a/src/bin/trios-train.rs
+++ b/src/bin/trios-train.rs
@@ -13,7 +13,9 @@
 
 use anyhow::Result;
 use clap::Parser;
+use migration::MigratorTrait;
 use trios_trainer::train_loop::{self, TrainArgs, GATE_FINAL_SEEDS};
+use trios_trainer::neon_writer::strip_channel_binding;
 
 #[derive(Parser, Debug)]
 #[command(
@@ -125,6 +127,50 @@ fn install_panic_hook() {
     }));
 }
 
+/// Run SeaORM schema migrations at startup if TRINITY_AUTOMIGRATE != "0".
+///
+/// Gating: TRINITY_AUTOMIGRATE=0 disables for local CI; default is ON.
+/// Logs: "[migrator] schema up-to-date (N migrations applied)"
+fn run_automigrate() {
+    let automigrate = std::env::var("TRINITY_AUTOMIGRATE")
+        .unwrap_or_else(|_| "1".to_string());
+    if automigrate == "0" {
+        eprintln!("[migrator] TRINITY_AUTOMIGRATE=0 — skipping");
+        return;
+    }
+
+    let raw_dsn = std::env::var("DATABASE_URL")
+        .or_else(|_| std::env::var("NEON_DATABASE_URL"))
+        .or_else(|_| std::env::var("TRIOS_NEON_DSN"))
+        .or_else(|_| std::env::var("TRIOS_DATABASE_URL"));
+
+    let dsn = match raw_dsn {
+        Ok(d) => strip_channel_binding(&d),
+        Err(_) => {
+            eprintln!("[migrator] DATABASE_URL unset — skipping automigrate");
+            return;
+        }
+    };
+
+    let rt = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .expect("migrator runtime");
+
+    rt.block_on(async {
+        match sea_orm::Database::connect(&dsn).await {
+            Ok(db) => {
+                match migration::Migrator::up(&db, None).await {
+                    Ok(()) => eprintln!("[migrator] schema up-to-date"),
+                    Err(e) => eprintln!("[migrator] migration failed (non-fatal): {e}"),
+                }
+                let _ = db.close().await;
+            }
+            Err(e) => eprintln!("[migrator] connect failed (non-fatal): {e}"),
+        }
+    });
+}
+
 fn main() -> Result<()> {
     install_panic_hook();
 
@@ -141,6 +187,9 @@ fn main() -> Result<()> {
     let _ = std::io::stderr().flush();
 
     let cli = Cli::parse();
+
+    // Run SeaORM migrations at startup (gated by TRINITY_AUTOMIGRATE != "0").
+    run_automigrate();
 
     // R5/L8 fix (trios#509 follow-up): re-export `--format` into the env so
     // `train_loop::resolve_fake_quant_format()` can see it. Without this line

--- a/src/entities/bpb_samples.rs
+++ b/src/entities/bpb_samples.rs
@@ -1,0 +1,29 @@
+// src/entities/bpb_samples.rs
+//
+// SeaORM entity for public.bpb_samples (legacy ledger table).
+//
+// Column types match the DDL in /tmp/full_ddl.sql:
+//   id BIGSERIAL, canon_name TEXT, seed BIGINT, step INT, bpb DOUBLE PRECISION,
+//   ts TIMESTAMPTZ
+//
+// Note: seed is BIGINT -> i64 in Rust (fixes the i32/INT8 mismatch from #114).
+
+use sea_orm::entity::prelude::*;
+
+#[derive(Clone, Debug, PartialEq, DeriveEntityModel)]
+#[sea_orm(table_name = "bpb_samples", schema_name = "public")]
+pub struct Model {
+    #[sea_orm(primary_key)]
+    pub id: i64,
+    pub canon_name: String,
+    /// BIGINT — must be i64, not i32 (fixes #114).
+    pub seed: i64,
+    pub step: i32,
+    pub bpb: f64,
+    pub ts: DateTimeWithTimeZone,
+}
+
+#[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]
+pub enum Relation {}
+
+impl ActiveModelBehavior for ActiveModel {}

--- a/src/entities/igla_agents_heartbeat.rs
+++ b/src/entities/igla_agents_heartbeat.rs
@@ -1,0 +1,22 @@
+// src/entities/igla_agents_heartbeat.rs
+//
+// SeaORM entity for public.igla_agents_heartbeat.
+
+use sea_orm::entity::prelude::*;
+
+#[derive(Clone, Debug, PartialEq, DeriveEntityModel)]
+#[sea_orm(table_name = "igla_agents_heartbeat", schema_name = "public")]
+pub struct Model {
+    #[sea_orm(primary_key, auto_increment = false)]
+    pub agent_id: String,
+    pub machine_id: String,
+    pub branch: String,
+    pub task: Option<String>,
+    pub status: String,
+    pub last_heartbeat: DateTimeWithTimeZone,
+}
+
+#[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]
+pub enum Relation {}
+
+impl ActiveModelBehavior for ActiveModel {}

--- a/src/entities/igla_race_trials.rs
+++ b/src/entities/igla_race_trials.rs
@@ -1,0 +1,30 @@
+// src/entities/igla_race_trials.rs
+//
+// SeaORM entity for public.igla_race_trials.
+
+use sea_orm::entity::prelude::*;
+
+#[derive(Clone, Debug, PartialEq, DeriveEntityModel)]
+#[sea_orm(table_name = "igla_race_trials", schema_name = "public")]
+pub struct Model {
+    #[sea_orm(primary_key, auto_increment = false, column_type = "Uuid")]
+    pub trial_id: Uuid,
+    pub config: Json,
+    pub status: String,
+    pub agent_id: Option<String>,
+    pub branch: Option<String>,
+    pub final_bpb: Option<f64>,
+    pub final_step: Option<i32>,
+    pub bpb_latest: Option<f64>,
+    pub steps_done: Option<i64>,
+    pub bpb_final: Option<f64>,
+    pub started_at: Option<DateTimeWithTimeZone>,
+    pub completed_at: Option<DateTimeWithTimeZone>,
+    pub created_at: DateTimeWithTimeZone,
+    pub updated_at: DateTimeWithTimeZone,
+}
+
+#[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]
+pub enum Relation {}
+
+impl ActiveModelBehavior for ActiveModel {}

--- a/src/entities/mod.rs
+++ b/src/entities/mod.rs
@@ -1,0 +1,18 @@
+// src/entities/mod.rs
+//
+// Re-export all SeaORM entity modules.
+//
+// Use i64 for every BIGINT column (seed, step, steps_done, id BIGSERIAL, etc.)
+// and chrono::DateTime<FixedOffset> (DateTimeWithTimeZone) for TIMESTAMPTZ.
+
+pub mod bpb_samples;
+pub mod igla_agents_heartbeat;
+pub mod igla_race_trials;
+pub mod scarabs;
+pub mod strategy_queue;
+
+pub use bpb_samples::Entity as BpbSamples;
+pub use igla_agents_heartbeat::Entity as IglaAgentsHeartbeat;
+pub use igla_race_trials::Entity as IglaRaceTrials;
+pub use scarabs::Entity as Scarabs;
+pub use strategy_queue::Entity as StrategyQueue;

--- a/src/entities/scarabs.rs
+++ b/src/entities/scarabs.rs
@@ -1,0 +1,25 @@
+// src/entities/scarabs.rs
+//
+// SeaORM entity for public.scarabs (fungible worker pool).
+
+use sea_orm::entity::prelude::*;
+
+#[derive(Clone, Debug, PartialEq, DeriveEntityModel)]
+#[sea_orm(table_name = "scarabs", schema_name = "public")]
+pub struct Model {
+    #[sea_orm(primary_key, auto_increment = false, column_type = "Uuid")]
+    pub scarab_id: Uuid,
+    pub label: Option<String>,
+    pub host: Option<String>,
+    pub railway_service_id: Option<String>,
+    pub railway_service_name: Option<String>,
+    /// BIGINT -> i64.
+    pub current_strategy_id: Option<i64>,
+    pub last_seen: DateTimeWithTimeZone,
+    pub created_at: DateTimeWithTimeZone,
+}
+
+#[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]
+pub enum Relation {}
+
+impl ActiveModelBehavior for ActiveModel {}

--- a/src/entities/strategy_queue.rs
+++ b/src/entities/strategy_queue.rs
@@ -1,0 +1,28 @@
+// src/entities/strategy_queue.rs
+//
+// SeaORM entity for public.strategy_queue (job queue).
+
+use sea_orm::entity::prelude::*;
+
+#[derive(Clone, Debug, PartialEq, DeriveEntityModel)]
+#[sea_orm(table_name = "strategy_queue", schema_name = "public")]
+pub struct Model {
+    #[sea_orm(primary_key)]
+    pub id: i64,
+    pub canon_name: String,
+    pub config: Json,
+    /// BIGINT -> i64.
+    pub seed: i64,
+    pub priority: i32,
+    pub status: String,
+    pub worker_id: Option<String>,
+    pub error_msg: Option<String>,
+    pub started_at: Option<DateTimeWithTimeZone>,
+    pub completed_at: Option<DateTimeWithTimeZone>,
+    pub created_at: DateTimeWithTimeZone,
+}
+
+#[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]
+pub enum Relation {}
+
+impl ActiveModelBehavior for ActiveModel {}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,6 +8,7 @@
 
 pub mod checkpoint;
 pub mod config;
+pub mod entities;
 pub mod data;
 pub mod fake_quant;
 pub mod gf16;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,8 +8,8 @@
 
 pub mod checkpoint;
 pub mod config;
-pub mod entities;
 pub mod data;
+pub mod entities;
 pub mod fake_quant;
 pub mod gf16;
 pub mod igla;

--- a/src/neon_writer.rs
+++ b/src/neon_writer.rs
@@ -26,14 +26,12 @@ use std::sync::OnceLock;
 use std::time::Duration;
 
 use sea_orm::{
-    ActiveModelTrait, ActiveValue::Set, ColumnTrait, ConnectionTrait, Database,
-    DatabaseConnection, EntityTrait, QueryFilter, sea_query::OnConflict,
+    sea_query::OnConflict, ActiveModelTrait, ActiveValue::Set, ColumnTrait, ConnectionTrait,
+    Database, DatabaseConnection, EntityTrait, QueryFilter,
 };
 use tokio::runtime::Runtime;
 
-use crate::entities::{
-    bpb_samples, igla_agents_heartbeat, igla_race_trials,
-};
+use crate::entities::{bpb_samples, igla_agents_heartbeat, igla_race_trials};
 
 // ── Tokio runtime ─────────────────────────────────────────────────────────────
 
@@ -92,9 +90,7 @@ fn db() -> Option<&'static DatabaseConnection> {
             eprintln!("[ledger] stripped channel_binding from DSN (rustls limitation)");
         }
         eprintln!("[ledger] connecting via SeaORM ...");
-        let result = rt().block_on(async {
-            Database::connect(&dsn).await
-        });
+        let result = rt().block_on(async { Database::connect(&dsn).await });
         match result {
             Ok(conn) => {
                 eprintln!("[ledger] connected OK");
@@ -218,10 +214,7 @@ pub fn heartbeat(trial_id: &str, agent_id: &str, bpb: f32, step: usize) {
     use sea_orm::sea_query::Expr;
     let res = rt().block_on(
         igla_race_trials::Entity::update_many()
-            .col_expr(
-                igla_race_trials::Column::BpbLatest,
-                Expr::value(bpb as f64),
-            )
+            .col_expr(igla_race_trials::Column::BpbLatest, Expr::value(bpb as f64))
             .col_expr(
                 igla_race_trials::Column::StepsDone,
                 Expr::value(step as i64),
@@ -230,7 +223,10 @@ pub fn heartbeat(trial_id: &str, agent_id: &str, bpb: f32, step: usize) {
             .exec(conn),
     );
     match res {
-        Ok(r) => eprintln!("[ledger] heartbeat ok: trial={trial_id} rows={}", r.rows_affected),
+        Ok(r) => eprintln!(
+            "[ledger] heartbeat ok: trial={trial_id} rows={}",
+            r.rows_affected
+        ),
         Err(e) => eprintln!("[ledger] heartbeat (update) failed: {e}"),
     }
 }
@@ -258,10 +254,7 @@ pub fn trial_complete(trial_id: &str, bpb: f32) {
     use sea_orm::sea_query::Expr;
     let res = rt().block_on(
         igla_race_trials::Entity::update_many()
-            .col_expr(
-                igla_race_trials::Column::BpbFinal,
-                Expr::value(bpb as f64),
-            )
+            .col_expr(igla_race_trials::Column::BpbFinal, Expr::value(bpb as f64))
             .col_expr(
                 igla_race_trials::Column::Status,
                 Expr::value("complete".to_string()),
@@ -270,7 +263,10 @@ pub fn trial_complete(trial_id: &str, bpb: f32) {
             .exec(conn),
     );
     match res {
-        Ok(r) => eprintln!("[ledger] trial_complete ok: trial={trial_id} rows={}", r.rows_affected),
+        Ok(r) => eprintln!(
+            "[ledger] trial_complete ok: trial={trial_id} rows={}",
+            r.rows_affected
+        ),
         Err(e) => eprintln!("[ledger] trial_complete failed: {e}"),
     }
 }

--- a/src/neon_writer.rs
+++ b/src/neon_writer.rs
@@ -1,28 +1,42 @@
-// Real Neon writer for tjepa_train.
+// src/neon_writer.rs  [ledger]
 //
-// Replaces the previous `eprintln!("NEON_SQL: ...")` log-only emits with actual
-// INSERT/UPDATE statements over `tokio-postgres`. DSN is read from
-// `DATABASE_URL` (canonical) or `NEON_DATABASE_URL` / `TRIOS_NEON_DSN` as
-// legacy fallbacks; if unset the writer is a no-op so existing developer
-// workflows that don't have Neon access keep working.
+// Ledger writer for trios-trainer-igla.
 //
-// Drift code: D2_NEON_NOT_WRITTEN (ref: trios-trainer-igla #36).
+// Provides the same public API as the original tokio-postgres version, but
+// uses SeaORM internally.  The connection is cached in a OnceCell keyed off
+// the resolved DSN.  All public functions keep their synchronous signatures;
+// they block on a private Tokio runtime (same pattern as before).
+//
+// ENV fallback chain (do NOT introduce NEON_* as primary):
+//   DATABASE_URL (canonical, set by Railway since #113)
+//   → NEON_DATABASE_URL  (legacy alias)
+//   → TRIOS_NEON_DSN     (legacy alias)
+//   → TRIOS_DATABASE_URL (legacy alias)
 //
 // Constitutional notes:
-//   R5 - never panic the trainer on Neon errors; log a warn and continue.
-//   R7 - emits forward step/seed/bpb verbatim (caller already builds the
-//        triplet for ledger::emit_row).
-//   R9 - writer never touches `ledger::emit_row`; embargo gate stays in trios.
+//   R5 - never panic the trainer on DB errors; log a warn and continue.
+//   R7 - emits forward step/seed/bpb verbatim.
+//   R9 - writer never touches ledger::emit_row; embargo gate stays in trios.
+//
+// Anchor: phi^2 + phi^-2 = 3 · DOI 10.5281/zenodo.19227877
 
 #![allow(dead_code)]
 
 use std::sync::OnceLock;
 use std::time::Duration;
 
+use sea_orm::{
+    ActiveModelTrait, ActiveValue::Set, ColumnTrait, ConnectionTrait, Database,
+    DatabaseConnection, EntityTrait, QueryFilter, sea_query::OnConflict,
+};
 use tokio::runtime::Runtime;
-use tokio_postgres::Client;
 
-/// Lazy-initialised tokio runtime shared by all sync wrappers.
+use crate::entities::{
+    bpb_samples, igla_agents_heartbeat, igla_race_trials,
+};
+
+// ── Tokio runtime ─────────────────────────────────────────────────────────────
+
 fn rt() -> &'static Runtime {
     static RT: OnceLock<Runtime> = OnceLock::new();
     RT.get_or_init(|| {
@@ -33,139 +47,24 @@ fn rt() -> &'static Runtime {
     })
 }
 
-/// Build a rustls TLS config with system root CAs (required for Neon).
-///
-/// Rustls 0.23+ requires a CryptoProvider to be installed before calling
-/// `ClientConfig::builder()`. We use `ring` and call `install_default()`
-/// here. The `Result` is intentionally ignored: if another thread already
-/// installed a provider the Err is benign.
-fn make_tls_config() -> rustls::ClientConfig {
-    // MUST be called before ClientConfig::builder() in rustls 0.23+.
-    let _ = rustls::crypto::ring::default_provider().install_default();
+// ── DSN helpers ───────────────────────────────────────────────────────────────
 
-    let mut roots = rustls::RootCertStore::empty();
-    roots.extend(webpki_roots::TLS_SERVER_ROOTS.iter().cloned());
-    rustls::ClientConfig::builder()
-        .with_root_certificates(roots)
-        .with_no_client_auth()
-}
-
-/// Lazy-initialised Neon client. `None` if DSN is unset or the
-/// connection failed. Cached across calls.
-fn client() -> Option<&'static Client> {
-    static CLIENT: OnceLock<Option<Client>> = OnceLock::new();
-    CLIENT
-        .get_or_init(|| {
-            let raw_dsn = std::env::var("DATABASE_URL")
-                .or_else(|_| std::env::var("NEON_DATABASE_URL"))
-                .or_else(|_| std::env::var("TRIOS_NEON_DSN"))
-                .or_else(|_| std::env::var("TRIOS_DATABASE_URL"))
-                .ok()?;
-            // tokio-postgres-rustls does NOT export tls-server-end-point
-            // channel binding (rustls 0.23 limitation). Neon's standard DSN
-            // contains `channel_binding=require` which would force SCRAM-SHA-256-PLUS
-            // and fail handshake with an opaque "db error". Strip it; sslmode=require
-            // is sufficient for at-rest TLS encryption (#84 round 3 root cause).
-            let dsn = strip_channel_binding(&raw_dsn);
-            if dsn != raw_dsn {
-                eprintln!("[ledger] stripped channel_binding from DSN (rustls limitation)");
-            }
-            eprintln!("[ledger] connecting to Postgres (TLS) ...");
-            let connect = rt().block_on(async {
-                let tls_config = make_tls_config();
-                let tls = tokio_postgres_rustls::MakeRustlsConnect::new(tls_config);
-                let connector = tokio_postgres::connect(&dsn, tls).await;
-                match connector {
-                    Ok((client, conn)) => {
-                        eprintln!("[ledger] connected OK");
-                        tokio::spawn(async move {
-                            if let Err(e) = conn.await {
-                                eprintln!(
-                                    "[ledger] connection task error: {e}{}",
-                                    full_error_chain(&e)
-                                );
-                            }
-                        });
-                        Some(client)
-                    }
-                    Err(e) => {
-                        eprintln!("[ledger] connect failed: {e}{}", full_error_chain(&e));
-                        None
-                    }
-                }
-            });
-            connect
-        })
-        .as_ref()
-}
-
-/// Run an SQL statement with up to `max_attempts` retries on transient errors.
-fn execute(stmt: &str, params: &[&(dyn tokio_postgres::types::ToSql + Sync)]) {
-    let Some(c) = client() else {
-        eprintln!(
-            "[ledger] DSN unset or unreachable; skipping: {}",
-            short(stmt)
-        );
-        return;
-    };
-    let max_attempts = 3u8;
-    for attempt in 1..=max_attempts {
-        let res = rt().block_on(c.execute(stmt, params));
-        match res {
-            Ok(rows) => {
-                eprintln!("[ledger] ok: {} ({} rows)", short(stmt), rows);
-                return;
-            }
-            Err(e) => {
-                eprintln!(
-                    "[ledger] attempt {attempt}/{max_attempts} failed for {} : {e}{}",
-                    short(stmt),
-                    full_error_chain(&e)
-                );
-                std::thread::sleep(Duration::from_millis(500 * attempt as u64));
-            }
-        }
-    }
-    eprintln!(
-        "[ledger] giving up after {max_attempts} attempts: {}",
-        short(stmt)
-    );
-}
-
-fn short(s: &str) -> &str {
-    let limit = 80usize.min(s.len());
-    &s[..limit]
-}
-
-/// Render the full `Error::source()` chain after a top-level Display, so
-/// opaque errors like tokio_postgres' "db error" surface their real cause
-/// (TLS handshake, SCRAM, channel binding, OID mismatch, ...).
-///
-/// Returns an empty string if the error has no source, so callers can
-/// concatenate unconditionally:  `eprintln!("failed: {e}{}", full_error_chain(&e))`.
-fn full_error_chain<E: std::error::Error + ?Sized>(err: &E) -> String {
-    let mut out = String::new();
-    let mut src: Option<&(dyn std::error::Error)> = err.source();
-    while let Some(s) = src {
-        out.push_str("\n  caused by: ");
-        out.push_str(&s.to_string());
-        src = s.source();
-    }
-    out
+/// Resolve the database DSN from the environment fallback chain.
+fn resolve_dsn() -> Option<String> {
+    std::env::var("DATABASE_URL")
+        .or_else(|_| std::env::var("NEON_DATABASE_URL"))
+        .or_else(|_| std::env::var("TRIOS_NEON_DSN"))
+        .or_else(|_| std::env::var("TRIOS_DATABASE_URL"))
+        .ok()
 }
 
 /// Remove `channel_binding=require` (or `=prefer`) from a Neon-style DSN.
 ///
-/// `tokio-postgres-rustls` 0.12 / rustls 0.23 do not expose the TLS exporter
-/// needed for `tls-server-end-point` channel binding, so SCRAM-SHA-256-PLUS
-/// auth fails with an opaque "db error" the moment a server requires PLUS.
-/// Neon Postgres accepts plain SCRAM-SHA-256 over TLS just fine; stripping
-/// this query-string param is the minimal change that unblocks scarab's writes
-/// without rewriting the TLS stack to native-tls.
+/// `tokio-postgres-rustls` / `sqlx-postgres` with rustls do not expose the TLS
+/// exporter needed for `tls-server-end-point` channel binding, so
+/// SCRAM-SHA-256-PLUS auth fails.  Neon Postgres accepts plain SCRAM-SHA-256
+/// over TLS; stripping this query-string param is the minimal fix (#84, #113).
 pub fn strip_channel_binding(dsn: &str) -> String {
-    // Match both URI and key=value forms. Keep parsing minimal — we only
-    // remove a single `channel_binding=...` token, leaving the rest of the
-    // DSN exactly as the operator supplied it (no URL-decoding/re-encoding).
     let Some(qpos) = dsn.find('?') else {
         return dsn.to_string();
     };
@@ -176,77 +75,276 @@ pub fn strip_channel_binding(dsn: &str) -> String {
         .collect();
     let rebuilt = kept.join("&");
     if rebuilt.is_empty() {
-        // strip the trailing `?` so libpq doesn't see an empty query.
         head.trim_end_matches('?').to_string()
     } else {
         format!("{head}{rebuilt}")
     }
 }
 
+// ── SeaORM connection cache ────────────────────────────────────────────────────
+
+fn db() -> Option<&'static DatabaseConnection> {
+    static DB: OnceLock<Option<DatabaseConnection>> = OnceLock::new();
+    DB.get_or_init(|| {
+        let raw_dsn = resolve_dsn()?;
+        let dsn = strip_channel_binding(&raw_dsn);
+        if dsn != raw_dsn {
+            eprintln!("[ledger] stripped channel_binding from DSN (rustls limitation)");
+        }
+        eprintln!("[ledger] connecting via SeaORM ...");
+        let result = rt().block_on(async {
+            Database::connect(&dsn).await
+        });
+        match result {
+            Ok(conn) => {
+                eprintln!("[ledger] connected OK");
+                Some(conn)
+            }
+            Err(e) => {
+                eprintln!("[ledger] connect failed: {e}");
+                None
+            }
+        }
+    })
+    .as_ref()
+}
+
+// ── Public API ────────────────────────────────────────────────────────────────
+
 /// Insert a fresh row into `igla_race_trials` (idempotent on `trial_id`).
+///
+/// Old raw-SQL call:
+///   INSERT INTO igla_race_trials ... ON CONFLICT (trial_id) DO UPDATE ...
+/// New SeaORM call:
+///   igla_race_trials::Entity::insert(active_model).on_conflict(...).exec(&db)
 pub fn trial_start(trial_id: &str, config_json: &str, agent_id: &str, branch: &str) {
-    execute(
-        "INSERT INTO igla_race_trials (trial_id, config, status, agent_id, branch) \
-         VALUES ($1, $2::jsonb, 'running', $3, $4) \
-         ON CONFLICT (trial_id) DO UPDATE SET status='running', agent_id=EXCLUDED.agent_id, branch=EXCLUDED.branch",
-        &[&trial_id, &config_json, &agent_id, &branch],
+    let Some(conn) = db() else {
+        eprintln!("[ledger] DSN unset — skipping trial_start");
+        return;
+    };
+
+    let trial_uuid = match trial_id.parse::<uuid::Uuid>() {
+        Ok(u) => u,
+        Err(e) => {
+            eprintln!("[ledger] trial_start: invalid UUID {trial_id}: {e}");
+            return;
+        }
+    };
+    let config_val: serde_json::Value = match serde_json::from_str(config_json) {
+        Ok(v) => v,
+        Err(e) => {
+            eprintln!("[ledger] trial_start: invalid JSON: {e}");
+            serde_json::json!({})
+        }
+    };
+
+    let model = igla_race_trials::ActiveModel {
+        trial_id: Set(trial_uuid),
+        config: Set(config_val),
+        status: Set("running".to_string()),
+        agent_id: Set(Some(agent_id.to_string())),
+        branch: Set(Some(branch.to_string())),
+        ..Default::default()
+    };
+
+    let on_conflict = OnConflict::column(igla_race_trials::Column::TrialId)
+        .update_columns([
+            igla_race_trials::Column::Status,
+            igla_race_trials::Column::AgentId,
+            igla_race_trials::Column::Branch,
+        ])
+        .to_owned();
+
+    let res = rt().block_on(
+        igla_race_trials::Entity::insert(model)
+            .on_conflict(on_conflict)
+            .exec(conn),
     );
+    match res {
+        Ok(_) => eprintln!("[ledger] trial_start ok: {trial_id}"),
+        Err(e) => eprintln!("[ledger] trial_start failed: {e}"),
+    }
 }
 
 /// Upsert agent heartbeat and update the latest BPB on the trial row.
+///
+/// Old raw-SQL calls:
+///   INSERT INTO igla_agents_heartbeat ... ON CONFLICT (agent_id) DO UPDATE ...
+///   UPDATE igla_race_trials SET bpb_latest=$1, steps_done=$2 WHERE trial_id=$3
+/// New SeaORM calls:
+///   igla_agents_heartbeat::Entity::insert(...).on_conflict(...).exec(&db)
+///   igla_race_trials::Entity::update_many().col_expr(...).filter(...).exec(&db)
 pub fn heartbeat(trial_id: &str, agent_id: &str, bpb: f32, step: usize) {
-    execute(
-        "INSERT INTO igla_agents_heartbeat (agent_id, machine_id, branch, task, status, last_heartbeat) \
-         VALUES ($1, 'railway', 'main', $2, 'active', NOW()) \
-         ON CONFLICT (agent_id) DO UPDATE SET status=EXCLUDED.status, last_heartbeat=EXCLUDED.last_heartbeat, task=EXCLUDED.task",
-        &[&agent_id, &trial_id],
+    let Some(conn) = db() else {
+        eprintln!("[ledger] DSN unset — skipping heartbeat");
+        return;
+    };
+
+    // Upsert heartbeat row.
+    let hb_model = igla_agents_heartbeat::ActiveModel {
+        agent_id: Set(agent_id.to_string()),
+        machine_id: Set("railway".to_string()),
+        branch: Set("main".to_string()),
+        task: Set(Some(trial_id.to_string())),
+        status: Set("active".to_string()),
+        last_heartbeat: Set(chrono::Utc::now().into()),
+    };
+    let on_conflict_hb = OnConflict::column(igla_agents_heartbeat::Column::AgentId)
+        .update_columns([
+            igla_agents_heartbeat::Column::Status,
+            igla_agents_heartbeat::Column::LastHeartbeat,
+            igla_agents_heartbeat::Column::Task,
+        ])
+        .to_owned();
+    let res = rt().block_on(
+        igla_agents_heartbeat::Entity::insert(hb_model)
+            .on_conflict(on_conflict_hb)
+            .exec(conn),
     );
-    // steps_done is BIGINT — bind as i64 to avoid type mismatch (#114).
-    execute(
-        "UPDATE igla_race_trials SET bpb_latest=$1, steps_done=$2 WHERE trial_id=$3",
-        &[&(bpb as f64), &(step as i64), &trial_id],
+    if let Err(e) = res {
+        eprintln!("[ledger] heartbeat (upsert) failed: {e}");
+    }
+
+    // Update trial row with latest bpb / step.
+    // steps_done is BIGINT — bind as i64.
+    let trial_uuid = match trial_id.parse::<uuid::Uuid>() {
+        Ok(u) => u,
+        Err(e) => {
+            eprintln!("[ledger] heartbeat: invalid UUID {trial_id}: {e}");
+            return;
+        }
+    };
+
+    use sea_orm::sea_query::Expr;
+    let res = rt().block_on(
+        igla_race_trials::Entity::update_many()
+            .col_expr(
+                igla_race_trials::Column::BpbLatest,
+                Expr::value(bpb as f64),
+            )
+            .col_expr(
+                igla_race_trials::Column::StepsDone,
+                Expr::value(step as i64),
+            )
+            .filter(igla_race_trials::Column::TrialId.eq(trial_uuid))
+            .exec(conn),
     );
+    match res {
+        Ok(r) => eprintln!("[ledger] heartbeat ok: trial={trial_id} rows={}", r.rows_affected),
+        Err(e) => eprintln!("[ledger] heartbeat (update) failed: {e}"),
+    }
 }
 
 /// Mark a trial complete with the final BPB.
+///
+/// Old raw-SQL call:
+///   UPDATE igla_race_trials SET bpb_final=$1, status='complete' WHERE trial_id=$2
+/// New SeaORM call:
+///   igla_race_trials::Entity::update_many().col_expr(...).filter(...).exec(&db)
 pub fn trial_complete(trial_id: &str, bpb: f32) {
-    execute(
-        "UPDATE igla_race_trials SET bpb_final=$1, status='complete' WHERE trial_id=$2",
-        &[&(bpb as f64), &trial_id],
+    let Some(conn) = db() else {
+        eprintln!("[ledger] DSN unset — skipping trial_complete");
+        return;
+    };
+
+    let trial_uuid = match trial_id.parse::<uuid::Uuid>() {
+        Ok(u) => u,
+        Err(e) => {
+            eprintln!("[ledger] trial_complete: invalid UUID {trial_id}: {e}");
+            return;
+        }
+    };
+
+    use sea_orm::sea_query::Expr;
+    let res = rt().block_on(
+        igla_race_trials::Entity::update_many()
+            .col_expr(
+                igla_race_trials::Column::BpbFinal,
+                Expr::value(bpb as f64),
+            )
+            .col_expr(
+                igla_race_trials::Column::Status,
+                Expr::value("complete".to_string()),
+            )
+            .filter(igla_race_trials::Column::TrialId.eq(trial_uuid))
+            .exec(conn),
     );
+    match res {
+        Ok(r) => eprintln!("[ledger] trial_complete ok: trial={trial_id} rows={}", r.rows_affected),
+        Err(e) => eprintln!("[ledger] trial_complete failed: {e}"),
+    }
 }
 
 /// Insert a single row into `public.bpb_samples` with checkpoint telemetry.
 ///
 /// Schema (verified against phd-postgres-ssot 2026-05-09):
-///   id BIGSERIAL, canon_name TEXT, seed BIGINT, step BIGINT, bpb DOUBLE PRECISION, ts TIMESTAMPTZ
+///   id BIGSERIAL, canon_name TEXT, seed BIGINT, step INT,
+///   bpb DOUBLE PRECISION, ts TIMESTAMPTZ
 ///
-/// seed and step are BIGINT in Postgres; we widen from i32 via `as i64`
-/// to avoid "cannot convert between Rust type i32 and Postgres int8" (#114).
+/// seed is cast from i32 to i64 to match the BIGINT column (#114).
+///
+/// Old raw-SQL call:
+///   INSERT INTO public.bpb_samples ... ON CONFLICT (canon_name, seed, step) DO NOTHING
+/// New SeaORM call:
+///   bpb_samples::Entity::insert(active_model).on_conflict(...).exec(&db)
 pub fn bpb_sample(canon_name: &str, seed: i32, step: i32, bpb: f32) {
-    // Idempotent: `bpb_samples_canon_name_seed_step_key` is UNIQUE
-    // (canon_name, seed, step). A duplicate emit (scarab restart on the
-    // same row, smoke retry, NOTIFY redelivery, etc.) used to throw
-    // "duplicate key value violates unique constraint" three times before
-    // giving up; now we let Postgres silently skip. Training output is
-    // deterministic for fixed (canon_name, seed, step), so DO NOTHING
-    // preserves the first-write timestamp and avoids redundant churn.
-    //
-    // Cast seed/step to i64 (BIGINT) — fixes bind-type mismatch (#114).
-    execute(
-        "INSERT INTO public.bpb_samples (canon_name, seed, step, bpb, ts) \
-         VALUES ($1, $2, $3, $4, NOW()) \
-         ON CONFLICT (canon_name, seed, step) DO NOTHING",
-        &[&canon_name, &(seed as i64), &(step as i64), &(bpb as f64)],
+    let Some(conn) = db() else {
+        eprintln!("[ledger] DSN unset — skipping bpb_sample");
+        return;
+    };
+
+    // Cast seed to i64 — BIGINT in Postgres (fixes #114 bind-type mismatch).
+    let model = bpb_samples::ActiveModel {
+        canon_name: Set(canon_name.to_string()),
+        seed: Set(seed as i64),
+        step: Set(step),
+        bpb: Set(bpb as f64),
+        ts: Set(chrono::Utc::now().into()),
+        ..Default::default()
+    };
+
+    // Conflict on (canon_name, seed, step) — DO NOTHING preserves first-write ts.
+    let on_conflict = OnConflict::columns([
+        bpb_samples::Column::CanonName,
+        bpb_samples::Column::Seed,
+        bpb_samples::Column::Step,
+    ])
+    .do_nothing()
+    .to_owned();
+
+    let res = rt().block_on(
+        bpb_samples::Entity::insert(model)
+            .on_conflict(on_conflict)
+            .exec(conn),
     );
+    match res {
+        Ok(_) => eprintln!("[ledger] bpb_sample ok: {canon_name} seed={seed} step={step}"),
+        Err(sea_orm::DbErr::RecordNotInserted) => {
+            // ON CONFLICT DO NOTHING — row already exists, this is fine.
+            eprintln!("[ledger] bpb_sample: row already exists (duplicate), skipping");
+        }
+        Err(e) => eprintln!("[ledger] bpb_sample failed: {e}"),
+    }
 }
 
 /// Apply idempotent DDL: ensure `bpb_latest` column exists on `igla_race_trials`.
+///
+/// Old raw-SQL call:
+///   ALTER TABLE igla_race_trials ADD COLUMN IF NOT EXISTS bpb_latest DOUBLE PRECISION
+/// New: delegated to the SeaORM migration (Migrator::up runs at startup).
+/// This stub is kept for callers that invoke it directly.
 pub fn ensure_schema() {
-    execute(
+    let Some(conn) = db() else {
+        eprintln!("[ledger] DSN unset — skipping ensure_schema");
+        return;
+    };
+    let res = rt().block_on(conn.execute_unprepared(
         "ALTER TABLE igla_race_trials ADD COLUMN IF NOT EXISTS bpb_latest DOUBLE PRECISION",
-        &[],
-    );
+    ));
+    match res {
+        Ok(_) => eprintln!("[ledger] ensure_schema ok"),
+        Err(e) => eprintln!("[ledger] ensure_schema failed: {e}"),
+    }
 }
 
 /// Default checkpoint interval honoured by trainers writing to bpb_samples.
@@ -302,37 +400,27 @@ mod tests {
 
     /// Regression test: seed and step parameters for bpb_sample must be bound
     /// as INT8 (i64) to match the BIGINT columns in public.bpb_samples (#114).
-    ///
-    /// This test proves that the values we pass to execute() are accepted by
-    /// Postgres's INT8 type checker without any type mismatch, using the
-    /// `accepts` method on the ToSql trait.
     #[test]
     fn bpb_sample_uses_i64_bind() {
         let seed: i32 = 43;
         let step: i32 = 200;
 
-        // Widen to i64 (exactly as bpb_sample() does internally).
         let seed_i64: i64 = seed as i64;
         let step_i64: i64 = step as i64;
 
-        // Verify that i64 accepts INT8 (BIGINT) via the ToSql::accepts method.
-        // This is the statically-dispatched type acceptance check.
+        // i64 must be accepted by Postgres INT8 (BIGINT).
         assert!(
             <i64 as ToSql>::accepts(&Type::INT8),
-            "i64 must be accepted by Postgres INT8 — the bpb_sample fix requires this"
+            "i64 must be accepted by Postgres INT8"
         );
-
-        // Verify that i32 does NOT accept INT8 — this documents the original bug.
+        // i32 must NOT be accepted by INT8 — documents the original bug.
         assert!(
             !<i32 as ToSql>::accepts(&Type::INT8),
-            "i32 must NOT be accepted by Postgres INT8 — confirms the bug we are fixing"
+            "i32 must NOT be accepted by Postgres INT8"
         );
 
-        // Verify that the widened values are the correct type (not accidentally i32).
-        let _: i64 = seed_i64; // type assertion: seed_i64 is i64
-        let _: i64 = step_i64; // type assertion: step_i64 is i64
-
-        // Sanity: values are correctly widened.
+        let _: i64 = seed_i64;
+        let _: i64 = step_i64;
         assert_eq!(seed_i64, 43i64);
         assert_eq!(step_i64, 200i64);
     }

--- a/tests/ledger_seaorm.rs
+++ b/tests/ledger_seaorm.rs
@@ -34,9 +34,8 @@ async fn ledger_seaorm_smoke() {
     let db_url = strip_channel_binding(&db_url);
 
     use sea_orm::{
-        ActiveModelTrait, ActiveValue::Set, ColumnTrait, Database, EntityTrait,
-        QueryFilter, QuerySelect,
-        sea_query::OnConflict,
+        sea_query::OnConflict, ActiveModelTrait, ActiveValue::Set, ColumnTrait, Database,
+        EntityTrait, QueryFilter, QuerySelect,
     };
     use trios_trainer::entities::bpb_samples;
 
@@ -98,9 +97,15 @@ async fn ledger_seaorm_smoke() {
     assert_eq!(row.canon_name, canon, "canon_name must match");
     assert_eq!(row.seed, seed, "seed must match (i64/BIGINT)");
     assert_eq!(row.step, step, "step must match");
-    assert!((row.bpb - bpb).abs() < 0.001, "bpb must be approximately correct");
+    assert!(
+        (row.bpb - bpb).abs() < 0.001,
+        "bpb must be approximately correct"
+    );
 
-    eprintln!("[ledger_seaorm_smoke] verified row: id={} seed={} bpb={}", row.id, row.seed, row.bpb);
+    eprintln!(
+        "[ledger_seaorm_smoke] verified row: id={} seed={} bpb={}",
+        row.id, row.seed, row.bpb
+    );
 
     db.close().await.expect("close connection");
 }
@@ -108,7 +113,6 @@ async fn ledger_seaorm_smoke() {
 /// Verifies the MigratorTrait is available and migration is idempotent.
 #[tokio::test]
 async fn ledger_seaorm_migration_idempotent() {
-
     let db_url = match std::env::var("DATABASE_URL")
         .or_else(|_| std::env::var("NEON_DATABASE_URL"))
         .or_else(|_| std::env::var("TRIOS_DATABASE_URL"))

--- a/tests/ledger_seaorm.rs
+++ b/tests/ledger_seaorm.rs
@@ -1,0 +1,137 @@
+// tests/ledger_seaorm.rs
+//
+// Smoke test for the SeaORM ledger writer.
+//
+// Requires a live Postgres database reachable via DATABASE_URL.
+// Skipped (passes trivially) if DATABASE_URL is not set, so CI runs
+// without a database do not fail.
+//
+// To run locally:
+//   DATABASE_URL=postgres://... cargo test -p trios-trainer ledger_seaorm -- --nocapture
+//
+// Acceptance gate G2: proves bpb_sample() writes and reads back correctly via SeaORM.
+
+use migration::MigratorTrait;
+use trios_trainer::neon_writer::strip_channel_binding;
+
+/// Smoke test: insert one bpb_sample row (seed=47, step=200, bpb=2.19) and read it back.
+///
+/// Uses sea_orm directly to verify the row is persisted, proving the SeaORM
+/// connection and ActiveModel insert work end-to-end.
+#[tokio::test]
+async fn ledger_seaorm_smoke() {
+    let db_url = match std::env::var("DATABASE_URL")
+        .or_else(|_| std::env::var("NEON_DATABASE_URL"))
+        .or_else(|_| std::env::var("TRIOS_DATABASE_URL"))
+    {
+        Ok(u) => u,
+        Err(_) => {
+            eprintln!("[ledger_seaorm_smoke] DATABASE_URL not set — skipping live test");
+            return;
+        }
+    };
+
+    let db_url = strip_channel_binding(&db_url);
+
+    use sea_orm::{
+        ActiveModelTrait, ActiveValue::Set, ColumnTrait, Database, EntityTrait,
+        QueryFilter, QuerySelect,
+        sea_query::OnConflict,
+    };
+    use trios_trainer::entities::bpb_samples;
+
+    let db = Database::connect(&db_url)
+        .await
+        .expect("connect to Postgres for smoke test");
+
+    // Ensure schema (idempotent).
+    migration::Migrator::up(&db, None)
+        .await
+        .expect("migration must succeed before smoke test");
+
+    let canon = "ledger_seaorm_smoke_test";
+    let seed: i64 = 47; // BIGINT
+    let step: i32 = 200;
+    let bpb: f64 = 2.19;
+
+    // Insert (idempotent: DO NOTHING on conflict).
+    let model = bpb_samples::ActiveModel {
+        canon_name: Set(canon.to_string()),
+        seed: Set(seed),
+        step: Set(step),
+        bpb: Set(bpb),
+        ts: Set(chrono::Utc::now().into()),
+        ..Default::default()
+    };
+
+    let on_conflict = OnConflict::columns([
+        bpb_samples::Column::CanonName,
+        bpb_samples::Column::Seed,
+        bpb_samples::Column::Step,
+    ])
+    .do_nothing()
+    .to_owned();
+
+    let insert_result = bpb_samples::Entity::insert(model)
+        .on_conflict(on_conflict)
+        .exec(&db)
+        .await;
+
+    match insert_result {
+        Ok(_) => eprintln!("[ledger_seaorm_smoke] insert ok"),
+        Err(sea_orm::DbErr::RecordNotInserted) => {
+            eprintln!("[ledger_seaorm_smoke] row already exists (OK — idempotent)");
+        }
+        Err(e) => panic!("bpb_sample insert failed: {e}"),
+    }
+
+    // Read back.
+    let row = bpb_samples::Entity::find()
+        .filter(bpb_samples::Column::CanonName.eq(canon))
+        .filter(bpb_samples::Column::Seed.eq(seed))
+        .filter(bpb_samples::Column::Step.eq(step))
+        .one(&db)
+        .await
+        .expect("SELECT must succeed")
+        .expect("row must exist after insert");
+
+    assert_eq!(row.canon_name, canon, "canon_name must match");
+    assert_eq!(row.seed, seed, "seed must match (i64/BIGINT)");
+    assert_eq!(row.step, step, "step must match");
+    assert!((row.bpb - bpb).abs() < 0.001, "bpb must be approximately correct");
+
+    eprintln!("[ledger_seaorm_smoke] verified row: id={} seed={} bpb={}", row.id, row.seed, row.bpb);
+
+    db.close().await.expect("close connection");
+}
+
+/// Verifies the MigratorTrait is available and migration is idempotent.
+#[tokio::test]
+async fn ledger_seaorm_migration_idempotent() {
+
+    let db_url = match std::env::var("DATABASE_URL")
+        .or_else(|_| std::env::var("NEON_DATABASE_URL"))
+        .or_else(|_| std::env::var("TRIOS_DATABASE_URL"))
+    {
+        Ok(u) => u,
+        Err(_) => {
+            eprintln!("[ledger_seaorm_migration_idempotent] DATABASE_URL not set — skipping");
+            return;
+        }
+    };
+
+    let db_url = strip_channel_binding(&db_url);
+    let db = sea_orm::Database::connect(&db_url)
+        .await
+        .expect("connect for idempotency test");
+
+    migration::Migrator::up(&db, None)
+        .await
+        .expect("first up must succeed");
+
+    migration::Migrator::up(&db, None)
+        .await
+        .expect("second up must succeed (idempotency)");
+
+    db.close().await.expect("close");
+}


### PR DESCRIPTION
## Summary

Closes #114 (PR-B). Lands on top of merged PR-A (#115).

Full SeaORM migration of the ledger writer — eliminates the raw-SQL path that caused type drift and future bind-type mismatches.

## Prerequisite

**PR-A (#115) must be merged first** — it fixed the immediate i32/INT8 crash. This PR (#116) is the full structural replacement that prevents future drift.

## Bind-type fix mapping

| Old raw-SQL call | New SeaORM call |
|---|---|
| `INSERT INTO igla_race_trials ... ON CONFLICT (trial_id) DO UPDATE ...` | `igla_race_trials::Entity::insert(active_model).on_conflict(...).exec(&db)` |
| `INSERT INTO igla_agents_heartbeat ... ON CONFLICT (agent_id) DO UPDATE ...` | `igla_agents_heartbeat::Entity::insert(active_model).on_conflict(...).exec(&db)` |
| `UPDATE igla_race_trials SET bpb_latest=$1, steps_done=$2 ...` (steps_done BIGINT) | `igla_race_trials::Entity::update_many().col_expr(StepsDone, Expr::value(step as i64)).filter(...).exec(&db)` |
| `UPDATE igla_race_trials SET bpb_final=$1, status='complete' ...` | `igla_race_trials::Entity::update_many().col_expr(...).filter(...).exec(&db)` |
| `INSERT INTO public.bpb_samples ... ON CONFLICT DO NOTHING` (`seed` was i32 → BIGINT crash) | `bpb_samples::Entity::insert(ActiveModel { seed: Set(seed as i64), ... }).on_conflict(do_nothing).exec(&db)` |
| `ALTER TABLE igla_race_trials ADD COLUMN IF NOT EXISTS bpb_latest ...` | Delegated to `Migrator::up` at startup; `ensure_schema()` stub preserved |

## Changes

### 1. `migration/` subcrate
- `migration/Cargo.toml` with sea-orm-migration 1.1
- `migration/src/m20260509_000001_init_schema.rs` — mirrors `full_ddl.sql` 1-to-1 with all `IF NOT EXISTS` guards
- `migration/src/lib.rs` — `Migrator` struct, `MigratorTrait` impl
- `migration/tests/idempotent.rs` — idempotency test (skipped if DATABASE_URL unset)

### 2. `src/entities/`
- `bpb_samples.rs` — `seed: i64` (BIGINT), `step: i32` (INT)
- `igla_race_trials.rs` — `steps_done: Option<i64>`, `bpb_latest`, `bpb_final`
- `igla_agents_heartbeat.rs`, `scarabs.rs`, `strategy_queue.rs`
- `mod.rs` — re-exports all entities

### 3. `src/neon_writer.rs` refactor
- SeaORM `DatabaseConnection` cached in `OnceLock`
- All `execute()` calls replaced with entity `insert`/`update_many`
- ENV fallback: `DATABASE_URL` → `NEON_DATABASE_URL` → `TRIOS_NEON_DSN` → `TRIOS_DATABASE_URL`
- `strip_channel_binding` helper preserved and made `pub`
- Log prefix renamed: `[neon_writer]` → `[ledger]`
- Public signatures unchanged

### 4. Binary wiring
- `src/bin/scarab.rs` — calls `Migrator::up` before claim loop
- `src/bin/trios-train.rs` — calls `run_automigrate()` before training
- Both gated by `TRINITY_AUTOMIGRATE != "0"` (default ON)
- Non-fatal: migrate errors logged, training continues

### 5. Tests
- `tests/ledger_seaorm.rs` — smoke test (seed=47, step=200, bpb=2.19 insert+readback; skipped if DATABASE_URL unset)
- `migration/tests/idempotent.rs` — idempotency assertion

## Acceptance gates

| Gate | Check |
|---|---|
| G1 | `cargo check --all-targets` clean ✅ |
| G2 | `cargo test --all-targets` passes (existing + new tests) |
| G3 | `cargo test -p migration` passes idempotency assertion |
| G4 | All required CI checks green |
| G5 | After merge + GHCR rebuild, `TEST-TRAINER-SEED-43` writes ≥1 row to `public.bpb_samples` within 60s |
| G6 | Schema idempotent re-apply produces identical `\d+ bpb_samples` output |

Anchor: `phi^2 + phi^-2 = 3` · DOI 10.5281/zenodo.19227877