### PR TITLE
fix(wave34): OPTIMIZER env alias + strict optimizer dispatch (no silent AdamW fallback)

### DIFF
--- a/src/bin/entrypoint.rs
+++ b/src/bin/entrypoint.rs
@@ -23,7 +23,12 @@ fn main() {
     let (steps, steps_src) = resolve_env_alias("TRIOS_STEPS", "STEPS", "81000");
     let (lr, lr_src) = resolve_env_alias("TRIOS_LR", "LR", "0.003");
     let (hidden, hidden_src) = resolve_env_alias("TRIOS_HIDDEN", "HIDDEN_DIM", "384");
-    let optimizer = env_or("TRIOS_OPTIMIZER", "adamw");
+    // Wave 34 hotfix: `OPTIMIZER` alias was forgotten in PR #130's STEPS/LR/HIDDEN/SEED
+    // alias fan-out. Result: 38-service Wave-34 deploy that set `OPTIMIZER=lion` (etc.)
+    // silently fell back to TRIOS_OPTIMIZER's default "adamw". Combined with the wildcard
+    // dispatch arm in trios-train.rs (also fixed in this PR), 15 nominally-distinct
+    // optimizers converged to bit-identical BPB=2.6814258098602295 on seed=123.
+    let (optimizer, optimizer_src) = resolve_env_alias("TRIOS_OPTIMIZER", "OPTIMIZER", "adamw");
 
     // Wave 33 trace: emit a deterministic startup line with every resolved
     // knob plus its source (TRIOS_* / alias / default). Operators can
@@ -32,12 +37,12 @@ fn main() {
     // STEPS=200000 silently degraded to default 81000 and 52 trainers
     // exited two cycles short; no log line told us why.
     println!(
-        "[entrypoint-trace] seed=({}, src={}) steps=({}, src={}) lr=({}, src={}) hidden=({}, src={}) opt={}",
+        "[entrypoint-trace] seed=({}, src={}) steps=({}, src={}) lr=({}, src={}) hidden=({}, src={}) opt=({}, src={})",
         seed, seed_src.as_str(),
         steps, steps_src.as_str(),
         lr, lr_src.as_str(),
         hidden, hidden_src.as_str(),
-        optimizer,
+        optimizer, optimizer_src.as_str(),
     );
     if let Ok(v) = env::var("NUM_ATTN_LAYERS") {
         println!("[entrypoint-trace] NUM_ATTN_LAYERS={v} (consumed inside train_loop::run_single)");

--- a/src/bin/trios-train.rs
+++ b/src/bin/trios-train.rs
@@ -295,10 +295,22 @@ fn main() -> Result<()> {
             train_path: cli.train_data.clone(),
             val_path: cli.val_data.clone(),
         };
+        // Wave 34 fix: strict optimizer dispatch. Previously the wildcard `_ => run_single`
+        // arm silently routed every unknown optimizer label (lion / lamb / soap / tiger /
+        // sgdm / prodigy / adafactor / shampoo / yogi / ranger / radam / adabelief /
+        // adamax) to plain AdamW. Combined with the missing OPTIMIZER env alias in
+        // entrypoint.rs (also fixed in this PR), Wave-34 burned ~4h of fleet credits on
+        // 38 services that all converged to bit-identical BPB=2.6814258098602295 on
+        // seed=123. Honest probe reproduction: /home/user/workspace/skills/user/
+        // igla-honest-short-run/SKILL.md. RCA: trios#143 comment 4427543239.
         let outcome = match cli.optimizer.as_str() {
+            "adamw" => train_loop::run_single(&args)?,
             "muon" => train_loop::run_single_muon(&args, false)?,
             "muon-cwd" => train_loop::run_single_muon(&args, true)?,
-            _ => train_loop::run_single(&args)?,
+            other => anyhow::bail!(
+                "Unsupported optimizer: {other:?}. Supported: adamw, muon, muon-cwd. \
+                 (Wave-34 RCA: silent wildcard fallback removed; see SKILL igla-honest-short-run.)"
+            ),
         };
         println!(
             "DONE: seed={} bpb={:.4} steps={} opt={}",


### PR DESCRIPTION
# Wave-34 RCA fix — OPTIMIZER env alias + strict optimizer dispatch

## Summary

Two compound bugs caused **Wave-34** (38 services × ~4h fleet credits) to converge 15 nominally-distinct optimizers to **bit-identical BPB = 2.6814258098602295** on seed=123. This PR fixes both and adds a hard fail-fast for unknown optimizer labels.

## Bugs

### Bug #1 — `src/bin/entrypoint.rs:26`

```rust
let optimizer = env_or("TRIOS_OPTIMIZER", "adamw");
```

Does **not** honor the un-prefixed `OPTIMIZER` alias. PR #130 (Wave-33 hotfix) added `resolve_env_alias` for STEPS/LR/HIDDEN/SEED but **forgot the optimizer knob**. Wave-34 set `OPTIMIZER=lion` (and 14 other labels) on 38 services and every one silently defaulted to `"adamw"`.

### Bug #2 — `src/bin/trios-train.rs:298`

```rust
let outcome = match cli.optimizer.as_str() {
    "muon" => train_loop::run_single_muon(&args, false)?,
    "muon-cwd" => train_loop::run_single_muon(&args, true)?,
    _ => train_loop::run_single(&args)?,   // ← silent fallback to AdamW
};
```

Wildcard arm silently routes any unsupported optimizer label (`lion` / `lamb` / `soap` / `tiger` / `sgdm` / `prodigy` / `adafactor` / `shampoo` / `yogi` / `ranger` / `radam` / `adabelief` / `adamax`) to AdamW. Even if Bug #1 were fixed, this fallback alone would have caused identical BPB.

## Fix

1. **`entrypoint.rs`** — replace `env_or` with `resolve_env_alias("TRIOS_OPTIMIZER", "OPTIMIZER", "adamw")`. Precedence (matches PR #130 contract): `TRIOS_OPTIMIZER` > `OPTIMIZER` > default `"adamw"`. Adds the optimizer source to the `[entrypoint-trace]` line so operators can grep one keyword to verify the override reached the trainer.

2. **`trios-train.rs`** — explicit `"adamw" => …` arm plus `other => anyhow::bail!("Unsupported optimizer: …")`. Fail-fast with a clear message listing the supported set.

## Honest probe — reproduction & verification

Reproduction artefacts at `/home/user/workspace/skills/user/igla-honest-short-run/SKILL.md` (new user skill, sibling of `tri-gardener-runbook` v2.3).

| Test | Before fix | After fix |
|------|-----------|-----------|
| adamw, 100 steps, seed=123 | BPB=6.4700 | BPB=6.4700 ✅ |
| muon, 100 steps, seed=123 | BPB=6.4409 | BPB=6.4409 ✅ (≠ adamw) |
| lion (fake) | silent → 6.4700 (same as adamw) ❌ | `bail!("Unsupported optimizer: \"lion\"…")` ✅ |
| OPTIMIZER=muon alias | silent → adamw default ❌ | trace: `opt=(muon, src=alias)` ✅ |
| TRIOS_OPTIMIZER=muon-cwd + OPTIMIZER=lion | TRIOS_* wins (already worked) | `opt=(muon-cwd, src=TRIOS_*)` ✅ |

## Why this took 38 services × 4h to spot

Wave-34 dashboard showed 15 distinct optimizer LABELS, BPB values printed in trace logs LOOKED distinct because rounding hid the byte-identity, and the canonical-name index pivoted on (canon, seed) — making it look like 15 architectures each had their own BPB. Only when one operator dumped raw `bpb` to 16 decimals did the byte-identity become visible.

## Operational mitigation

`tri-gardener-runbook` skill bumped to **v2.3** with a new mandatory section **"Pre-flight gate — `igla-honest-short-run`"**. Three gate criteria before ANY Wave-N Railway deploy:

1. **Seed variance real**: 4 seeds × adamw → BPB spread ≥ 0.005 (catches dead SEED alias)
2. **Optimizer variance real**: seed=123 × {adamw, muon, muon-cwd} → at least one pair differs by ≥ 0.001 BPB (catches dead OPTIMIZER alias)
3. **Fake optimizer trap**: seed=123 × {adamw, lion, lamb, soap} — if all four byte-identical, the wildcard fallback is still present → **HARD BLOCK**

Total wall-clock cost: **< 5 min** on operator's CPU box. Compare with Wave-34 cost: 38 × 4h cloud = **152 service-hours**.

## RCA artefacts

- Bug report: [trios#143 comment 4427543239](https://github.com/gHashTag/trios/issues/143#issuecomment-4427543239)
- Honest probe results: [trios#143 comment 4427583321](https://github.com/gHashTag/trios/issues/143#issuecomment-4427583321)
- Wave-34 final BPB (canonical names only): [trios#143 comment 4427530532](https://github.com/gHashTag/trios/issues/143#issuecomment-4427530532)
- New skill: `igla-honest-short-run` (scope=user)
- Updated skill: `tri-gardener-runbook` v2.3 (scope=user, §"Pre-flight gate (MANDATORY)")

## Checklist

- [x] Build: `cargo build --release --bin trios-train --bin entrypoint` → green
- [x] Smoke: fake optimizer fails fast with clear error
- [x] Smoke: real optimizers produce distinct BPB values
- [x] Smoke: `OPTIMIZER` alias resolves through entrypoint
- [x] Smoke: `TRIOS_OPTIMIZER` precedence preserved
- [x] No new dependencies (uses existing `anyhow` + `resolve_env_alias`)
- [x] Backward-compatible: existing `TRIOS_OPTIMIZER` deployments unaffected

🌻 phi² + phi⁻² = 3 · TRINITY · NEVER STOP · DOI [10.5281/zenodo.19227877](https://zenodo.org/records/19227877)
