### PR TITLE
fix(env): promote OPTIMIZER/FORMAT/HIDDEN aliases to TRIOS_* before clap (trios#777)

### DIFF
--- a/src/bin/trios-train.rs
+++ b/src/bin/trios-train.rs
@@ -212,9 +212,7 @@ fn main() -> Result<()> {
         if std::env::var(canonical).is_err() {
             if let Ok(v) = std::env::var(alias) {
                 if !v.is_empty() {
-                    eprintln!(
-                        "[trios-train][trios#777] promoting {alias}={v} -> {canonical}"
-                    );
+                    eprintln!("[trios-train][trios#777] promoting {alias}={v} -> {canonical}");
                     std::env::set_var(canonical, v);
                 }
             }

--- a/src/bin/trios-train.rs
+++ b/src/bin/trios-train.rs
@@ -189,6 +189,38 @@ fn main() -> Result<()> {
     use std::io::Write as _;
     let _ = std::io::stderr().flush();
 
+    // trios#777 fix: promote un-prefixed env aliases set by wave-a-dispatch.yml
+    // (`OPTIMIZER`, `FORMAT`, `HIDDEN`) into the canonical `TRIOS_*` names BEFORE
+    // clap parses, so the CLI struct picks them up via #[arg(env = "TRIOS_*")].
+    //
+    // Without this promotion, 47 distinct canon_name configs (ranger/adafactor/
+    // adamw/adopt/demo on binary16) all collapsed to bit-identical bpb=2.9504
+    // because every trainer silently fell back to the clap defaults
+    // (adamw / None→f32 / hidden=828). R5-evidence: ssot.bpb_samples shows 94
+    // rows across 47 canons with bpb=2.9504425525665283 at step 80000.
+    //
+    // Resolution: TRIOS_* (canonical) > alias (un-prefixed) > clap default.
+    // The alias only fires when the canonical env is unset, so existing
+    // TRIOS_OPTIMIZER/TRIOS_FORMAT_TYPE/TRIOS_HIDDEN users are unaffected.
+    //
+    // Anchor: phi^2 + phi^-2 = 3 · DOI 10.5281/zenodo.19227877.
+    for (canonical, alias) in [
+        ("TRIOS_OPTIMIZER", "OPTIMIZER"),
+        ("TRIOS_FORMAT_TYPE", "FORMAT"),
+        ("TRIOS_HIDDEN", "HIDDEN"),
+    ] {
+        if std::env::var(canonical).is_err() {
+            if let Ok(v) = std::env::var(alias) {
+                if !v.is_empty() {
+                    eprintln!(
+                        "[trios-train][trios#777] promoting {alias}={v} -> {canonical}"
+                    );
+                    std::env::set_var(canonical, v);
+                }
+            }
+        }
+    }
+
     let mut cli = Cli::parse();
 
     // Canon #93 enforcement.

--- a/tests/trios_777_env_alias_promotion.rs
+++ b/tests/trios_777_env_alias_promotion.rs
@@ -1,0 +1,132 @@
+//! Regression test for gHashTag/trios#777 — fake-fallback bug where 47
+//! distinct canon_name configs (ranger/adafactor/adamw/adopt/demo on
+//! binary16) collapsed to bit-identical bpb=2.9504425525665283 at step
+//! 80000 in `ssot.bpb_samples` because every trainer silently fell back to
+//! the clap defaults (adamw / None→f32 / hidden=828).
+//!
+//! Root cause: `gHashTag/trios-railway/.github/workflows/wave-a-dispatch.yml`
+//! sets env vars with the un-prefixed names `OPTIMIZER`, `FORMAT`, `HIDDEN`,
+//! but `src/bin/trios-train.rs::Cli` only reads `TRIOS_OPTIMIZER`,
+//! `TRIOS_FORMAT_TYPE`, `TRIOS_HIDDEN` via `#[arg(env = "...")]`.
+//!
+//! Fix: `main()` promotes the un-prefixed aliases into the canonical
+//! `TRIOS_*` names BEFORE `Cli::parse()` so clap picks them up. Resolution
+//! order is `TRIOS_*` > alias > clap default, mirroring the Wave-33
+//! `entrypoint_env::resolve_env_alias` pattern (`STEPS`/`SEED`).
+//!
+//! This test asserts the promotion logic in isolation: given a fresh env
+//! where only the un-prefixed aliases are set, the canonical names must end
+//! up populated with the alias values.
+//!
+//! Anchor: phi^2 + phi^-2 = 3 · DOI 10.5281/zenodo.19227877.
+
+use std::sync::Mutex;
+
+/// Env mutations across tests would race; serialize via a global mutex.
+static ENV_LOCK: Mutex<()> = Mutex::new(());
+
+/// Mirror of the production promotion loop in `trios-train.rs::main()`.
+/// Kept verbatim so the test exercises the exact same algorithm; if the
+/// production loop changes, this copy must be updated in lock-step.
+fn promote_unprefixed_aliases() {
+    for (canonical, alias) in [
+        ("TRIOS_OPTIMIZER", "OPTIMIZER"),
+        ("TRIOS_FORMAT_TYPE", "FORMAT"),
+        ("TRIOS_HIDDEN", "HIDDEN"),
+    ] {
+        if std::env::var(canonical).is_err() {
+            if let Ok(v) = std::env::var(alias) {
+                if !v.is_empty() {
+                    std::env::set_var(canonical, v);
+                }
+            }
+        }
+    }
+}
+
+fn clear_all() {
+    for k in [
+        "OPTIMIZER",
+        "FORMAT",
+        "HIDDEN",
+        "TRIOS_OPTIMIZER",
+        "TRIOS_FORMAT_TYPE",
+        "TRIOS_HIDDEN",
+    ] {
+        std::env::remove_var(k);
+    }
+}
+
+#[test]
+fn alias_only_gets_promoted_to_canonical() {
+    let _g = ENV_LOCK.lock().unwrap();
+    clear_all();
+
+    // Wave-A dispatch shape: only un-prefixed aliases set, no TRIOS_*.
+    std::env::set_var("OPTIMIZER", "muon");
+    std::env::set_var("FORMAT", "gf16");
+    std::env::set_var("HIDDEN", "128");
+
+    promote_unprefixed_aliases();
+
+    assert_eq!(std::env::var("TRIOS_OPTIMIZER").as_deref(), Ok("muon"));
+    assert_eq!(std::env::var("TRIOS_FORMAT_TYPE").as_deref(), Ok("gf16"));
+    assert_eq!(std::env::var("TRIOS_HIDDEN").as_deref(), Ok("128"));
+
+    clear_all();
+}
+
+#[test]
+fn canonical_wins_over_alias() {
+    let _g = ENV_LOCK.lock().unwrap();
+    clear_all();
+
+    std::env::set_var("OPTIMIZER", "muon");
+    std::env::set_var("TRIOS_OPTIMIZER", "adamw");
+    std::env::set_var("FORMAT", "gf16");
+    std::env::set_var("TRIOS_FORMAT_TYPE", "fp16");
+    std::env::set_var("HIDDEN", "128");
+    std::env::set_var("TRIOS_HIDDEN", "828");
+
+    promote_unprefixed_aliases();
+
+    // Existing TRIOS_* values must not be clobbered by aliases.
+    assert_eq!(std::env::var("TRIOS_OPTIMIZER").as_deref(), Ok("adamw"));
+    assert_eq!(std::env::var("TRIOS_FORMAT_TYPE").as_deref(), Ok("fp16"));
+    assert_eq!(std::env::var("TRIOS_HIDDEN").as_deref(), Ok("828"));
+
+    clear_all();
+}
+
+#[test]
+fn empty_alias_does_not_overwrite() {
+    let _g = ENV_LOCK.lock().unwrap();
+    clear_all();
+
+    std::env::set_var("OPTIMIZER", "");
+    std::env::set_var("FORMAT", "");
+    std::env::set_var("HIDDEN", "");
+
+    promote_unprefixed_aliases();
+
+    // Empty alias values must NOT promote — otherwise we'd set
+    // `TRIOS_OPTIMIZER=""` and clap might pick the empty string instead
+    // of its declared default.
+    assert!(std::env::var("TRIOS_OPTIMIZER").is_err());
+    assert!(std::env::var("TRIOS_FORMAT_TYPE").is_err());
+    assert!(std::env::var("TRIOS_HIDDEN").is_err());
+
+    clear_all();
+}
+
+#[test]
+fn no_env_no_promotion() {
+    let _g = ENV_LOCK.lock().unwrap();
+    clear_all();
+
+    promote_unprefixed_aliases();
+
+    assert!(std::env::var("TRIOS_OPTIMIZER").is_err());
+    assert!(std::env::var("TRIOS_FORMAT_TYPE").is_err());
+    assert!(std::env::var("TRIOS_HIDDEN").is_err());
+}


### PR DESCRIPTION
Closes gHashTag/trios#777

## Summary

Fixes Wave-34-style fake-fallback bug where 47 distinct trainer configs collapsed to bit-identical loss. Promotes the un-prefixed env aliases (`OPTIMIZER`, `FORMAT`, `HIDDEN`) set by `gHashTag/trios-railway/.github/workflows/wave-a-dispatch.yml` into the canonical `TRIOS_*` names that `Cli::parse()` reads via `#[arg(env = "...")]`.

## R5 Evidence (live Railway phd-postgres-ssot, 2026-05-13T15:04Z)

```sql
SELECT ROUND(bpb::numeric, 4) AS bpb_r,
       COUNT(*) AS n,
       COUNT(DISTINCT canon_name) AS canons
FROM ssot.bpb_samples
WHERE step >= 80000
GROUP BY 1
ORDER BY n DESC
LIMIT 1;
-- -> bpb_r=2.9504, n=94, canons=47
```

Sample of the 47-canon cluster — every row identical to bit at step 80000 (`2.9504425525665283`) and step 81000 (`2.9503908157348633`):

| canon_name (intended config) | format (DB) | algo (DB) | hidden (DB) |
| --- | --- | --- | --- |
| `IGLA-COVERAGE-A-binary16-h384-LR0001-rng123-ranger` | f32 | adamw | 828 |
| `IGLA-SCARAB-ADAFACTOR-binary16-h384-LR0001-rng123-adafactor` | f32 | adamw | 828 |
| `IGLA-SCARAB-ADOPT-binary16-h384-LR0001-rng47-adopt` | f32 | adamw | 828 |
| `IGLA-SCARAB-DEMO-binary16-h384-LR0001-rng144-demo` | f32 | adamw | 828 |

Five different optimizers (`ranger`/`adafactor`/`adamw`/`adopt`/`demo`) and three different seeds (47/123/144) reach the **same loss to the last bit**. Mathematically impossible unless the optimizer / format / seed plumbing is ignored.

## Root Cause

| Source | Sets env var | But trainer reads… |
| --- | --- | --- |
| `gHashTag/trios-railway/.github/workflows/wave-a-dispatch.yml:74-78` | `OPTIMIZER=$ALGO` | `TRIOS_OPTIMIZER` (default `adamw`) — `trios-train.rs:79` |
| same | `FORMAT=$FMT` | `TRIOS_FORMAT_TYPE` (default `None` → `f32`) — `trios-train.rs:101` |
| same | `HIDDEN=128` | `TRIOS_HIDDEN` (default `828`) — `trios-train.rs:43` |

The un-prefixed aliases were never resolved, so every trainer fell through to the clap defaults. This matches the DB shape exactly: 11,824 rows with `format=f32, algo=adamw, hidden=384` and 5,042 rows with `hidden=828` — the two historical defaults.

The fix follows the existing Wave-33 pattern from `src/entrypoint_env.rs::resolve_env_alias`, which already does this for `STEPS` and `SEED`.

## Patch

In `main()`, before `Cli::parse()`:

```rust
for (canonical, alias) in [
    ("TRIOS_OPTIMIZER",   "OPTIMIZER"),
    ("TRIOS_FORMAT_TYPE", "FORMAT"),
    ("TRIOS_HIDDEN",      "HIDDEN"),
] {
    if std::env::var(canonical).is_err() {
        if let Ok(v) = std::env::var(alias) {
            if !v.is_empty() {
                eprintln!("[trios-train][trios#777] promoting {alias}={v} -> {canonical}");
                std::env::set_var(canonical, v);
            }
        }
    }
}
```

Resolution order: **`TRIOS_*` (canonical) > alias (un-prefixed) > clap default**. Empty alias values are ignored so they cannot clobber the declared defaults.

## Tests

New file `tests/trios_777_env_alias_promotion.rs` with four cases (env mutations serialized through a global `Mutex`):

1. `alias_only_gets_promoted_to_canonical` — wave-a dispatch shape: only un-prefixed aliases set → canonical names populated with alias values.
2. `canonical_wins_over_alias` — both set → existing TRIOS_* values are never clobbered.
3. `empty_alias_does_not_overwrite` — empty alias values do not promote (avoid setting `TRIOS_OPTIMIZER=""`).
4. `no_env_no_promotion` — no env at all → no canonical names appear, clap defaults take over.

## Risk

Minimal:
- Strictly additive: no existing behaviour changes when `TRIOS_*` is set.
- Pre-clap shim: zero impact on the clap struct definition or downstream code paths.
- Empty-string guard prevents accidental override-with-empty.

## Verification After Merge

1. Operator redeploys the Wave-A trainer fleet (Railway).
2. Re-run the R5 query above; expect the 2.9504 cluster to dissolve — different `algo` / `format` should produce different `bpb`.
3. Run a fresh `IGLA-SHORT-WAVE-MATRIX-bf16-h128-LR0.0001-rng1597-muon` cell; `ssot.bpb_samples.algo` must read `muon`, not `adamw`.

Anchor: `phi^2 + phi^-2 = 3` · DOI `10.5281/zenodo.19227877`
