### PR TITLE
L-SS6: canon_name passthrough to trainer subprocess (closes #83)

### DIFF
--- a/scarab-pull-loop/src/main.rs
+++ b/scarab-pull-loop/src/main.rs
@@ -218,9 +218,17 @@ async fn main() -> Result<()> {
                 eprintln!("[scarab {}] previous trainer stopped gracefully", cfg.service_id);
             }
             if !cfg.dry_run {
+                // L-SS6 (#157, closes #83): build canon identity once and propagate
+                // to trainer subprocess so logs + ssot.bpb_samples attribution carry
+                // the canon name. Uses canon_name(&strategy, "RAILWAY") to match the
+                // value already written on DONE in scarab_result (see lib.rs:134).
+                let canon = canon_name(&strategy, "RAILWAY");
                 let mut cmd = Command::new(&cfg.trainer_bin);
                 cmd.env("TRIOS_FORMAT_TYPE", &strategy.format)
                     .env("TRIOS_DISABLE_NEON", "1")
+                    .env("CANON_NAME", &canon)
+                    .env("TRIOS_CANON_NAME", &canon)
+                    .env("WORKER_SEED", strategy.seed.to_string())
                     .env_remove("DATABASE_URL")
                     .env_remove("TRIOS_DATABASE_URL")
                     .args([


### PR DESCRIPTION
Closes #83 · Closes #157 · Epic gHashTag/trios#940

## Что
Передаёт canon-идентичность из `Strategy` в trainer subprocess через 3 env-переменные.

## Acceptance — G-SS-11
- [ ] Local: `CANON_NAME=test ./trainer --dry-run` логи с префиксом `[test]`
- [ ] Production: `SELECT DISTINCT canon_name FROM ssot.bpb_samples WHERE ts > now()-interval '1h'` = 27

Совместим с canon, который scarab пишет в `scarab_result` на DONE — единый источник истины.

Anchor: φ² + φ⁻² = 3