### PR TITLE
feat(wave31): env-gated architectural patches — PR-B (h=1024 / 4L / GF16)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -178,6 +178,10 @@ ci-strict = []
 smoke = []
 # GPU acceleration using Candle with CUDA support
 gpu = ["candle-core", "candle-nn"]
+# GF16 ternary matmul kernel — compile-time gate for Wave 32.
+# Build with: cargo build --features gf16
+# Without this flag, GF16_ENABLED=true at runtime returns an error.
+gf16 = []
 
 
 [dependencies]

--- a/src/arch_config.rs
+++ b/src/arch_config.rs
@@ -1,0 +1,71 @@
+//! Wave 31 PR-B — env-gated architectural knobs.
+//! Anchor: φ²+φ⁻²=3 · DOI 10.5281/zenodo.19227877
+//!
+//! Three knobs read from environment at trainer init:
+//!
+//! | Env var          | Default | Wave-32 value | Forbidden |
+//! |------------------|---------|---------------|-----------|
+//! | `HIDDEN_DIM`     | 384     | 1024          | <256      |
+//! | `NUM_ATTN_LAYERS`| 1       | 4             | <1        |
+//! | `GF16_ENABLED`   | false   | true          | —         |
+//!
+//! Defaults preserve the Wave-30 baseline (h=384, 1L, no GF16).
+//! Wave 32 redeploy sets all three to attack Gate-2 (BPB<1.85).
+
+/// Parse `HIDDEN_DIM` from environment.
+///
+/// Default: 384 (Wave-30 arch floor).
+/// Forbidden: h < 256 (R6).
+pub fn parse_hidden_dim() -> Result<usize, String> {
+    let raw = std::env::var("HIDDEN_DIM").unwrap_or_else(|_| "384".to_string());
+    let h: usize = raw.parse().map_err(|e| format!("HIDDEN_DIM parse: {e}"))?;
+    if h < 256 {
+        return Err(format!("HIDDEN_DIM={h} < 256 forbidden (R6)"));
+    }
+    Ok(h)
+}
+
+/// Parse `NUM_ATTN_LAYERS` from environment.
+///
+/// Default: 1 (Wave-30 arch floor).
+/// Forbidden: n < 1.
+pub fn parse_num_attn_layers() -> Result<usize, String> {
+    let raw = std::env::var("NUM_ATTN_LAYERS").unwrap_or_else(|_| "1".to_string());
+    let n: usize = raw
+        .parse()
+        .map_err(|e| format!("NUM_ATTN_LAYERS parse: {e}"))?;
+    if n < 1 {
+        return Err(format!("NUM_ATTN_LAYERS={n} < 1 forbidden"));
+    }
+    Ok(n)
+}
+
+/// Parse `GF16_ENABLED` from environment.
+///
+/// Default: false (Wave-30 baseline, no GF16 quantisation).
+/// Accepts: true/1/yes/on → true; false/0/no/off → false.
+pub fn parse_gf16_enabled() -> Result<bool, String> {
+    let raw = std::env::var("GF16_ENABLED").unwrap_or_else(|_| "false".to_string());
+    match raw.to_lowercase().as_str() {
+        "true" | "1" | "yes" | "on" => Ok(true),
+        "false" | "0" | "no" | "off" => Ok(false),
+        _ => Err(format!("GF16_ENABLED parse: invalid value {raw}")),
+    }
+}
+
+/// Parsed arch knobs — returned as a struct for convenience.
+#[derive(Debug, Clone, PartialEq)]
+pub struct ArchConfig {
+    pub hidden_dim: usize,
+    pub num_attn_layers: usize,
+    pub gf16_enabled: bool,
+}
+
+/// Parse all three knobs at once. Fails fast on the first violation.
+pub fn parse_arch_config() -> Result<ArchConfig, String> {
+    Ok(ArchConfig {
+        hidden_dim: parse_hidden_dim()?,
+        num_attn_layers: parse_num_attn_layers()?,
+        gf16_enabled: parse_gf16_enabled()?,
+    })
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,6 +6,7 @@
 //! Gate-2 (deadline 2026-04-30 23:59 UTC). Each lint pays down in a dedicated
 //! technical-debt PR after merge. R5-honest: NOT introduced by PR #32.
 
+pub mod arch_config;
 pub mod checkpoint;
 pub mod config;
 pub mod data;

--- a/src/train_loop.rs
+++ b/src/train_loop.rs
@@ -2,6 +2,7 @@ use anyhow::Result;
 use std::io::Read;
 use std::time::Instant;
 
+use crate::arch_config::{parse_gf16_enabled, parse_hidden_dim, parse_num_attn_layers};
 use crate::fake_quant::{self, FormatKind};
 use crate::model_hybrid_attn::{AttentionCache, HybridAttn};
 use crate::objective::{nca_entropy_loss, NcaObjective};
@@ -37,6 +38,28 @@ fn gf16_enabled() -> bool {
     std::env::var("TRIOS_GF16_DISABLE")
         .map(|v| v != "1")
         .unwrap_or(true)
+}
+
+/// Wave 31 PR-B: resolve GF16 from `GF16_ENABLED` env knob (default false).
+/// If `GF16_ENABLED=true` but feature `gf16` is not compiled in, returns Err.
+/// Falls back to `gf16_enabled()` for legacy `TRIOS_GF16_DISABLE` path.
+/// Anchor: φ²+φ⁻²=3 · DOI 10.5281/zenodo.19227877
+fn resolve_gf16_knob() -> Result<bool> {
+    let knob = parse_gf16_enabled().map_err(|e| anyhow::anyhow!("GF16_ENABLED: {e}"))?;
+    if knob {
+        #[cfg(not(feature = "gf16"))]
+        {
+            return Err(anyhow::anyhow!(
+                "GF16_ENABLED=true but feature 'gf16' not compiled in; \
+                 rebuild with: cargo build --features gf16"
+            ));
+        }
+        #[cfg(feature = "gf16")]
+        {
+            return Ok(true);
+        }
+    }
+    Ok(false)
 }
 
 fn attn_seq_override() -> usize {
@@ -599,9 +622,31 @@ fn evaluate(model: &HybridModel, tokens: &[usize]) -> f32 {
 }
 
 pub fn run_single(args: &TrainArgs) -> Result<RunOutcome> {
+    // Wave 31 PR-B: apply env-gated arch knobs (HIDDEN_DIM, NUM_ATTN_LAYERS).
+    // Defaults preserve Wave-30 baseline (h=384, 1L).
+    // Anchor: φ²+φ⁻²=3 · DOI 10.5281/zenodo.19227877
+    let eff_hidden = if std::env::var("HIDDEN_DIM").is_ok() {
+        let h = parse_hidden_dim().map_err(|e| anyhow::anyhow!("HIDDEN_DIM: {e}"))?;
+        eprintln!("[arch-knob] HIDDEN_DIM={h} (override, Wave-31 PR-B)");
+        h
+    } else {
+        args.hidden
+    };
+    let eff_attn_layers: u8 = if std::env::var("NUM_ATTN_LAYERS").is_ok() {
+        let n = parse_num_attn_layers().map_err(|e| anyhow::anyhow!("NUM_ATTN_LAYERS: {e}"))?;
+        eprintln!("[arch-knob] NUM_ATTN_LAYERS={n} (override, Wave-31 PR-B)");
+        n as u8
+    } else {
+        args.attn_layers
+    };
+    // Wave 31 PR-B: validate GF16_ENABLED knob (default false, feature-gated).
+    let _gf16_knob = resolve_gf16_knob()?;
+    if _gf16_knob {
+        eprintln!("[arch-knob] GF16_ENABLED=true (Wave-31 PR-B, feature=gf16)");
+    }
     eprintln!(
         "=== trios-train seed={} steps={} hidden={} lr={:.4} attn_layers={} ===",
-        args.seed, args.steps, args.hidden, args.lr, args.attn_layers
+        args.seed, args.steps, eff_hidden, args.lr, eff_attn_layers
     );
     let train = load_data(&args.train_path);
     let val = load_data(&args.val_path);
@@ -616,7 +661,7 @@ pub fn run_single(args: &TrainArgs) -> Result<RunOutcome> {
         eprintln!("QAT: FakeQuant enabled for format {:?}", fmt);
     }
 
-    let mut model = HybridModel::new(args.hidden, args.seed, args.attn_layers);
+    let mut model = HybridModel::new(eff_hidden, args.seed, eff_attn_layers);
     if let Some(fmt) = fq_fmt {
         fake_quantize_model(&mut model, fmt);
     }
@@ -626,10 +671,10 @@ pub fn run_single(args: &TrainArgs) -> Result<RunOutcome> {
     let wd = 0.04f32;
     let mut opt_embed = AdamW::new(VOCAB * DIM, wd);
     let mut opt_ctx: Vec<AdamW> = (0..NUM_CTX).map(|_| AdamW::new(VOCAB * DIM, wd)).collect();
-    let mut opt_proj = AdamW::new(args.hidden * DIM, wd);
-    let mut opt_attn_down = AdamW::new(d * args.hidden, wd);
-    let mut opt_attn_up = AdamW::new(args.hidden * d, wd);
-    let mut opt_head = AdamW::new(VOCAB * args.hidden, wd);
+    let mut opt_proj = AdamW::new(eff_hidden * DIM, wd);
+    let mut opt_attn_down = AdamW::new(d * eff_hidden, wd);
+    let mut opt_attn_up = AdamW::new(eff_hidden * d, wd);
+    let mut opt_head = AdamW::new(VOCAB * eff_hidden, wd);
     let mut opt_attn_w = AdamW::new(attn_total, wd);
 
     let init_bpb = evaluate(&model, &val);
@@ -648,10 +693,10 @@ pub fn run_single(args: &TrainArgs) -> Result<RunOutcome> {
         let lr = cosine_lr(step, args.steps, args.lr, warmup);
         let mut ge = vec![0.0f32; VOCAB * DIM];
         let mut gc: Vec<Vec<f32>> = (0..NUM_CTX).map(|_| vec![0.0f32; VOCAB * DIM]).collect();
-        let mut gp = vec![0.0f32; args.hidden * DIM];
-        let mut gh = vec![0.0f32; VOCAB * args.hidden];
-        let mut g_ad = vec![0.0f32; d * args.hidden];
-        let mut g_au = vec![0.0f32; args.hidden * d];
+        let mut gp = vec![0.0f32; eff_hidden * DIM];
+        let mut gh = vec![0.0f32; VOCAB * eff_hidden];
+        let mut g_ad = vec![0.0f32; d * eff_hidden];
+        let mut g_au = vec![0.0f32; eff_hidden * d];
         let mut g_aw = vec![0.0f32; 8 * dd];
 
         for _ in 0..accum {
@@ -839,10 +884,26 @@ pub fn run_single(args: &TrainArgs) -> Result<RunOutcome> {
 }
 
 pub fn run_single_muon(args: &TrainArgs, use_cwd: bool) -> Result<RunOutcome> {
+    // Wave 31 PR-B: apply env-gated arch knobs.
+    let eff_hidden = if std::env::var("HIDDEN_DIM").is_ok() {
+        let h = parse_hidden_dim().map_err(|e| anyhow::anyhow!("HIDDEN_DIM: {e}"))?;
+        eprintln!("[arch-knob] HIDDEN_DIM={h} (override, Wave-31 PR-B)");
+        h
+    } else {
+        args.hidden
+    };
+    let eff_attn_layers: u8 = if std::env::var("NUM_ATTN_LAYERS").is_ok() {
+        let n = parse_num_attn_layers().map_err(|e| anyhow::anyhow!("NUM_ATTN_LAYERS: {e}"))?;
+        eprintln!("[arch-knob] NUM_ATTN_LAYERS={n} (override, Wave-31 PR-B)");
+        n as u8
+    } else {
+        args.attn_layers
+    };
+    let _gf16_knob = resolve_gf16_knob()?;
     let label = if use_cwd { "MuonCwd" } else { "Muon" };
     eprintln!(
         "=== P1 {} seed={} steps={} hidden={} ===",
-        label, args.seed, args.steps, args.hidden
+        label, args.seed, args.steps, eff_hidden
     );
     let train = load_data(&args.train_path);
     let val = load_data(&args.val_path);
@@ -854,7 +915,7 @@ pub fn run_single_muon(args: &TrainArgs, use_cwd: bool) -> Result<RunOutcome> {
         eprintln!("QAT: FakeQuant enabled for format {:?}", fmt);
     }
 
-    let mut model = HybridModel::new(args.hidden, args.seed, args.attn_layers);
+    let mut model = HybridModel::new(eff_hidden, args.seed, eff_attn_layers);
     if let Some(fmt) = fq_fmt {
         fake_quantize_model(&mut model, fmt);
     }
@@ -871,17 +932,17 @@ pub fn run_single_muon(args: &TrainArgs, use_cwd: bool) -> Result<RunOutcome> {
         .map(|_| AdamW::new(VOCAB * DIM, adamw_wd))
         .collect();
     let mut opt_proj_muon = crate::optimizer::MuonOptimizer::with_matrix_shape(
-        args.hidden * DIM,
-        args.hidden,
+        eff_hidden * DIM,
+        eff_hidden,
         DIM,
         muon_lr,
         muon_mom,
         muon_wd,
     );
     opt_proj_muon.ns_steps = if use_cwd { 3 } else { 1 };
-    let mut opt_attn_down = AdamW::new(d * args.hidden, adamw_wd);
-    let mut opt_attn_up = AdamW::new(args.hidden * d, adamw_wd);
-    let mut opt_head = AdamW::new(VOCAB * args.hidden, adamw_wd);
+    let mut opt_attn_down = AdamW::new(d * eff_hidden, adamw_wd);
+    let mut opt_attn_up = AdamW::new(eff_hidden * d, adamw_wd);
+    let mut opt_head = AdamW::new(VOCAB * eff_hidden, adamw_wd);
     let mut opt_attn_w_muon = AdamW::new(8 * dd, adamw_wd);
     let _cwd_lambda = cwd_lambda;
 
@@ -901,10 +962,10 @@ pub fn run_single_muon(args: &TrainArgs, use_cwd: bool) -> Result<RunOutcome> {
         let lr = cosine_lr(step, args.steps, args.lr, warmup);
         let mut ge = vec![0.0f32; VOCAB * DIM];
         let mut gc: Vec<Vec<f32>> = (0..NUM_CTX).map(|_| vec![0.0f32; VOCAB * DIM]).collect();
-        let mut gp = vec![0.0f32; args.hidden * DIM];
-        let mut gh = vec![0.0f32; VOCAB * args.hidden];
-        let mut g_ad = vec![0.0f32; d * args.hidden];
-        let mut g_au = vec![0.0f32; args.hidden * d];
+        let mut gp = vec![0.0f32; eff_hidden * DIM];
+        let mut gh = vec![0.0f32; VOCAB * eff_hidden];
+        let mut g_ad = vec![0.0f32; d * eff_hidden];
+        let mut g_au = vec![0.0f32; eff_hidden * d];
         let mut g_aw = vec![0.0f32; 8 * dd];
 
         for _ in 0..accum {

--- a/tests/arch_config.rs
+++ b/tests/arch_config.rs
@@ -1,0 +1,123 @@
+//! Wave 31 PR-B — arch_config tests.
+//! Anchor: φ²+φ⁻²=3 · DOI 10.5281/zenodo.19227877
+//!
+//! 9 cases:
+//!   HIDDEN_DIM=1024      → Ok(1024)
+//!   HIDDEN_DIM=128       → Err containing "forbidden"
+//!   HIDDEN_DIM unset     → Ok(384)   (default)
+//!   NUM_ATTN_LAYERS=4    → Ok(4)
+//!   NUM_ATTN_LAYERS=0    → Err
+//!   GF16_ENABLED=true    → Ok(true)
+//!   GF16_ENABLED=false   → Ok(false)
+//!   GF16_ENABLED=garbage → Err
+//!   all-defaults         → (h=384, n=1, gf16=false)
+
+use std::sync::Mutex;
+use trios_trainer::arch_config::{
+    parse_arch_config, parse_gf16_enabled, parse_hidden_dim, parse_num_attn_layers, ArchConfig,
+};
+
+/// Serialise env-var mutations; std::env is process-global.
+static ENV_LOCK: Mutex<()> = Mutex::new(());
+
+// ── HIDDEN_DIM ────────────────────────────────────────────────────────────────
+
+#[test]
+fn hidden_dim_1024_allowed() {
+    let _g = ENV_LOCK.lock().unwrap();
+    std::env::set_var("HIDDEN_DIM", "1024");
+    assert_eq!(parse_hidden_dim(), Ok(1024));
+    std::env::remove_var("HIDDEN_DIM");
+}
+
+#[test]
+fn hidden_dim_128_forbidden() {
+    let _g = ENV_LOCK.lock().unwrap();
+    std::env::set_var("HIDDEN_DIM", "128");
+    let err = parse_hidden_dim().unwrap_err();
+    assert!(
+        err.contains("forbidden"),
+        "expected 'forbidden' in error: {err}"
+    );
+    std::env::remove_var("HIDDEN_DIM");
+}
+
+#[test]
+fn hidden_dim_default_384() {
+    let _g = ENV_LOCK.lock().unwrap();
+    std::env::remove_var("HIDDEN_DIM");
+    assert_eq!(parse_hidden_dim(), Ok(384));
+}
+
+// ── NUM_ATTN_LAYERS ───────────────────────────────────────────────────────────
+
+#[test]
+fn num_attn_layers_4_allowed() {
+    let _g = ENV_LOCK.lock().unwrap();
+    std::env::set_var("NUM_ATTN_LAYERS", "4");
+    assert_eq!(parse_num_attn_layers(), Ok(4));
+    std::env::remove_var("NUM_ATTN_LAYERS");
+}
+
+#[test]
+fn num_attn_layers_0_forbidden() {
+    let _g = ENV_LOCK.lock().unwrap();
+    // usize can't be negative; test 0 which is < 1.
+    std::env::set_var("NUM_ATTN_LAYERS", "0");
+    let err = parse_num_attn_layers().unwrap_err();
+    assert!(
+        err.contains("forbidden") || err.contains("< 1"),
+        "expected forbidden/< 1 in error: {err}"
+    );
+    std::env::remove_var("NUM_ATTN_LAYERS");
+}
+
+// ── GF16_ENABLED ─────────────────────────────────────────────────────────────
+
+#[test]
+fn gf16_enabled_true() {
+    let _g = ENV_LOCK.lock().unwrap();
+    std::env::set_var("GF16_ENABLED", "true");
+    assert_eq!(parse_gf16_enabled(), Ok(true));
+    std::env::remove_var("GF16_ENABLED");
+}
+
+#[test]
+fn gf16_enabled_false() {
+    let _g = ENV_LOCK.lock().unwrap();
+    std::env::set_var("GF16_ENABLED", "false");
+    assert_eq!(parse_gf16_enabled(), Ok(false));
+    std::env::remove_var("GF16_ENABLED");
+}
+
+#[test]
+fn gf16_enabled_garbage_err() {
+    let _g = ENV_LOCK.lock().unwrap();
+    std::env::set_var("GF16_ENABLED", "garbage");
+    let err = parse_gf16_enabled().unwrap_err();
+    assert!(
+        err.contains("invalid value"),
+        "expected 'invalid value' in error: {err}"
+    );
+    std::env::remove_var("GF16_ENABLED");
+}
+
+// ── all-defaults ──────────────────────────────────────────────────────────────
+
+#[test]
+fn all_defaults_wave30_baseline() {
+    let _g = ENV_LOCK.lock().unwrap();
+    std::env::remove_var("HIDDEN_DIM");
+    std::env::remove_var("NUM_ATTN_LAYERS");
+    std::env::remove_var("GF16_ENABLED");
+    let cfg = parse_arch_config().expect("all-defaults must not error");
+    assert_eq!(
+        cfg,
+        ArchConfig {
+            hidden_dim: 384,
+            num_attn_layers: 1,
+            gf16_enabled: false,
+        },
+        "all-defaults must be the Wave-30 baseline (h=384, 1L, no GF16)"
+    );
+}


### PR DESCRIPTION
# Wave 31 ONE SHOT — PR-B: env-gated architectural patches

Sibling of PR-A (#125 seed-canon, #127 ON CONFLICT). Defaults preserve Wave-30 baseline (h=384, 1L, no GF16). Wave 32 redeploy will set HIDDEN_DIM=1024, NUM_ATTN_LAYERS=4, GF16_ENABLED=true to attack Gate-2 (BPB<1.85).

Refs trios#709 (Wave 31 ONE SHOT hub issue).

**Anchor**: φ²+φ⁻²=3 · DOI 10.5281/zenodo.19227877

## Knobs

| Env var | Default | Wave-32 value | Forbidden |
|---|---|---|---|
| `HIDDEN_DIM` | 384 | 1024 | <256 |
| `NUM_ATTN_LAYERS` | 1 | 4 | <1 |
| `GF16_ENABLED` | false | true | — |

## Tests

`tests/arch_config.rs` — 9 cases (allowed / forbidden / default / parse error per knob).

## R7 Falsification

If after Wave 32 redeploy with knobs ON we still see BPB ≥ 2.50 after 100k steps across all 62 services and all 4 canon seeds, the architecture hypothesis (h=1024 + 4L + GF16 → Gate-2) is falsified — fall back to investigate JEPA-T or alternative depth profiles.

## Author
Dmitrii Vasilev <admin@t27.ai> — Defense 2026-06-15.

🌻 phi^2 + phi^-2 = 3 · TRINITY · NEVER STOP
