### PR TITLE
fix(queen-hive-mcp): sentinel test no longer scans itself

### DIFF
--- a/queen-hive-mcp/src/lib.rs
+++ b/queen-hive-mcp/src/lib.rs
@@ -253,11 +253,13 @@ mod tests {
 
     #[test]
     fn no_railway_api_constants_anywhere() {
-        // Compile-time guard: this file must not mention RAILWAY_TOKEN /
-        // variableUpsert. Asserted at runtime as a sentinel.
+        // Sentinel: scan only the *production* portion of this file (before the
+        // #[cfg(test)] marker) so the test assertions themselves don't trigger
+        // the checks they are testing.
         let src = include_str!("lib.rs");
-        assert!(!src.contains("RAILWAY_TOKEN"), "R-SI-1: no RAILWAY_TOKEN");
-        assert!(!src.contains("variableUpsert"), "L-SS7: no variableUpsert");
-        assert!(!src.contains("railway.app/graphql"), "no Railway GraphQL");
+        let prod = src.split("#[cfg(test)]").next().unwrap_or(src);
+        assert!(!prod.contains("RAILWAY_TOKEN"), "R-SI-1: no RAILWAY_TOKEN in prod code");
+        assert!(!prod.contains("variableUpsert"), "L-SS7: no variableUpsert in prod code");
+        assert!(!prod.contains("railway.app/graphql"), "no Railway GraphQL in prod code");
     }
 }


### PR DESCRIPTION
Hot-fix on top of L-SS3 (#161, merged at 16:30Z).

## Проблема
Local smoke с rustup 1.85.0 показал 4/5 PASS — тест `no_railway_api_constants_anywhere` падал на самом себе: `include_str!("lib.rs")` возвращает весь файл вместе с assert-строками, которые буквально содержат запрещённые литералы.

## Решение
Разрезаем содержимое файла по маркеру `#[cfg(test)]` и сканируем только production-часть.

## Проверено локально
- Rust 1.85.0 (rustup minimal)
- `cargo build --release` → finished 53.59s, без warnings
- `cargo test --release` → **5/5 PASS**
- `rg -n 'RAILWAY_TOKEN|variableUpsert|railway.app/graphql' queen-hive-mcp/src/` → пусто в production-коде

Related: #161 · Epic gHashTag/trios#940
Anchor: φ² + φ⁻² = 3