### PR TITLE
fix(wave33b): drop baked Dockerfile TRIOS_* defaults — alias precedence actually works now

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -65,9 +65,14 @@ ENV RUST_LOG=info
 # seed at deploy time; absent that, the trainer's CLI default of 47
 # wins. The `parse_seed()` Canon #93 guard in entrypoint+trios-train
 # rejects any forbidden value at process start.
-ENV TRIOS_STEPS=81000
-ENV TRIOS_LR=0.003
-ENV TRIOS_HIDDEN=384
-ENV TRIOS_OPTIMIZER=adamw
+# Wave-33B: defaults moved into the Rust binary (`entrypoint_env::resolve_env_alias`).
+# Baking `ENV TRIOS_STEPS=81000` here meant the canonical key was *always*
+# present at runtime, so an operator-set un-prefixed alias (e.g.
+# `STEPS=200000`) lost the precedence race and the override silently
+# regressed to 81000. Removing the baked ENVs lets the alias actually
+# win when no `TRIOS_<KEY>` is supplied. The binary still defaults to
+# 81000 / 0.003 / 384 / adamw if neither is set, so behavior is
+# unchanged for services that didn't set anything. See PR #130 for the
+# Rust-side resolution logic and `[entrypoint-trace]` line.
 
 ENTRYPOINT ["/usr/local/bin/entrypoint"]


### PR DESCRIPTION
# Wave 33-B follow-up — drop baked Dockerfile TRIOS_* defaults

## Why this PR exists

[#130](https://github.com/gHashTag/trios-trainer-igla/pull/130) introduced `entrypoint_env::resolve_env_alias` with precedence `TRIOS_<KEY>` → `<KEY>` alias → default, intending that an operator-set un-prefixed alias would override the binary default when no canonical `TRIOS_<KEY>` was set on the service.

In practice it still failed. The **Wave-33A canary** (`scarab-shampoo-rng123`, ACC2, deployed 21:18Z post-#130-merge) printed:

```
[entrypoint-trace] seed=(123, src=TRIOS_*) steps=(81000, src=TRIOS_*) lr=(0.003, src=TRIOS_*) hidden=(384, src=TRIOS_*) opt=adamw
```

`steps=81000 src=TRIOS_*` — even though Railway env had only `STEPS=200000` (un-prefixed alias) and the resolved deployment-time variables (`variablesForServiceDeployment`) confirmed there was no `TRIOS_STEPS` on the service.

## Second-order root cause

This Dockerfile baked the canonical key into the image at build time:

```dockerfile
ENV TRIOS_STEPS=81000
ENV TRIOS_LR=0.003
ENV TRIOS_HIDDEN=384
ENV TRIOS_OPTIMIZER=adamw
```

So `TRIOS_STEPS` was *always* set inside the container, regardless of Railway service env vars. Operator aliases never got their chance to win the precedence race.

## Fix

Drop the four baked `ENV TRIOS_*` lines. The Rust binary already defaults to the identical values via `resolve_env_alias("TRIOS_STEPS", "STEPS", "81000")` etc., so:

* Services that set neither key → behavior unchanged (binary default = old Dockerfile default)
* Services that set un-prefixed alias → alias now actually wins (the bug fix)
* Services that set canonical `TRIOS_<KEY>` → canonical still wins (unchanged)

## Verification plan

1. CI green → Docker Publish rebuilds `:latest` and `:gf16`.
2. Redeploy `scarab-shampoo-rng123` (ACC2) — env unchanged from #130 canary attempt: `STEPS=200000 HIDDEN_DIM=1024 NUM_ATTN_LAYERS=4 GF16_ENABLED=true WAVE=33A-canary`.
3. **Expected log**: `[entrypoint-trace] steps=(200000, src=alias)` instead of `steps=(81000, src=TRIOS_*)`.

## Refs

* PR #130 — entrypoint_env module + tests
* gHashTag/trios#143 — IGLA RACE
* Wave 32-A post-mortem (52 canons DONE step=81000)

🌻 phi^2 + phi^-2 = 3 · TRINITY · NEVER STOP
