### PR TITLE
feat(wave32): docker --features gf16 parallel image — preflight for Wave-32-B

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -58,6 +58,23 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
+      # Wave-32-B: parallel gf16 image — compiled with --features gf16 so
+      # GF16_ENABLED=true is safe at runtime. The :latest image above is
+      # unchanged; Wave-30/31 baselines are unaffected.
+      - name: Build & push gf16 variant (Wave-32)
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: ${{ github.event_name != 'pull_request' }}
+          build-args: CARGO_FEATURES=gf16
+          tags: |
+            ghcr.io/ghashtag/trios-trainer-igla:gf16
+            ghcr.io/ghashtag/trios-trainer-igla:gf16-${{ github.sha }}
+            ghcr.io/ghashtag/trios-train:gf16
+            ghcr.io/ghashtag/trios-train:gf16-sha-${{ github.sha }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
   smoke-image:
     runs-on: ubuntu-latest
     needs: publish

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,9 @@
 FROM debian:bookworm-slim AS builder
 
+# Optional Cargo feature flags (e.g. gf16). Default empty = baseline build.
+# Pass --build-arg CARGO_FEATURES=gf16 to enable Wave-32-B GF16 kernel.
+ARG CARGO_FEATURES=""
+
 RUN apt-get update && apt-get install -y --no-install-recommends \
         ca-certificates pkg-config build-essential git curl \
     && rm -rf /var/lib/apt/lists/*
@@ -10,14 +14,18 @@ RUN rustup default 1.91
 
 WORKDIR /build
 COPY . .
-RUN cargo build --release \
+RUN set -e; \
+    FEATURES_FLAG=""; \
+    if [ -n "${CARGO_FEATURES}" ]; then FEATURES_FLAG="--features ${CARGO_FEATURES}"; fi; \
+    cargo build --release --locked \
         --bin entrypoint \
         --bin trios-train \
         --bin scarab \
         --bin gf16_test \
         --bin ngram_train_gf16 \
         --bin bpb_smoke \
-        -p trios-trainer
+        -p trios-trainer \
+        ${FEATURES_FLAG}
 
 FROM debian:bookworm-slim AS runtime
 


### PR DESCRIPTION
## Summary

Add a parallel Docker image build compiled with `--features gf16` so Wave-32-B can safely set `GF16_ENABLED=true` at runtime without hitting the compile-time gate error.

## What changed

**`Dockerfile`**
- Added `ARG CARGO_FEATURES=""` at the top of the builder stage (default empty — preserves existing baseline behaviour).
- The `cargo build` invocation now conditionally appends `--features ${CARGO_FEATURES}` when the build-arg is non-empty (shell guard: `${FEATURES_FLAG}`).
- Also added `--locked` to pin dependency versions reproducibly.

**`.github/workflows/docker-publish.yml`**
- Added a second `Build & push gf16 variant (Wave-32)` step immediately after the existing baseline step.
- Passes `build-args: CARGO_FEATURES=gf16` so the gf16 kernel is compiled in.
- Publishes four new tags: `trios-trainer-igla:gf16`, `trios-trainer-igla:gf16-<sha>`, `trios-train:gf16`, `trios-train:gf16-sha-<sha>`.

## Safety / backwards-compatibility

- The existing `:latest` and `:sha-*` images are **completely unchanged** — Wave-30/31 deployments are unaffected.
- This PR only **adds** new image tags; it does not modify any existing ones.
- When `CARGO_FEATURES` is empty (the default), the Dockerfile produces an identical build to the previous version.

## References

- Predecessor: Wave-31 PR-B #128
- Feature gate: `gf16 = []` declared in `Cargo.toml` — zero dependencies, compile-time only.
- Wave-32-B will reference `ghcr.io/ghashtag/trios-train:gf16` in its deployment manifest.