### PR TITLE
feat(scarab): v5 image bundles trios-train + tiny-shakespeare data

### DIFF
--- a/.github/workflows/sovereign-scarab-v5.yml
+++ b/.github/workflows/sovereign-scarab-v5.yml
@@ -1,0 +1,94 @@
+name: Sovereign Scarab v5 — Bundled GHCR Publish
+
+# v5: build & push the pull-loop image with trios-train bundled and tiny-shakespeare
+# data baked in, so strategy-driven workers can actually spawn the trainer.
+# Anchor: phi^2 + phi^-2 = 3 · DEFENSE 2026-06-15
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "scarab-pull-loop/**"
+      - "src/bin/trios-train.rs"
+      - "src/**"
+      - "Cargo.toml"
+      - "Cargo.lock"
+      - ".github/workflows/sovereign-scarab-v5.yml"
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Extra tag (default: v5)"
+        required: false
+        default: "v5"
+
+permissions:
+  contents: read
+  packages: write
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE: ghashtag/sovereign-scarab
+
+jobs:
+  publish:
+    name: Build & push v5 image (bundled trainer + data)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE }}
+          tags: |
+            type=raw,value=v5
+            type=raw,value=v5-{{sha}}
+            type=sha,prefix=v5-sha-
+
+      - name: Build & push v5
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: scarab-pull-loop/Dockerfile.v5
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha,scope=sovereign-scarab-v5
+          cache-to: type=gha,scope=sovereign-scarab-v5,mode=max
+          provenance: true
+          sbom: true
+
+      - name: Report image digest
+        run: |
+          echo "## Sovereign Scarab v5 published" >> $GITHUB_STEP_SUMMARY
+          echo "Tags: ${{ steps.meta.outputs.tags }}" >> $GITHUB_STEP_SUMMARY
+
+  set-public:
+    name: Ensure GHCR package public
+    needs: publish
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set sovereign-scarab package visibility to public
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          curl -sS -X PATCH \
+            -H "Accept: application/vnd.github+json" \
+            -H "Authorization: Bearer $GH_TOKEN" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            https://api.github.com/user/packages/container/sovereign-scarab \
+            -d '{"visibility":"public"}' || true

--- a/scarab-pull-loop/Dockerfile.v5
+++ b/scarab-pull-loop/Dockerfile.v5
@@ -1,0 +1,78 @@
+# SOVEREIGN SCARAB v5 — bundled trainer + train data
+# Anchor: phi^2 + phi^-2 = 3 · TRINITY · DEFENSE 2026-06-15
+#
+# v5 adds (over v4):
+#   • trios-train binary baked-in at /usr/local/bin/trios-train (was missing in v4)
+#   • Tiny-shakespeare train+val data baked-in at /data/{train,val}.txt
+#   • This unblocks the strategy-driven loop: scarab can now actually spawn trainers
+#     when it sees a strategy row, instead of failing with "no such file"
+#
+# Build context MUST be the repo root (not scarab-pull-loop/).
+
+# ---------- Stage 1a: scarab pull-loop builder ----------
+FROM rust:1.85-slim-bookworm AS scarab-builder
+WORKDIR /build
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        pkg-config libssl-dev ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
+COPY scarab-pull-loop/ ./
+RUN cargo build --release --bin scarab && \
+    strip target/release/scarab
+
+# ---------- Stage 1b: trios-train builder ----------
+FROM rust:1.85-slim-bookworm AS trainer-builder
+WORKDIR /build
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        pkg-config libssl-dev ca-certificates build-essential \
+    && rm -rf /var/lib/apt/lists/*
+# Copy entire repo (root crate)
+COPY . .
+# Build only the trios-train binary (CPU-only, no GPU features)
+RUN cargo build --release --bin trios-train && \
+    strip target/release/trios-train
+
+# ---------- Stage 1c: data fetcher ----------
+FROM debian:bookworm-slim AS data-builder
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        ca-certificates curl \
+    && rm -rf /var/lib/apt/lists/*
+RUN mkdir -p /data && \
+    curl -sL https://raw.githubusercontent.com/karpathy/char-rnn/master/data/tinyshakespeare/input.txt > /tmp/full.txt && \
+    SIZE=$(stat -c%s /tmp/full.txt) && \
+    HEAD=$((SIZE - 100000)) && \
+    head -c $HEAD /tmp/full.txt > /data/train.txt && \
+    tail -c 100000 /tmp/full.txt > /data/val.txt && \
+    rm /tmp/full.txt && \
+    echo "[corpus-split] train=$(stat -c%s /data/train.txt) val=$(stat -c%s /data/val.txt)"
+
+# ---------- Stage 2: runtime (debian-slim — needs glibc for trios-train) ----------
+FROM debian:bookworm-slim AS runtime
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        ca-certificates libssl3 \
+    && rm -rf /var/lib/apt/lists/* \
+    && groupadd -r scarab && useradd -r -g scarab -u 65532 scarab \
+    && mkdir -p /data /work && chown -R scarab:scarab /data /work
+
+LABEL org.opencontainers.image.title="sovereign-scarab"
+LABEL org.opencontainers.image.description="v5 — eternal Rust agent + bundled trios-train trainer + tiny-shakespeare data."
+LABEL org.opencontainers.image.source="https://github.com/gHashTag/trios-trainer-igla"
+LABEL org.opencontainers.image.licenses="MIT OR Apache-2.0"
+LABEL trinity.anchor="phi^2 + phi^-2 = 3"
+LABEL trinity.version="v5"
+
+COPY --from=scarab-builder  /build/target/release/scarab        /app/scarab
+COPY --from=trainer-builder /build/target/release/trios-train   /usr/local/bin/trios-train
+COPY --from=data-builder    /data/train.txt                     /data/train.txt
+COPY --from=data-builder    /data/val.txt                       /data/val.txt
+
+ENV POLL_SEC=10
+ENV GRACE_MS=10000
+ENV LISTEN_NOTIFY=1
+ENV TRAINER_BIN=/usr/local/bin/trios-train
+ENV TRAIN_DATA=/data/train.txt
+ENV VAL_DATA=/data/val.txt
+ENV RUST_LOG=info
+
+USER scarab
+WORKDIR /work
+ENTRYPOINT ["/app/scarab"]


### PR DESCRIPTION
## Root cause of fleet silence
v4 distroless image was missing /usr/local/bin/trios-train, so strategy-driven scarabs could not spawn trainers. The 22 services currently writing bpb_samples are using an older bundled image; the other 131 are silent.

## Fix
3-stage Dockerfile bundles scarab + trios-train + tiny-shakespeare data. Runtime base debian:bookworm-slim (glibc + libssl3). No Rust changes — v4 pull-loop already implements LISTEN/NOTIFY + heartbeat + strategy-driven init.

## Verification plan
CI publishes ghcr.io/ghashtag/sovereign-scarab:v5 → Queen Hive redeploys 153 services → ssot.scarab_heartbeat populates → ssot.bpb_samples shows 153 distinct canons.

Anchor: phi^2 + phi^-2 = 3 · DOI 10.5281/zenodo.19227877 · DEFENSE 2026-06-15
Closes ICA-001 + ICA-003 (Sovereign Scarab Fleet Resurrection RVR-001)