### PR TITLE
feat(ledger): alter step columns to BIGINT (m20260510, closes Wave 23 drift)

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -90,3 +90,5 @@ helpers were removed:
 
 Anchor: `phi^2 + phi^-2 = 3` —
 [Zenodo 10.5281/zenodo.19227877](https://doi.org/10.5281/zenodo.19227877).
+
+- 2026-05-09 Wave 24 — m20260510_000001_step_to_bigint: ALTER public.bpb_samples.step, ssot.bpb_samples.step, igla_race_trials.final_step → BIGINT (idempotent guard via information_schema check). Closes drift identified at end of #114.

--- a/migration/src/lib.rs
+++ b/migration/src/lib.rs
@@ -7,12 +7,16 @@
 pub use sea_orm_migration::prelude::*;
 
 pub mod m20260509_000001_init_schema;
+pub mod m20260510_000001_step_to_bigint;
 
 pub struct Migrator;
 
 #[async_trait::async_trait]
 impl MigratorTrait for Migrator {
     fn migrations() -> Vec<Box<dyn MigrationTrait>> {
-        vec![Box::new(m20260509_000001_init_schema::Migration)]
+        vec![
+            Box::new(m20260509_000001_init_schema::Migration),
+            Box::new(m20260510_000001_step_to_bigint::Migration),
+        ]
     }
 }

--- a/migration/src/m20260510_000001_step_to_bigint.rs
+++ b/migration/src/m20260510_000001_step_to_bigint.rs
@@ -1,0 +1,139 @@
+// migration/src/m20260510_000001_step_to_bigint.rs
+//
+// Wave 24 — ALTER step columns to BIGINT (closes Wave 23 drift).
+//
+// Why: public.bpb_samples.step was declared INT in the init migration, but
+// long-running multi-run evaluations may push step beyond 2.1B. All other
+// ledger columns (seed, steps_done) are already BIGINT. This migration
+// lifts step to BIGINT for type uniformity and future-proofing.
+//
+// Tables altered:
+//   - public.bpb_samples.step        INT  → BIGINT
+//   - ssot.bpb_samples.step          INT  → BIGINT (guarded: IF EXISTS)
+//   - public.igla_race_trials.final_step  INT → BIGINT
+//   - public.igla_race_trials.steps_done  BIGINT already (no-op guard)
+//
+// All ALTER statements are idempotent via information_schema checks.
+//
+// down(): Reversing BIGINT → INT is lossy when values > INT_MAX exist.
+// The conservative approach is to log a warning and return Ok(()) without
+// making any changes. Callers must handle the rollback manually if needed.
+//
+// Anchor: phi^2 + phi^-2 = 3 · DOI 10.5281/zenodo.19227877
+
+use sea_orm_migration::prelude::*;
+
+pub struct Migration;
+
+impl MigrationName for Migration {
+    fn name(&self) -> &str {
+        "m20260510_000001_step_to_bigint"
+    }
+}
+
+#[async_trait::async_trait]
+impl MigrationTrait for Migration {
+    async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        let db = manager.get_connection();
+
+        // ── public.bpb_samples.step ──────────────────────────────────────
+        db.execute_unprepared(
+            r#"
+DO $$
+BEGIN
+    IF (SELECT data_type
+        FROM information_schema.columns
+        WHERE table_schema = 'public'
+          AND table_name   = 'bpb_samples'
+          AND column_name  = 'step') = 'integer' THEN
+        ALTER TABLE public.bpb_samples
+            ALTER COLUMN step TYPE BIGINT USING step::BIGINT;
+    END IF;
+END $$;
+"#,
+        )
+        .await?;
+
+        // ── ssot.bpb_samples.step ────────────────────────────────────────
+        // Guarded by IF EXISTS in case the ssot schema is absent on a fresh DB.
+        db.execute_unprepared(
+            r#"
+DO $$
+BEGIN
+    IF EXISTS (
+        SELECT 1 FROM information_schema.tables
+        WHERE table_schema = 'ssot' AND table_name = 'bpb_samples'
+    ) THEN
+        IF (SELECT data_type
+            FROM information_schema.columns
+            WHERE table_schema = 'ssot'
+              AND table_name   = 'bpb_samples'
+              AND column_name  = 'step') = 'integer' THEN
+            ALTER TABLE ssot.bpb_samples
+                ALTER COLUMN step TYPE BIGINT USING step::BIGINT;
+        END IF;
+    END IF;
+END $$;
+"#,
+        )
+        .await?;
+
+        // ── public.igla_race_trials.final_step ───────────────────────────
+        db.execute_unprepared(
+            r#"
+DO $$
+BEGIN
+    IF (SELECT data_type
+        FROM information_schema.columns
+        WHERE table_schema = 'public'
+          AND table_name   = 'igla_race_trials'
+          AND column_name  = 'final_step') = 'integer' THEN
+        ALTER TABLE public.igla_race_trials
+            ALTER COLUMN final_step TYPE BIGINT USING final_step::BIGINT;
+    END IF;
+END $$;
+"#,
+        )
+        .await?;
+
+        // ── public.igla_race_trials.steps_done ──────────────────────────
+        // The init migration already declared steps_done as BIGINT (line 109),
+        // so this is a defensive no-op guard; it will never ALTER in practice.
+        db.execute_unprepared(
+            r#"
+DO $$
+BEGIN
+    IF (SELECT data_type
+        FROM information_schema.columns
+        WHERE table_schema = 'public'
+          AND table_name   = 'igla_race_trials'
+          AND column_name  = 'steps_done') = 'integer' THEN
+        ALTER TABLE public.igla_race_trials
+            ALTER COLUMN steps_done TYPE BIGINT USING steps_done::BIGINT;
+    END IF;
+END $$;
+"#,
+        )
+        .await?;
+
+        // ── public.scarabs ───────────────────────────────────────────────
+        // Audit result: scarabs has no step / final_step column (only
+        // current_strategy_id which is already BIGINT). No ALTER needed.
+
+        Ok(())
+    }
+
+    /// Reversing BIGINT → INT is a lossy operation: any value > 2,147,483,647
+    /// would be silently truncated or cause a Postgres cast error. Rather than
+    /// risk data loss, this down() is intentionally a no-op. Operators who need
+    /// to roll back must do so manually after verifying no out-of-range values
+    /// exist in any of the affected columns.
+    async fn down(&self, _manager: &SchemaManager) -> Result<(), DbErr> {
+        eprintln!(
+            "[migration] m20260510_000001_step_to_bigint: down() is a deliberate no-op. \
+             Reversing BIGINT → INT is lossy when values > INT_MAX exist. \
+             Perform manual rollback if required."
+        );
+        Ok(())
+    }
+}

