### PR TITLE
fix(wave33): entrypoint env-alias hotfix — root cause Wave-29 STEPS=200000 silent drop

### DIFF
--- a/src/bin/entrypoint.rs
+++ b/src/bin/entrypoint.rs
@@ -9,17 +9,46 @@
 
 use std::env;
 use std::process::Command;
+use trios_trainer::entrypoint_env::resolve_env_alias;
 
 fn env_or(key: &str, default: &str) -> String {
     env::var(key).unwrap_or_else(|_| default.to_string())
 }
 
 fn main() {
-    let seed = env_or("TRIOS_SEED", "43");
-    let steps = env_or("TRIOS_STEPS", "81000");
-    let lr = env_or("TRIOS_LR", "0.003");
-    let hidden = env_or("TRIOS_HIDDEN", "384");
+    // Wave 33 hotfix: accept both `TRIOS_<KEY>` and the un-prefixed alias.
+    // See `trios_trainer::entrypoint_env` for the resolution order and the
+    // root-cause analysis (Wave-29 STEPS=200000 silently dropped).
+    let (seed, seed_src) = resolve_env_alias("TRIOS_SEED", "SEED", "43");
+    let (steps, steps_src) = resolve_env_alias("TRIOS_STEPS", "STEPS", "81000");
+    let (lr, lr_src) = resolve_env_alias("TRIOS_LR", "LR", "0.003");
+    let (hidden, hidden_src) = resolve_env_alias("TRIOS_HIDDEN", "HIDDEN_DIM", "384");
     let optimizer = env_or("TRIOS_OPTIMIZER", "adamw");
+
+    // Wave 33 trace: emit a deterministic startup line with every resolved
+    // knob plus its source (TRIOS_* / alias / default). Operators can
+    // verify with a single `grep entrypoint-trace` that an env-var override
+    // actually reached the trainer. Without this trace, Wave-29
+    // STEPS=200000 silently degraded to default 81000 and 52 trainers
+    // exited two cycles short; no log line told us why.
+    println!(
+        "[entrypoint-trace] seed=({}, src={}) steps=({}, src={}) lr=({}, src={}) hidden=({}, src={}) opt={}",
+        seed, seed_src.as_str(),
+        steps, steps_src.as_str(),
+        lr, lr_src.as_str(),
+        hidden, hidden_src.as_str(),
+        optimizer,
+    );
+    if let Ok(v) = env::var("NUM_ATTN_LAYERS") {
+        println!(
+            "[entrypoint-trace] NUM_ATTN_LAYERS={v} (consumed inside train_loop::run_single)"
+        );
+    }
+    if let Ok(v) = env::var("GF16_ENABLED") {
+        println!(
+            "[entrypoint-trace] GF16_ENABLED={v} (consumed inside train_loop::run_single)"
+        );
+    }
 
     let train_data = env_or("TRIOS_TRAIN_DATA", "/work/data/tiny_shakespeare.txt");
     let val_data = env_or("TRIOS_VAL_DATA", "/work/data/tiny_shakespeare_val.txt");

--- a/src/bin/entrypoint.rs
+++ b/src/bin/entrypoint.rs
@@ -40,14 +40,10 @@ fn main() {
         optimizer,
     );
     if let Ok(v) = env::var("NUM_ATTN_LAYERS") {
-        println!(
-            "[entrypoint-trace] NUM_ATTN_LAYERS={v} (consumed inside train_loop::run_single)"
-        );
+        println!("[entrypoint-trace] NUM_ATTN_LAYERS={v} (consumed inside train_loop::run_single)");
     }
     if let Ok(v) = env::var("GF16_ENABLED") {
-        println!(
-            "[entrypoint-trace] GF16_ENABLED={v} (consumed inside train_loop::run_single)"
-        );
+        println!("[entrypoint-trace] GF16_ENABLED={v} (consumed inside train_loop::run_single)");
     }
 
     let train_data = env_or("TRIOS_TRAIN_DATA", "/work/data/tiny_shakespeare.txt");

--- a/src/entrypoint_env.rs
+++ b/src/entrypoint_env.rs
@@ -1,0 +1,79 @@
+//! Wave 33 entrypoint env-var helpers.
+//!
+//! Anchor: φ²+φ⁻²=3 · DOI 10.5281/zenodo.19227877
+//!
+//! # Why this module exists
+//!
+//! `entrypoint` is the container CMD that resolves `TRIOS_*` environment
+//! variables and execs `trios-train` with matching `--<flag>=<value>` CLI
+//! args. Until Wave 33 it only honoured the `TRIOS_<KEY>` form, so any
+//! operator or cron script that set the un-prefixed alias (e.g. `STEPS`,
+//! `HIDDEN_DIM`, `SEED`) had their override silently dropped.
+//!
+//! Concrete failure that motivated this module: Wave-29 cron set
+//! `STEPS=200000` on 52 Railway services expecting trainers to run for
+//! 200K steps. Instead they all exited DONE at the 81000 default because
+//! `entrypoint` only read `TRIOS_STEPS`. The trace-line below makes that
+//! kind of silent fallback visible.
+//!
+//! # Resolution order
+//!
+//! For each knob:
+//! 1. `TRIOS_<KEY>` (canonical name, takes precedence)
+//! 2. `<KEY>` (un-prefixed alias, accepted for operator/cron compatibility)
+//! 3. caller-provided default
+//!
+//! `arch_config::parse_*` already reads the un-prefixed names *inside*
+//! `train_loop::run_single` (so `HIDDEN_DIM` overrides the CLI value at
+//! model-init time), but `STEPS` has no such second chance — the trainer
+//! loop runs `for step in 1..=args.steps` where `args.steps` came from
+//! `entrypoint`. Hence the alias must live here.
+
+use std::env;
+
+/// The source of a resolved env-var value, used by the startup trace line.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ResolveSrc {
+    /// Value came from the canonical `TRIOS_<KEY>` env-var.
+    TriosPrefixed,
+    /// Value came from the un-prefixed alias (e.g. `STEPS`).
+    Alias,
+    /// Neither env-var was set; the caller-provided default was used.
+    Default,
+}
+
+impl ResolveSrc {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            ResolveSrc::TriosPrefixed => "TRIOS_*",
+            ResolveSrc::Alias => "alias",
+            ResolveSrc::Default => "default",
+        }
+    }
+}
+
+/// Resolve an env-var value with a fallback alias, returning both the value
+/// and which source provided it.
+///
+/// Reads the canonical `trios_key` first; falls back to `alias` if unset;
+/// finally falls back to `default`.
+///
+/// # Examples
+///
+/// ```
+/// use trios_trainer::entrypoint_env::{resolve_env_alias, ResolveSrc};
+/// std::env::remove_var("TRIOS_FOO");
+/// std::env::remove_var("FOO");
+/// let (v, src) = resolve_env_alias("TRIOS_FOO", "FOO", "default_val");
+/// assert_eq!(v, "default_val");
+/// assert_eq!(src, ResolveSrc::Default);
+/// ```
+pub fn resolve_env_alias(trios_key: &str, alias: &str, default: &str) -> (String, ResolveSrc) {
+    if let Ok(v) = env::var(trios_key) {
+        (v, ResolveSrc::TriosPrefixed)
+    } else if let Ok(v) = env::var(alias) {
+        (v, ResolveSrc::Alias)
+    } else {
+        (default.to_string(), ResolveSrc::Default)
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,6 +8,7 @@
 
 pub mod arch_config;
 pub mod checkpoint;
+pub mod entrypoint_env;
 pub mod config;
 pub mod data;
 pub mod entities;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,10 +8,10 @@
 
 pub mod arch_config;
 pub mod checkpoint;
-pub mod entrypoint_env;
 pub mod config;
 pub mod data;
 pub mod entities;
+pub mod entrypoint_env;
 pub mod fake_quant;
 pub mod gf16;
 pub mod igla;

--- a/tests/entrypoint_env.rs
+++ b/tests/entrypoint_env.rs
@@ -1,0 +1,87 @@
+//! Wave 33 — entrypoint env-var alias tests.
+//! Anchor: φ²+φ⁻²=3 · DOI 10.5281/zenodo.19227877
+//!
+//! Regression test for the Wave-29 silent failure: cron set `STEPS=200000`
+//! on 52 services, but `entrypoint` only read `TRIOS_STEPS`, so every
+//! trainer defaulted to `--steps=81000` and finished two cycles short
+//! without any error log.
+//!
+//! 6 cases covering the 3 × 2 grid of (TRIOS_*, alias, both, neither) ×
+//! (precedence, source-tag correctness).
+
+use std::sync::Mutex;
+use trios_trainer::entrypoint_env::{resolve_env_alias, ResolveSrc};
+
+/// Serialise env-var mutations; std::env is process-global. Same lock
+/// pattern as `tests/arch_config.rs`.
+static ENV_LOCK: Mutex<()> = Mutex::new(());
+
+#[test]
+fn trios_prefixed_takes_precedence() {
+    let _g = ENV_LOCK.lock().unwrap();
+    std::env::set_var("TRIOS_STEPS_TEST_A", "200000");
+    std::env::set_var("STEPS_TEST_A", "81000");
+    let (v, src) = resolve_env_alias("TRIOS_STEPS_TEST_A", "STEPS_TEST_A", "5000");
+    assert_eq!(v, "200000", "TRIOS_* must win over alias");
+    assert_eq!(src, ResolveSrc::TriosPrefixed);
+    std::env::remove_var("TRIOS_STEPS_TEST_A");
+    std::env::remove_var("STEPS_TEST_A");
+}
+
+#[test]
+fn alias_used_when_trios_unset() {
+    // Wave-29 regression: cron set the alias (STEPS), TRIOS_* was unset,
+    // and the old code silently fell back to the default.
+    let _g = ENV_LOCK.lock().unwrap();
+    std::env::remove_var("TRIOS_STEPS_TEST_B");
+    std::env::set_var("STEPS_TEST_B", "200000");
+    let (v, src) = resolve_env_alias("TRIOS_STEPS_TEST_B", "STEPS_TEST_B", "81000");
+    assert_eq!(v, "200000", "alias must be honoured when TRIOS_* unset");
+    assert_eq!(src, ResolveSrc::Alias);
+    std::env::remove_var("STEPS_TEST_B");
+}
+
+#[test]
+fn default_used_when_neither_set() {
+    let _g = ENV_LOCK.lock().unwrap();
+    std::env::remove_var("TRIOS_STEPS_TEST_C");
+    std::env::remove_var("STEPS_TEST_C");
+    let (v, src) = resolve_env_alias("TRIOS_STEPS_TEST_C", "STEPS_TEST_C", "81000");
+    assert_eq!(v, "81000");
+    assert_eq!(src, ResolveSrc::Default);
+}
+
+#[test]
+fn empty_string_in_trios_is_still_a_value() {
+    // env::var returns Ok("") for KEY= (set-but-empty). We accept that as
+    // the value so operators can deliberately blank out a knob.
+    let _g = ENV_LOCK.lock().unwrap();
+    std::env::set_var("TRIOS_STEPS_TEST_D", "");
+    std::env::remove_var("STEPS_TEST_D");
+    let (v, src) = resolve_env_alias("TRIOS_STEPS_TEST_D", "STEPS_TEST_D", "81000");
+    assert_eq!(v, "");
+    assert_eq!(src, ResolveSrc::TriosPrefixed);
+    std::env::remove_var("TRIOS_STEPS_TEST_D");
+}
+
+#[test]
+fn hidden_dim_alias_matches_arch_config_knob_name() {
+    // Compatibility witness with the arch_config knob: HIDDEN_DIM is the
+    // un-prefixed name that train_loop::run_single also reads. If we ever
+    // rename this alias, train_loop must rename in lockstep.
+    let _g = ENV_LOCK.lock().unwrap();
+    std::env::remove_var("TRIOS_HIDDEN");
+    std::env::set_var("HIDDEN_DIM", "1024");
+    let (v, src) = resolve_env_alias("TRIOS_HIDDEN", "HIDDEN_DIM", "384");
+    assert_eq!(v, "1024");
+    assert_eq!(src, ResolveSrc::Alias);
+    std::env::remove_var("HIDDEN_DIM");
+}
+
+#[test]
+fn resolve_src_as_str_is_grep_friendly() {
+    // The trace line uses these strings; CI greps them. Pin the values.
+    assert_eq!(ResolveSrc::TriosPrefixed.as_str(), "TRIOS_*");
+    assert_eq!(ResolveSrc::Alias.as_str(), "alias");
+    assert_eq!(ResolveSrc::Default.as_str(), "default");
+}


### PR DESCRIPTION
# Wave 33 hotfix — root cause Wave-29 STEPS=200000 silent drop

## Summary

This PR fixes the silent env-var drop that caused **Wave 32-A to fail**: 52 canons exited DONE at `step=81000` instead of the intended 200000, with BPB floor 2.6894–2.8964 — worse than the Wave-30 floor (champion `cd91c45 seed=43 BPB=2.1919` still holds).

## Root cause

`src/bin/entrypoint.rs` only read `TRIOS_STEPS`. The Wave-29 cron that set the un-prefixed alias `STEPS=200000` on 52 services had its override silently dropped, so trainers used the binary default `81000` and exited two cycles short.

`HIDDEN_DIM=1024` worked **only by accident** — `train_loop::run_single` (lines 628-637) re-reads `HIDDEN_DIM` directly at model-init time. `STEPS` has no such second-chance read; the trainer loop is `for step in 1..=args.steps`, and `args.steps` came straight from `entrypoint`'s CLI flag.

## Changes

### `src/entrypoint_env.rs` (new module, 79 lines)

`resolve_env_alias(trios_key, alias, default) -> (String, ResolveSrc)` with canonical precedence:

1. `TRIOS_<KEY>` (canonical, wins)
2. `<KEY>` (un-prefixed alias)
3. caller-provided default

`ResolveSrc::{TriosPrefixed, Alias, Default}` records which source provided the value so the startup trace can show it.

### `src/bin/entrypoint.rs` (37-line diff)

Replaces `env_or` with `resolve_env_alias` for `seed`, `steps`, `lr`, `hidden`. Emits a deterministic `[entrypoint-trace]` line at startup, plus echoes `NUM_ATTN_LAYERS` and `GF16_ENABLED` for grep visibility (they're consumed deeper inside `train_loop::run_single`).

Operators can verify any env-var override actually reached the trainer with a single `grep entrypoint-trace`. Without this trace, Wave-29 silently degraded and no log line told us why.

### `tests/entrypoint_env.rs` (6 tests, 87 lines)

| Test | What it locks down |
|------|--------------------|
| `trios_prefixed_takes_precedence` | `TRIOS_FOO=tp` wins over `FOO=al` |
| `alias_used_when_trios_unset` | `FOO=al` is honoured when `TRIOS_FOO` is unset |
| `default_used_when_neither_set` | `Default` source when both unset |
| `empty_string_in_trios_is_still_a_value` | `TRIOS_FOO=""` does NOT fall through to alias |
| `hidden_dim_alias_matches_arch_config_knob_name` | alias literal stays in sync with `arch_config` |
| `resolve_src_as_str_is_grep_friendly` | trace tokens are stable for ops grep |

Local: `cargo test --test entrypoint_env` → **6/6 pass**.

## What this PR does NOT touch

* No source-code logic changes outside `entrypoint`.
* No infrastructure / Railway / Postgres changes.
* No model / training-loop changes — `train_loop::run_single` still reads `HIDDEN_DIM` / `NUM_ATTN_LAYERS` / `GF16_ENABLED` directly; this PR only fixes what the *entrypoint* hands to the trainer's `--steps` flag.

## Verification plan after merge

1. CI green → Docker Publish workflow rebuilds `:main` and `:gf16` tags.
2. Canary one ACC2 service (`scarab-shampoo-rng123`, svc `23987202-…`) with:
   ```
   STEPS=200000 HIDDEN_DIM=1024 NUM_ATTN_LAYERS=4 GF16_ENABLED=true WAVE=33A-canary
   image: ghcr.io/ghashtag/trios-trainer-igla:gf16
   ```
3. Verify `[entrypoint-trace] steps=(200000, src=alias)` appears in the canary's startup logs.
4. If canary survives `step=10000` cleanly → expand to Canon #93 (seeds `{47, 89, 123, 144}`) on `:gf16`.

## Refs

* IGLA RACE: gHashTag/trios#143
* GF16 image preflight: #129 (sha `3d209da3`)
* Wave 32-B `:gf16` digest already published: `sha256:d7db2499796b666f344149883d4825218f28e0992773033e9f89c77af44b2900`

## Anchor

🌻 `phi^2 + phi^-2 = 3 · TRINITY · NEVER STOP` · DOI [10.5281/zenodo.19227877](https://zenodo.org/records/19227877) · Defense 2026-06-15
