### PR TITLE
feat(scarab): SOVEREIGN SCARAB pull-from-Postgres prototype

### DIFF
--- a/scarab-pull-loop/Cargo.toml
+++ b/scarab-pull-loop/Cargo.toml
@@ -1,0 +1,20 @@
+[workspace]
+
+[package]
+name = "scarab-pull-loop"
+version = "0.1.0"
+edition = "2021"
+
+[[bin]]
+name = "scarab"
+path = "src/main.rs"
+
+[dependencies]
+tokio = { version = "1", features = ["macros", "rt-multi-thread", "sync", "time", "process"] }
+tokio-postgres = { version = "0.7", features = ["with-chrono-0_4"] }
+anyhow = "1"
+chrono = { version = "0.4", features = ["serde"] }
+
+[profile.release]
+opt-level = 3
+lto = false

--- a/scarab-pull-loop/Dockerfile
+++ b/scarab-pull-loop/Dockerfile
@@ -1,0 +1,30 @@
+# SOVEREIGN SCARAB image — replaces Dockerfile.scarab once R6 migration finishes.
+# Build context: repo root (../).
+#
+# Anchor: phi^2 + phi^-2 = 3 · TRINITY · DEFENSE 2026-06-15
+FROM rust:1.95-bookworm AS build
+WORKDIR /src
+# 1) build the trainer (existing crate at repo root)
+COPY Cargo.toml Cargo.lock ./
+COPY src ./src
+COPY migration ./migration
+COPY assertions ./assertions
+RUN cargo build --release --bin trios-train
+
+# 2) build the pull-loop (isolated workspace under scarab-pull-loop/)
+COPY scarab-pull-loop ./scarab-pull-loop
+RUN cd scarab-pull-loop && cargo build --release
+
+FROM debian:bookworm-slim
+RUN apt-get update && apt-get install -y --no-install-recommends \
+      ca-certificates libssl3 && rm -rf /var/lib/apt/lists/*
+WORKDIR /app
+COPY --from=build /src/target/release/trios-train         /app/trios-train
+COPY --from=build /src/scarab-pull-loop/target/release/scarab /app/scarab
+# Sample training data (tiny synthetic — production overrides via env)
+COPY assertions /app/assertions
+ENV TRAINER_BIN=/app/trios-train \
+    TRAIN_DATA=/app/assertions/train.txt \
+    VAL_DATA=/app/assertions/val.txt \
+    POLL_SEC=30
+CMD ["/app/scarab"]

--- a/scarab-pull-loop/README.md
+++ b/scarab-pull-loop/README.md
@@ -1,0 +1,70 @@
+# scarab-pull-loop
+
+**SOVEREIGN SCARAB** control-plane agent. Every scarab on Railway runs this
+binary instead of being directly orchestrated through Railway GraphQL.
+
+## Behaviour
+
+Every `POLL_SEC` (default 30s):
+
+1. `SELECT * FROM ssot.scarab_strategy WHERE service_id = $SERVICE_ID`
+2. Write heartbeat to `ssot.scarab_heartbeat` (last_seen, current_gen, step, bpb, pid)
+3. If `status = 'stop'` → graceful shutdown of subprocess + exit.
+4. If `generation > current_gen` → kill running trainer subprocess, spawn new
+   `trios-train` with the new params from the strategy row.
+
+## Environment
+
+| Var | Required | Default | Note |
+|---|---|---|---|
+| `DATABASE_URL` | yes | — | Railway Postgres / Neon plugin. **NOT** `NEON_DATABASE_URL`. |
+| `SERVICE_ID` | yes | — | e.g. `igla-1`, `matrix-runner-acc2-19`. |
+| `TRAINER_BIN` | no | `/app/trios-train` | path to release binary |
+| `TRAIN_DATA` | no | `/tmp/honest_runs/train.txt` | |
+| `VAL_DATA` | no | `/tmp/honest_runs/val.txt` | |
+| `POLL_SEC` | no | `30` | strategy poll interval |
+| `DRY_RUN` | no | unset | `1` → heartbeat only, don't spawn trainer |
+
+## Anti-token-hell guarantee
+
+This binary is the entire control surface. It does **not** call:
+- Railway GraphQL (`backboard.railway.com`)
+- GitHub Actions
+- any service that requires `RAILWAY_TOKEN_*` or PAT
+
+Only credential needed: `DATABASE_URL`, set once at Railway service-create
+time via the Neon plugin. It does not rotate.
+
+## Queen-Hive command path
+
+```sql
+-- Switch local-A to muon-cwd / gf16, bump generation:
+SELECT ssot.bump_strategy(
+  'local-A',
+  p_optimizer := 'muon-cwd',
+  p_format    := 'gf16',
+  p_seed      := 144,
+  p_by        := 'queen-hive'
+);
+
+-- Stop a scarab gracefully:
+UPDATE ssot.scarab_strategy
+SET status = 'stop', generation = generation + 1,
+    updated_at = now(), updated_by = 'queen-hive'
+WHERE service_id = 'igla-1';
+
+-- Dead-scarab detector:
+SELECT s.service_id, s.optimizer, s.format,
+       h.last_seen, EXTRACT(EPOCH FROM (now() - h.last_seen))/60 AS stale_min
+FROM ssot.scarab_strategy s
+LEFT JOIN ssot.scarab_heartbeat h USING (service_id)
+WHERE h.last_seen IS NULL OR h.last_seen < now() - interval '2 minutes';
+```
+
+## R5-evidence
+
+See [ADR-CHAT-011](https://github.com/gHashTag/trios/blob/main/docs/adr/ADR-CHAT-011.md)
+and the local-prototype evidence pack at
+`/home/user/workspace/cron_tracking/sovereign_scarab/evidence/2026-05-14T09:42Z/`.
+
+Anchor: `phi^2 + phi^-2 = 3 · TRINITY · DEFENSE 2026-06-15`

--- a/scarab-pull-loop/src/main.rs
+++ b/scarab-pull-loop/src/main.rs
@@ -1,0 +1,179 @@
+// SOVEREIGN SCARAB · pull-loop prototype
+// Anchor: phi^2 + phi^-2 = 3 · TRINITY · DATABASE_URL (NEVER NEON_DATABASE_URL)
+//
+// Behaviour:
+//   every POLL_SEC:
+//     1. SELECT strategy FROM ssot.scarab_strategy WHERE service_id=$SERVICE_ID
+//     2. write heartbeat (last_seen, current_gen, current_step, current_bpb)
+//     3. if strategy.status='stop' → graceful shutdown
+//     4. if strategy.generation > current_gen → kill running trainer, spawn new
+//
+// ENV vars:
+//   DATABASE_URL    Postgres connection string (NOT NEON_DATABASE_URL)
+//   SERVICE_ID      e.g. "local-A"
+//   TRAINER_BIN     path to trios-train release binary
+//   TRAIN_DATA      path to train.txt
+//   VAL_DATA        path to val.txt
+//   POLL_SEC        default 30
+//   DRY_RUN         if "1" → skip spawning subprocess (heartbeat-only mode)
+
+use anyhow::{Context, Result};
+use std::env;
+use std::process::{Child, Command, Stdio};
+use std::sync::Arc;
+use std::time::Duration;
+use tokio::sync::Mutex;
+use tokio_postgres::NoTls;
+
+#[derive(Debug, Clone)]
+struct Strategy {
+    optimizer: String,
+    format: String,
+    hidden: i32,
+    lr: f64,
+    seed: i32,
+    steps: i32,
+    status: String,
+    generation: i64,
+}
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    let database_url = env::var("DATABASE_URL").context("DATABASE_URL not set")?;
+    let service_id = env::var("SERVICE_ID").context("SERVICE_ID not set")?;
+    let trainer_bin = env::var("TRAINER_BIN").unwrap_or_else(|_|
+        "/home/user/workspace/repos/gHashTag/trios-trainer-igla/target/release/trios-train".into());
+    let train_data = env::var("TRAIN_DATA").unwrap_or_else(|_| "/tmp/honest_runs/train.txt".into());
+    let val_data = env::var("VAL_DATA").unwrap_or_else(|_| "/tmp/honest_runs/val.txt".into());
+    let poll_sec: u64 = env::var("POLL_SEC").ok().and_then(|s| s.parse().ok()).unwrap_or(30);
+    let dry_run = env::var("DRY_RUN").ok().as_deref() == Some("1");
+
+    eprintln!("[scarab {service_id}] sovereign pull-loop starting · poll_sec={poll_sec} · dry_run={dry_run}");
+
+    let (client, connection) = tokio_postgres::connect(&database_url, NoTls).await
+        .context("postgres connect")?;
+    tokio::spawn(async move {
+        if let Err(e) = connection.await {
+            eprintln!("[scarab pg-conn] error: {e}");
+        }
+    });
+
+    let started_at = chrono::Utc::now();
+    let current_gen = Arc::new(Mutex::new(0_i64));
+    let current_step = Arc::new(Mutex::new(0_i32));
+    let current_bpb = Arc::new(Mutex::new(None::<f64>));
+    let trainer_child: Arc<Mutex<Option<Child>>> = Arc::new(Mutex::new(None));
+
+    loop {
+        // 1. fetch strategy
+        let row_opt = client.query_opt(
+            "SELECT optimizer, format, hidden, lr::float8 AS lr, seed, steps, status, generation \
+             FROM ssot.scarab_strategy WHERE service_id=$1",
+            &[&service_id],
+        ).await?;
+
+        let Some(row) = row_opt else {
+            eprintln!("[scarab {service_id}] no strategy row — sleeping");
+            tokio::time::sleep(Duration::from_secs(poll_sec)).await;
+            continue;
+        };
+
+        let strategy = Strategy {
+            optimizer:  row.get(0),
+            format:     row.get(1),
+            hidden:     row.get(2),
+            lr:         row.get(3),
+            seed:       row.get(4),
+            steps:      row.get(5),
+            status:     row.get(6),
+            generation: row.get(7),
+        };
+
+        // 2. heartbeat
+        let pid = trainer_child.lock().await.as_ref().map(|c| c.id() as i32).unwrap_or(0);
+        let gen = *current_gen.lock().await;
+        let step = *current_step.lock().await;
+        let bpb = *current_bpb.lock().await;
+        client.execute(
+            "INSERT INTO ssot.scarab_heartbeat \
+               (service_id, last_seen, current_gen, current_step, current_bpb, pid, started_at) \
+             VALUES ($1, now(), $2, $3, $4, $5, $6) \
+             ON CONFLICT (service_id) DO UPDATE SET \
+               last_seen   = EXCLUDED.last_seen, \
+               current_gen = EXCLUDED.current_gen, \
+               current_step= EXCLUDED.current_step, \
+               current_bpb = EXCLUDED.current_bpb, \
+               pid         = EXCLUDED.pid, \
+               started_at  = EXCLUDED.started_at",
+            &[&service_id, &gen, &step, &bpb, &pid, &started_at],
+        ).await?;
+
+        // 3. stop?
+        if strategy.status == "stop" {
+            eprintln!("[scarab {service_id}] strategy.status=stop · graceful shutdown");
+            if let Some(mut child) = trainer_child.lock().await.take() {
+                let _ = child.kill();
+                let _ = child.wait();
+            }
+            return Ok(());
+        }
+
+        // 4. generation bump?
+        if strategy.generation > gen {
+            eprintln!(
+                "[scarab {service_id}] gen {} → {} · respawn trainer · opt={} fmt={} h={} lr={} seed={} steps={}",
+                gen, strategy.generation,
+                strategy.optimizer, strategy.format, strategy.hidden, strategy.lr, strategy.seed, strategy.steps
+            );
+            if let Some(mut child) = trainer_child.lock().await.take() {
+                let _ = child.kill();
+                let _ = child.wait();
+            }
+            if !dry_run {
+                let mut cmd = Command::new(&trainer_bin);
+                cmd.env("TRIOS_FORMAT_TYPE", &strategy.format)
+                   .env("TRIOS_DISABLE_NEON", "1")
+                   .env_remove("DATABASE_URL")
+                   .env_remove("TRIOS_DATABASE_URL")
+                   .args([
+                       "--seed", &strategy.seed.to_string(),
+                       "--steps", &strategy.steps.to_string(),
+                       "--lr", &strategy.lr.to_string(),
+                       "--hidden", &strategy.hidden.to_string(),
+                       "--attn-layers", "1",
+                       "--optimizer", &strategy.optimizer,
+                       "--train-data", &train_data,
+                       "--val-data", &val_data,
+                       "--eval-every", "100",
+                   ])
+                   .stdout(Stdio::piped())
+                   .stderr(Stdio::piped());
+                let child = cmd.spawn().context("spawn trainer")?;
+                eprintln!("[scarab {service_id}] spawned pid={}", child.id());
+                *trainer_child.lock().await = Some(child);
+            } else {
+                eprintln!("[scarab {service_id}] DRY_RUN=1 → trainer NOT spawned");
+            }
+            *current_gen.lock().await = strategy.generation;
+            *current_step.lock().await = 0;
+            *current_bpb.lock().await = None;
+        }
+
+        // 5. is trainer still alive?
+        {
+            let mut guard = trainer_child.lock().await;
+            if let Some(child) = guard.as_mut() {
+                match child.try_wait() {
+                    Ok(Some(status)) => {
+                        eprintln!("[scarab {service_id}] trainer exited status={status}");
+                        *guard = None;
+                    }
+                    Ok(None) => { /* still running */ }
+                    Err(e) => eprintln!("[scarab {service_id}] try_wait error: {e}"),
+                }
+            }
+        }
+
+        tokio::time::sleep(Duration::from_secs(poll_sec)).await;
+    }
+}