--- a/migration/tests/idempotent.rs
+++ b/migration/tests/idempotent.rs
@@ -44,6 +44,67 @@ async fn migration_is_idempotent() {
     db.close().await.expect("close connection");
 }
 
+/// Wave 24 — verify that after running Migrator::up() twice, the step column
+/// in public.bpb_samples is reported as bigint by information_schema.
+///
+/// Skipped when DATABASE_URL is not set (no live DB in CI).
+#[tokio::test]
+#[ignore = "requires live DATABASE_URL"]
+async fn step_column_is_bigint_after_migration() {
+    let db_url = match std::env::var("DATABASE_URL")
+        .or_else(|_| std::env::var("NEON_DATABASE_URL"))
+        .or_else(|_| std::env::var("TRIOS_DATABASE_URL"))
+    {
+        Ok(u) => u,
+        Err(_) => {
+            eprintln!("[step_column_is_bigint] DATABASE_URL not set — skipping");
+            return;
+        }
+    };
+
+    let db_url = strip_channel_binding(&db_url);
+
+    let db = sea_orm::Database::connect(&db_url)
+        .await
+        .expect("connect to Postgres");
+
+    // First apply.
+    Migrator::up(&db, None)
+        .await
+        .expect("first migration::up must succeed");
+
+    // Second apply — must be idempotent.
+    Migrator::up(&db, None)
+        .await
+        .expect("second migration::up must also succeed (idempotency)");
+
+    // Verify step column type via information_schema.
+    use sea_orm::ConnectionTrait;
+    let result = db
+        .query_one(sea_orm::Statement::from_string(
+            sea_orm::DatabaseBackend::Postgres,
+            "SELECT data_type FROM information_schema.columns \
+             WHERE table_schema='public' AND table_name='bpb_samples' AND column_name='step'"
+                .to_owned(),
+        ))
+        .await
+        .expect("information_schema query must succeed")
+        .expect("step column must exist in public.bpb_samples");
+
+    let data_type: String = result
+        .try_get_by_index(0)
+        .expect("data_type column must be present");
+
+    assert_eq!(
+        data_type, "bigint",
+        "public.bpb_samples.step must be bigint after Wave 24 migration"
+    );
+
+    eprintln!("[step_column_is_bigint] public.bpb_samples.step data_type = {data_type} ✓");
+
+    db.close().await.expect("close connection");
+}
+
 /// Mirror of neon_writer::strip_channel_binding — duplicated here to keep
 /// the migration crate self-contained without a dep on trios_trainer.
 fn strip_channel_binding(dsn: &str) -> String {

--- a/src/entities/bpb_samples.rs
+++ b/src/entities/bpb_samples.rs
@@ -3,7 +3,7 @@
 // SeaORM entity for public.bpb_samples (legacy ledger table).
 //
 // Column types match the DDL in /tmp/full_ddl.sql:
-//   id BIGSERIAL, canon_name TEXT, seed BIGINT, step INT, bpb DOUBLE PRECISION,
+//   id BIGSERIAL, canon_name TEXT, seed BIGINT, step BIGINT, bpb DOUBLE PRECISION,
 //   ts TIMESTAMPTZ
 //
 // Note: seed is BIGINT -> i64 in Rust (fixes the i32/INT8 mismatch from #114).
@@ -18,7 +18,7 @@ pub struct Model {
     pub canon_name: String,
     /// BIGINT — must be i64, not i32 (fixes #114).
     pub seed: i64,
-    pub step: i32,
+    pub step: i64,
     pub bpb: f64,
     pub ts: DateTimeWithTimeZone,
 }

--- a/src/entities/igla_race_trials.rs
+++ b/src/entities/igla_race_trials.rs
@@ -14,7 +14,7 @@ pub struct Model {
     pub agent_id: Option<String>,
     pub branch: Option<String>,
     pub final_bpb: Option<f64>,
-    pub final_step: Option<i32>,
+    pub final_step: Option<i64>,
     pub bpb_latest: Option<f64>,
     pub steps_done: Option<i64>,
     pub bpb_final: Option<f64>,

--- a/src/neon_writer.rs
+++ b/src/neon_writer.rs
@@ -273,11 +273,11 @@ pub fn trial_complete(trial_id: &str, bpb: f32) {
 
 /// Insert a single row into `public.bpb_samples` with checkpoint telemetry.
 ///
-/// Schema (verified against phd-postgres-ssot 2026-05-09):
-///   id BIGSERIAL, canon_name TEXT, seed BIGINT, step INT,
+/// Schema (verified against phd-postgres-ssot 2026-05-09, updated Wave 24):
+///   id BIGSERIAL, canon_name TEXT, seed BIGINT, step BIGINT,
 ///   bpb DOUBLE PRECISION, ts TIMESTAMPTZ
 ///
-/// seed is cast from i32 to i64 to match the BIGINT column (#114).
+/// seed and step are cast from i32 to i64 to match the BIGINT columns (#114, Wave 24).
 ///
 /// Old raw-SQL call:
 ///   INSERT INTO public.bpb_samples ... ON CONFLICT (canon_name, seed, step) DO NOTHING
@@ -289,11 +289,11 @@ pub fn bpb_sample(canon_name: &str, seed: i32, step: i32, bpb: f32) {
         return;
     };
 
-    // Cast seed to i64 — BIGINT in Postgres (fixes #114 bind-type mismatch).
+    // Cast seed and step to i64 — BIGINT in Postgres (fixes #114, Wave 24 step migration).
     let model = bpb_samples::ActiveModel {
         canon_name: Set(canon_name.to_string()),
         seed: Set(seed as i64),
-        step: Set(step),
+        step: Set(step as i64),
         bpb: Set(bpb as f64),
         ts: Set(chrono::Utc::now().into()),
         ..Default::default()

--- a/tests/ledger_seaorm.rs
+++ b/tests/ledger_seaorm.rs
@@ -50,7 +50,7 @@ async fn ledger_seaorm_smoke() {
 
     let canon = "ledger_seaorm_smoke_test";
     let seed: i64 = 47; // BIGINT
-    let step: i32 = 200;
+    let step: i64 = 200; // BIGINT (Wave 24: step lifted from INT to BIGINT)
     let bpb: f64 = 2.19;
 
     // Insert (idempotent: DO NOTHING on conflict).


### PR DESCRIPTION
## Why

After Wave 23, `public.bpb_samples.step` is still declared as INT (4-byte, max 2,147,483,647). Long-running multi-run evaluations may push `step` beyond 2.1B. All other ledger columns (`seed`, `steps_done`) are already BIGINT. This migration lifts `step` to BIGINT for type uniformity and future-proofing.

Closes drift identified at end of #114. Implements #118.

## What

New migration `m20260510_000001_step_to_bigint` runs idempotent `DO $$ ... END $$;` blocks via `information_schema` checks for:

- `public.bpb_samples.step` INT → BIGINT
- `ssot.bpb_samples.step` INT → BIGINT (guarded `IF EXISTS` for fresh DBs without ssot schema)
- `public.igla_race_trials.final_step` INT → BIGINT
- `public.igla_race_trials.steps_done` BIGINT already (defensive no-op guard)
- `public.scarabs` — no step/final_step column, no ALTER needed

Entity changes:
- `bpb_samples::Model.step`: `i32` → `i64`
- `igla_race_trials::Model.final_step`: `Option<i32>` → `Option<i64>`

Writer changes:
- `neon_writer::bpb_sample`: `step: Set(step)` → `Set(step as i64)`

`down()` is an intentional no-op: reversing BIGINT → INT is lossy when values > INT_MAX exist.

## How verified

- `cargo check --all-targets` clean
- `migration::migration_is_idempotent` test pattern preserved
- New `#[ignore = "requires live DATABASE_URL"]` test `step_column_is_bigint_after_migration` asserts `data_type = 'bigint'` via `information_schema` after double migration run

## Acceptance gates

| Gate | Status |
|---|---|
| G1 | `cargo check --all-targets` clean ✓ |
| G2 | `cargo test -p migration` passes (idempotency test guarded by ignore) |
| G3 | CI checks green (see below) |
| G4 | After merge + GHCR rebuild: `SELECT data_type FROM information_schema.columns WHERE table_schema='public' AND table_name='bpb_samples' AND column_name='step'` → `bigint` |
| G5 | New `bpb_samples` rows continue to land (auto-migrate must not break the writer) |

## Verification SQL (post-deploy)

```sql
SELECT table_schema, table_name, column_name, data_type
FROM information_schema.columns
WHERE column_name IN ('step', 'final_step')
  AND table_name IN ('bpb_samples', 'igla_race_trials')
ORDER BY table_schema, table_name, column_name;
-- Expected: all data_type = 'bigint'
```

## Links

- Closes #118
- Closes drift identified at end of #114
- Anchor: `phi^2 + phi^-2 = 3` · DOI [10.5281/zenodo.19227877](https://zenodo.org/records/19227877)