### PR TITLE
🪝 feat(arch-writer): add neon_writer::bpb_sample hook to tjepa_train + hybrid_train

### DIFF
--- a/src/bin/hybrid_train.rs
+++ b/src/bin/hybrid_train.rs
@@ -17,6 +17,7 @@ use std::fs;
 use std::time::Instant;
 
 use trios_trainer::model_hybrid_attn::HybridAttn;
+use trios_trainer::neon_writer;
 use trios_trainer::optimizer::MuonOptimizer;
 
 const VOCAB: usize = 128;
@@ -622,6 +623,19 @@ fn main() {
                     "seed={} step={} val_bpb={:.4} ema_bpb={:.4} best={:.4} t={:.1}s",
                     seed, step, val_bpb, ema_bpb, best_ema_bpb, t
                 );
+                // R5-honest ledger write to ssot.bpb_samples (ARCH writer hook).
+                // No-op if TRIOS_CANON_NAME unset; safe to call every eval.
+                if let Ok(canon) = std::env::var("TRIOS_CANON_NAME") {
+                    if !canon.is_empty() {
+                        neon_writer::bpb_sample(
+                            &canon,
+                            seed as i32,
+                            step as i32,
+                            val_bpb,
+                            Some(ema_bpb),
+                        );
+                    }
+                }
             }
         }
 

--- a/src/bin/tjepa_train.rs
+++ b/src/bin/tjepa_train.rs
@@ -24,6 +24,7 @@ use trios_trainer::{
         predictor::{JepaPredictor, PredictorConfig},
         EmaConfig, EmaTarget,
     },
+    neon_writer,
     objective::{
         compute_combined_loss, nca_entropy_loss, ComponentLosses, NcaObjective, ObjectiveConfig,
     },
@@ -877,6 +878,19 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                 st.best_val_bpb,
                 elapsed
             );
+            // R5-honest ledger write to ssot.bpb_samples (ARCH writer hook).
+            // No-op if TRIOS_CANON_NAME unset; safe to call every eval.
+            if let Ok(canon) = std::env::var("TRIOS_CANON_NAME") {
+                if !canon.is_empty() {
+                    neon_writer::bpb_sample(
+                        &canon,
+                        cfg.seed as i32,
+                        step as i32,
+                        val_bpb,
+                        Some(st.best_val_bpb),
+                    );
+                }
+            }
         }
 
         neon_heartbeat(&cfg, step, st.best_val_bpb, &mut st.last_heartbeat);


### PR DESCRIPTION
## 🪝 ARCH writer hook — tjepa_train + hybrid_train

### Root cause
Despite ARCH carriers (ACC4/5/6, services 051cb5a4, 01cf32d5, 002b62ee) deploying SUCCESS with correct env vars (TRIOS_CANON_NAME=IGLA-ARCH-*, TRIOS_FORMAT=gf256, TRIOS_HIDDEN=384, TRIOS_TRAINER_BIN=hybrid_train|tjepa_train), `ssot.bpb_samples WHERE canon_name LIKE 'IGLA-ARCH-%'` was **empty**.

Investigation via `diag-arch-full` showed containers actually training (e.g. `seed=2584 step=30000 val_bpb=2.9694 best=2.8965`) and printing to stdout — but the two ARCH binaries had **no writer code at all**.

Other trainers (`matrix_runner`, `smoke_train`, etc.) all call `trios_trainer::neon_writer::bpb_sample(canon, seed, step, val_bpb, ema_bpb)`, which already routes IGLA-shaped canons to `ssot.bpb_samples`. `tjepa_train` only writes `igla_race_trials` / `igla_agents_heartbeat` via heartbeat; `hybrid_train` writes nothing.

### Fix
Both binaries gain a `neon_writer::bpb_sample` call inside their existing eval block:
- `hybrid_train.rs`: at `step % eval_every == 0 || step == steps`
- `tjepa_train.rs`: at `step % 500 == 0 || step == cfg.steps`

Gated on `TRIOS_CANON_NAME` being set & non-empty → behaviour unchanged for local/test runs.

### Verification path
1. Merge → docker image `ghcr.io/ghashtag/trios-trainer-igla:<sha>` builds
2. `mass-deploy-arch` repoints 3 ARCH services to new image
3. Within ~5 min of redeploy, rows appear in `ssot.bpb_samples WHERE canon_name LIKE 'IGLA-ARCH-%'`

### Local sanity
- `cargo check --bin hybrid_train --bin tjepa_train` → green
- `cargo build --release` not re-run here (CI does it), but only 28 lines added, no API changes

Anchor: phi^2 + phi^-2 = 3 · TRINITY · NEVER STOP · DOI 10.5281/zenodo.19227877