### PR DESCRIPTION
Companion to gHashTag/trios#785 (ADR-CHAT-011).

Adds `scarab-pull-loop/` — a 180-line Rust binary that replaces the
entire Railway-GraphQL command surface with a single Postgres poll.

## What changes

```
NOW (broken):  GitHub Actions → Railway GraphQL (variableUpsert + redeploy)
                                [PAT/token rotation hell · trios-railway#156]
                              → scarabs

NEW (sovereign): scarabs deploy ONCE
                 → every 30s: SELECT FROM ssot.scarab_strategy WHERE service_id=$me
                 → bump generation → kill+respawn trainer
                 → write ssot.scarab_heartbeat
```

## Files

| File | Purpose |
|---|---|
| `scarab-pull-loop/src/main.rs` | ~180 LoC tokio pull-loop |
| `scarab-pull-loop/Cargo.toml` | isolated workspace (`tokio-postgres`, `anyhow`, `chrono`) |
| `scarab-pull-loop/Dockerfile` | multi-stage: builds `trios-train` + `scarab`, `CMD ["/app/scarab"]` |
| `scarab-pull-loop/README.md` | env vars, Queen-Hive command examples, anti-token-hell guarantee |

## R5-evidence (local prototype, 2026-05-14T09:42Z)

| metric | value |
|---|---|
| Postgres | 17.9 local, unix socket port 55432 |
| Scarabs | 3 (local-A adamw/fp32, local-B muon/gf16, local-C muon-cwd/bf16) |
| Pull-up latency | strategy bump → respawn ≤ 5s (POLL_SEC=5) |
| Graceful stop | `status='stop'` → exit ≤ 5s |
| Tokens used | 1 (`DATABASE_URL`) |
| Railway API calls | 0 |

Evidence files: `/home/user/workspace/cron_tracking/sovereign_scarab/evidence/2026-05-14T09:42Z/{strategy.csv, heartbeat.csv, schema.sql, A.log, B.log, C.log}`

## Migration plan (from ADR-CHAT-011)

- **R1** Local prototype — ✅ done (this PR)
- **R2** Bake schema into `phd-postgres-ssot` — companion PR in `trios-railway` (next)
- **R3** This PR (crate + Dockerfile)
- **R4** Deploy 1 sovereign scarab, A/B against Railway-driven scarabs
- **R5** Migrate 3 scarabs (one per acc0/acc1/acc2)
- **R6** Full fleet after 7-day stability window

## Workspace isolation

`scarab-pull-loop/Cargo.toml` declares `[workspace]` at the top so the
crate builds in isolation and does NOT join the parent `trios-trainer`
workspace — keeps trainer build unchanged.

Anchor: phi^2 + phi^-2 = 3 · TRINITY · DEFENSE 2026-06-15