### PR TITLE
hot-fix(L-SS1): purge libscarab_pull_loop cache between dummy and real build

### DIFF
--- a/scarab-pull-loop/Dockerfile
+++ b/scarab-pull-loop/Dockerfile
@@ -11,12 +11,19 @@ COPY Cargo.toml ./
 COPY Cargo.lock* ./
 RUN mkdir -p src && \
     echo 'fn main() {}' > src/main.rs && \
-    echo '' > src/lib.rs && \
+    echo '// dummy' > src/lib.rs && \
     cargo build --release --bin scarab && \
-    rm -rf src target/release/deps/scarab*
+    rm -rf src \
+           target/release/deps/scarab* \
+           target/release/deps/libscarab_pull_loop* \
+           target/release/deps/scarab_pull_loop* \
+           target/release/libscarab_pull_loop* \
+           target/release/scarab \
+           target/release/.fingerprint/scarab-pull-loop-*
 
 # Real sources
 COPY src/ ./src/
+# Force Cargo to detect changed sources (mtime is newer than cached fingerprint).
 RUN cargo build --release --bin scarab && \
     strip target/release/scarab
 


### PR DESCRIPTION
## Problem

GHCR build on main (run [25967292017](https://github.com/gHashTag/trios-trainer-igla/actions/runs/25967292017)) failed with:

```
error[E0432]: unresolved imports `scarab_pull_loop::canon_name`, `graceful_kill`,
              `Config`, `DoneEvent`, `Strategy`
  --> src/main.rs:24:24
```

Even though `src/lib.rs` clearly exports all five items. The PR-time `publish` job is gated by `if: github.event_name != 'pull_request'`, so this stage was never exercised before merging.

## Root cause

Stage-1 dummy build pre-compiles deps to cache the cargo registry + `target/release/deps/*`. We then `rm -rf src target/release/deps/scarab*` — but we DID NOT purge the cached **empty** `libscarab_pull_loop` artefacts. When stage-2 COPYs real `src/` and re-runs `cargo build`, fingerprint check missed the swap and Cargo linked the stale empty rlib → bin can't find any pub items.

## Fix

Expand the stage-1 cleanup to wipe:
- `target/release/deps/libscarab_pull_loop*`
- `target/release/deps/scarab_pull_loop*`
- `target/release/libscarab_pull_loop*`
- `target/release/scarab` (extra safety)
- `target/release/.fingerprint/scarab-pull-loop-*` (force fingerprint mismatch)

Plus tiny semantic fix: use `'// dummy'` (not empty string) as stage-1 lib.rs so the cached .rmeta isn't zero-sized.

## Verification (local)

Reproduced the failure pattern in /tmp with cargo 1.85, then applied the patch:

| Stage | Without fix | With fix |
|---|---|---|
| Stage-1 dummy | 30.95s ✅ | 30.95s ✅ |
| Stage-2 real | 0.18s ❌ E0432 | 6.60s ✅ Finished |

## Why publish skipped pre-merge

The `publish` job has `if: github.event_name != 'pull_request'` — by design, GHCR push runs only on `main`/dispatch. This caught us blind on #159 because the green `test` job on PR didn't exercise the Dockerfile.

Next PR (post-merge) can lift this guard and gate by branch instead, so future Dockerfile regressions are caught at PR-time.

## Acceptance

- [x] Local repro of E0432 with stage-1 dummy
- [x] Local validation that patched Dockerfile resolves all pub items
- [ ] GHCR workflow on main publishes `ghcr.io/ghashtag/sovereign-scarab:v4` (this PR proves it)
- [ ] `set-public` job flips package visibility

## Anchor

phi^2 + phi^-2 = 3 · DOI 10.5281/zenodo.19227877

Related: epic #940, L-SS1 issue #155.