### PR TITLE
fix(wave35): optimizer-honesty — RCA Wave-34 bit-identical BPB

### DIFF
--- a/src/bin/entrypoint.rs
+++ b/src/bin/entrypoint.rs
@@ -23,7 +23,7 @@ fn main() {
     let (steps, steps_src) = resolve_env_alias("TRIOS_STEPS", "STEPS", "81000");
     let (lr, lr_src) = resolve_env_alias("TRIOS_LR", "LR", "0.003");
     let (hidden, hidden_src) = resolve_env_alias("TRIOS_HIDDEN", "HIDDEN_DIM", "384");
-    let optimizer = env_or("TRIOS_OPTIMIZER", "adamw");
+    let (optimizer, optimizer_src) = resolve_env_alias("TRIOS_OPTIMIZER", "OPTIMIZER", "adamw");
 
     // Wave 33 trace: emit a deterministic startup line with every resolved
     // knob plus its source (TRIOS_* / alias / default). Operators can
@@ -32,12 +32,12 @@ fn main() {
     // STEPS=200000 silently degraded to default 81000 and 52 trainers
     // exited two cycles short; no log line told us why.
     println!(
-        "[entrypoint-trace] seed=({}, src={}) steps=({}, src={}) lr=({}, src={}) hidden=({}, src={}) opt={}",
+        "[entrypoint-trace] seed=({}, src={}) steps=({}, src={}) lr=({}, src={}) hidden=({}, src={}) opt=({}, src={})",
         seed, seed_src.as_str(),
         steps, steps_src.as_str(),
         lr, lr_src.as_str(),
         hidden, hidden_src.as_str(),
-        optimizer,
+        optimizer, optimizer_src.as_str(),
     );
     if let Ok(v) = env::var("NUM_ATTN_LAYERS") {
         println!("[entrypoint-trace] NUM_ATTN_LAYERS={v} (consumed inside train_loop::run_single)");

--- a/src/bin/trios-train.rs
+++ b/src/bin/trios-train.rs
@@ -295,10 +295,21 @@ fn main() -> Result<()> {
             train_path: cli.train_data.clone(),
             val_path: cli.val_data.clone(),
         };
+        // R5-honest dispatch: every supported optimizer is named explicitly.
+        // Any unsupported name is a hard error, NOT a silent AdamW fallback.
+        // Pre-Wave-35 bug: 12 optimizer-named canons (lion/soap/tiger/...)
+        // silently ran AdamW, producing byte-identical BPB across the fleet.
         let outcome = match cli.optimizer.as_str() {
+            "adamw" => train_loop::run_single(&args)?,
             "muon" => train_loop::run_single_muon(&args, false)?,
             "muon-cwd" => train_loop::run_single_muon(&args, true)?,
-            _ => train_loop::run_single(&args)?,
+            other => {
+                return Err(anyhow::anyhow!(
+                    "[R5-honesty] unsupported optimizer={:?}: only {{adamw, muon, muon-cwd}} are implemented. \
+                     Refusing silent AdamW fallback. Fix env, redeploy, or implement the optimizer first.",
+                    other
+                ));
+            }
         };
         println!(
             "DONE: seed={} bpb={:.4} steps={} opt={}",


### PR DESCRIPTION
Closes #265

## Wave-35 Optimizer-Honesty Hotfix (two compound bugs)

RCA reference: [trios#143 — RCA comment](https://github.com/gHashTag/trios/issues/143#issuecomment-4427543239)

### Bug #1 — Missing `OPTIMIZER` alias (src/bin/entrypoint.rs)
```diff
- let optimizer = env_or("TRIOS_OPTIMIZER", "adamw");
+ let (optimizer, optimizer_src) = resolve_env_alias("TRIOS_OPTIMIZER", "OPTIMIZER", "adamw");
```
Orchestrators only set `OPTIMIZER`. With no alias the variable was dropped and every canon defaulted to AdamW. The trace line now prints `opt=(name, src=...)` so silent-drops cannot recur.

### Bug #2 — Silent wildcard fallback (src/bin/trios-train.rs:298)
```diff
- _ => train_loop::run_single(&args)?,
+ "adamw" => train_loop::run_single(&args)?,
+ "muon"  => train_loop::run_single_muon(&args, false)?,
+ "muon-cwd" => train_loop::run_single_muon(&args, true)?,
+ other => return Err(anyhow::anyhow!("[R5-honesty] unsupported optimizer={:?} ...", other)),
```
`lion / soap / tiger / prodigy / lamb / shampoo / signum / ranger / adafactor / adopt / sf-lite / sgdm / lion-m1 / demo` all silently routed to AdamW. This is the proximal cause of bit-identical BPB across Wave-34's 7-canon × 4-seed fleet.

### Why it matters
- Wave-34 produced byte-identical BPB rows (seed=123 → 2.6634 across 7 "different" optimizers). This was widely (mis-)interpreted as an "architectural floor".
- The OptimizerKind enum (`src/optimizer.rs`) declares only `AdamW | Muon | MuonCwd`. Every other canon name was a lie. This PR refuses the lie at the dispatch layer.

### Validation
- `cargo check` PASSED locally
- `cargo fmt` applied
- `cargo test` linker failure in sandbox (bus error, irrelevant for CI)
- Wave-35 honest smoke matrix (3 real opts × 4 Canon-#93 seeds × STEPS=20000, 12 services) will be launched after merge + image publish.

### R-rule compliance
- R1 Rust ✅
- R5 honest (refuses silent fallback) ✅
- R10 atomic (2 files, both bugs) ✅
- L2: `Closes #265` first line ✅

`phi^2 + phi^-2 = 3 · DOI 10.5281/zenodo.19227877`
