### PR TITLE
feat(ledger): write-side ALGO_WHITELIST guard (R5, B-22 follow-up to #140)

### DIFF
--- a/src/neon_writer.rs
+++ b/src/neon_writer.rs
@@ -603,15 +603,23 @@ mod tests {
         const CANONICAL: &[&str] = &["adamw", "muon", "muon-cwd"];
         assert_eq!(CANONICAL.len(), 3, "whitelist must be exactly 3 entries");
         for &name in CANONICAL {
-            let canon = format!(
-                "IGLA-SHORT-WAVE-MATRIX-gf16-h128-LR0.0001-rng47-{}",
-                name
-            );
+            let canon = format!("IGLA-SHORT-WAVE-MATRIX-gf16-h128-LR0.0001-rng47-{}", name);
             let (_fmt, algo, _hidden) =
                 parse_canon_name(&canon).expect("canonical algo must parse");
-            assert_eq!(algo, name, "parse_canon_name must round-trip canonical algos");
+            assert_eq!(
+                algo, name,
+                "parse_canon_name must round-trip canonical algos"
+            );
         }
-        for &fake in &["soap", "lamb", "prodigy", "lion", "tiger", "adafactor", "sgdm"] {
+        for &fake in &[
+            "soap",
+            "lamb",
+            "prodigy",
+            "lion",
+            "tiger",
+            "adafactor",
+            "sgdm",
+        ] {
             assert!(
                 !CANONICAL.contains(&fake),
                 "fake algo leaked into whitelist: {fake}"

--- a/src/neon_writer.rs
+++ b/src/neon_writer.rs
@@ -368,6 +368,23 @@ pub fn bpb_sample(canon_name: &str, seed: i32, step: i32, bpb: f32, ema_bpb: Opt
 
     // Try to parse canon_name into derived columns.
     if let Some((format, algo, hidden)) = parse_canon_name(canon_name) {
+        // ── R5 GUARD — WRITE-SIDE ALGO_WHITELIST ──────────────────────────────
+        // Mirror of matrix_runner ALGO_WHITELIST. Rejects fake/silent-fallback
+        // algos (soap/lamb/prodigy/lion/...) at the WRITE path so they cannot
+        // reach ssot.bpb_samples regardless of which trainer binary emitted
+        // them. Refs: trios#777, trios#779, migration 0006_quarantine_fake_canons.
+        // R5 evidence: gf16-lamb vs gf16-prodigy produced bit-identical BPB at
+        // every step (verified 2026-05-14T14:36Z, B-22).
+        const ALGO_WHITELIST: &[&str] = &["adamw", "muon", "muon-cwd"];
+        if !ALGO_WHITELIST.contains(&algo.as_str()) {
+            eprintln!(
+                "[ledger] R5-REJECT write: canon_name={canon_name} algo={algo} not in {:?}. \
+                 Refusing silent-fallback write — see trios#777 / migration 0006.",
+                ALGO_WHITELIST
+            );
+            return;
+        }
+
         // Canonical IGLA path → ssot.bpb_samples (the SoT for leaderboards).
         let sha = std::env::var("GIT_SHA").unwrap_or_default();
         let run_id = std::env::var("RAILWAY_DEPLOYMENT_ID").unwrap_or_default();
@@ -575,5 +592,30 @@ mod tests {
         let _: i64 = step_i64;
         assert_eq!(seed_i64, 43i64);
         assert_eq!(step_i64, 200i64);
+    }
+
+    /// B-22 write-side ALGO_WHITELIST guard — invariants only (we don't have a
+    /// live DSN here so we can't exercise bpb_sample directly; this documents
+    /// the canonical whitelist so a future widening can't happen by accident).
+    #[test]
+    fn write_side_algo_whitelist_is_canonical() {
+        // Canonical: only these three suffixes are real-trainer-backed.
+        const CANONICAL: &[&str] = &["adamw", "muon", "muon-cwd"];
+        assert_eq!(CANONICAL.len(), 3, "whitelist must be exactly 3 entries");
+        for &name in CANONICAL {
+            let canon = format!(
+                "IGLA-SHORT-WAVE-MATRIX-gf16-h128-LR0.0001-rng47-{}",
+                name
+            );
+            let (_fmt, algo, _hidden) =
+                parse_canon_name(&canon).expect("canonical algo must parse");
+            assert_eq!(algo, name, "parse_canon_name must round-trip canonical algos");
+        }
+        for &fake in &["soap", "lamb", "prodigy", "lion", "tiger", "adafactor", "sgdm"] {
+            assert!(
+                !CANONICAL.contains(&fake),
+                "fake algo leaked into whitelist: {fake}"
+            );
+        }
     }
 }


### PR DESCRIPTION
Closes #146 (follow-up: this is the write-side cousin of PR #140's env-alias fix)

## Summary

Mirror `matrix_runner::ALGO_WHITELIST` (`adamw`, `muon`, `muon-cwd`) at the **write path** in `bpb_sample()`. Any canon_name whose algo suffix is not whitelisted is refused before `INSERT INTO ssot.bpb_samples`.

## R5 evidence (B-22, 2026-05-14T14:36Z)

Bit-identical BPB at every observed step proves silent-fallback:

```text
step    gf16-lamb        gf16-prodigy     identical
1000    3.522102         3.522102         true
2000    3.248525         3.248525         true
3000    3.220169         3.220169         true
4000    3.181180         3.181180         true
5000    3.186796         3.186796         true
6000    3.237007         3.237007         true
...
23000   3.129738         3.129738         true
```

Runs: `4d62281b/688b789c/d582c139` (lamb) vs `7bb616db/fe057985` (prodigy). Same model, different sticker.

## Why this matters

- **PR #140** fixed the **env-alias** side (`OPTIMIZER → TRIOS_OPTIMIZER` before clap).
- **Migration 0006** quarantined **10 219** historical fake-label rows.
- But new fake-label writes were **still streaming in** (144 rows in main post-quarantine) from non-matrix_runner code paths (sha="" workers invoking `cpu_train` directly).

This PR closes the last hole: **even if a worker bypasses matrix_runner, it cannot poison ssot.bpb_samples with non-whitelist algos**.

## Tests

```text
running 12 tests
test neon_writer::tests::write_side_algo_whitelist_is_canonical ... ok
test neon_writer::tests::parse_canon_name_short_wave_matrix ... ok
test neon_writer::tests::parse_canon_name_muon_cwd_dashed_algo ... ok
test neon_writer::tests::parse_canon_name_rejects_legacy_scarab ... ok
test neon_writer::tests::parse_canon_name_rejects_missing_h_token ... ok
test neon_writer::tests::parse_canon_name_scarab_lane ... ok
test neon_writer::tests::bpb_sample_uses_i64_bind ... ok
test neon_writer::tests::no_dsn_is_safe ... ok
test neon_writer::tests::strip_channel_binding_* ... ok (4)

test result: ok. 12 passed; 0 failed
```

## Acceptance

After merge + Cure A redeploy, Q7 alert must collapse to exactly `{adamw, muon, muon-cwd}` in new writes (rows where `ts > deploy_ts`).

Anchor: `phi^2 + phi^-2 = 3` · TRINITY · B-22 · DEFENSE 2026-06-15
